### PR TITLE
README: fix quickstart claim about post-run mockway state

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ make down
 
 You should see `Status: success` and `run/terminal_reason: pass (target_reached)`
 after step 3. The LLM generated a Scaleway Block Storage volume in HCL,
-the static validator + mockway apply + topology test all passed, and
-mockway is left in the post-apply state for inspection at
-`http://127.0.0.1:8080/mock/state`.
+the static validator + mockway apply + topology test + destroy/orphan-check
+all passed. The default `run` tears the resources down at the end of the
+test cycle (the scenario's `destruction: no_orphans` acceptance criterion),
+so `http://127.0.0.1:8080/mock/state` reports empty collections. To inspect
+the post-apply state, add `--no-destroy` to the run command.
 
 Use `make status` at any time to see which of the five ports
 (`8080`, `8081`, `8082`, `9090`, `4173`) are listening.


### PR DESCRIPTION
## Summary
Quickstart audit (verified by running the documented \`./bin/infrafactory run scenarios/training/block-paris.yaml --config infrafactory.yaml\` end-to-end) caught one inaccuracy: the README said mockway is left in the post-apply state for inspection after a successful run. The default \`run\` actually includes destroy + orphan-check (the scenario's \`destruction: no_orphans\` acceptance criterion), so \`/mock/state\` returns empty collections.

Reword to:
- Acknowledge the destroy/orphan-check stage in the success path.
- State that \`/mock/state\` reports empty collections after a clean run.
- Point at \`--no-destroy\` for users who want to inspect the post-apply state.

Verified the fix matches reality: with default flags, \`block.volumes\` count = 0; with \`--no-destroy\`, count = 1.

## Test plan
- [x] Ran the documented quickstart command and confirmed the new wording matches actual behavior
- [x] Pre-commit hook green (doc-only commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)