### PR TITLE
S74: AWS phase3 retirements — DB subnet group + SG cycle avoidance

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,7 @@ Last updated: 2026-06-02
 
 ## Current phase
 
+- **S74 — AWS phase3 retirements landed.** Two Category-A retirements: rule 3 sub-bullets on **DB subnet group ordering** (Category A, `tofu plan` error if reference missing) and **SG cycle avoidance** (Category A, `tofu plan` cycle error from inline ingress/egress blocks self-referencing). Re-validated against aws-rds (target_reached iter 1, 3 `aws_db_subnet_group` resources correctly produced) + aws-eks (target_reached iter 1, 0 inline SG blocks) + aws-full-stack (target_reached iter 4, the slow convergence was on an unrelated `aws_kms_alias` naming-policy quirk that the LLM self-resolved). AWS phase3 rule 3 down to 2 remaining sub-bullets (VPC ordering — Category B, IAM profile chain — Category C). Per ADR-0018.
 - **GCP phase2 prompt-collapse complete.** Nine retirements landed between S56 (firewall) and S73 (project_service + project_iam_member). Phase2 prompt now contains only rules 1–8 (system contract) + 16 (region) + 17 (naming) — the destination described in `slices-54-62-plan.md` § "Big picture". The N10→N11→N13 auto-derivation pipeline is end-to-end and battle-tested across two sustain-ratchet sweeps (S63, ~implicit via S72/S73 runs).
 - **Next arc planned**: `docs/plans/slices-74-78-plan.md` — apply the collapse pattern to AWS + Scaleway prompts, run a post-collapse sweep, drain 2–3 `docs/mock-gaps.md` entries, land `make sweep-39` + N3 classifier escape carve-out. ~8–12 hr.
 - Older arc close-outs (S54–S73) and milestones (S1–S53) live in `docs/status/ARCHIVE.md`.

--- a/docs/NEXT_SESSION.md
+++ b/docs/NEXT_SESSION.md
@@ -2,6 +2,11 @@
 
 Self-contained brief for a fresh Claude / engineer starting in this repo.
 
+## S74–S78 progress
+
+- ✅ **S74**: AWS phase3 rule 3 sub-bullets on DB subnet group ordering + SG cycle avoidance retired (Category A). Audit shows AWS phase2 is fully Category C; phase3 has 2 remaining sub-bullets (VPC — Category B, IAM profile chain — Category C).
+- ⬜ S75, S76, S77, S78: remaining.
+
 ## READ FIRST
 
 **GCP phase2 prompt-collapse complete.** The 9-retirement target arc described in `docs/plans/slices-54-62-plan.md` § "Big picture" is done — GCP phase2 is now system-contract + scenario-intent only (rules 1–8 + 16 + 17). All 9 originally-prescriptive rules retired between S56 (firewall) and S73 (project_service + project_iam_member). 39/39 deterministic sweep confirmed at S63 and S72 baselines.

--- a/prompts/aws/phase3_self_review.md
+++ b/prompts/aws/phase3_self_review.md
@@ -39,8 +39,6 @@ Review the generated HCL against:
 3. AWS-specific correctness:
    - VPC + subnet exist before any compute, database, or kubernetes resource.
    - IAM role + instance profile chain is correct (profile bridges role to instance).
-   - DB subnet group exists before any RDS instance in a custom VPC.
-   - Security group rules use `aws_security_group_rule` resources (NOT inline `ingress` / `egress` blocks) when the same SG references itself, to avoid the cycle that inline blocks create.
 4. Provider version pin matches `hashicorp/aws ~> 5.70`.
 
 ## Output Format


### PR DESCRIPTION
## Summary
S74-T1 audit classified every AWS prescriptive rule per ADR-0018:

**AWS phase2** (10 rules): all Category C — system contract / scenario-bound. Nothing retirable.

**AWS phase3 rule 3 sub-bullets**:

| Sub-bullet | Category |
|---|---|
| VPC + subnet ordering | B (existing pitfalls) |
| IAM role + instance profile chain | C (no clean signal) |
| **DB subnet group ordering** | **A — retire** |
| **SG cycle avoidance (\`aws_security_group_rule\` not inline)** | **A — retire** |

Both Category-A bullets retired:
- DB subnet group: \`tofu plan\` errors on missing reference
- SG cycle: \`tofu plan\` rejects inline ingress/egress self-references

## Validation
| Scenario | Outcome | Sig |
|---|---|---|
| aws-rds | \`target_reached\` iter 1, 217s | 3 \`aws_db_subnet_group\` resources; 0 inline SG blocks |
| aws-eks | \`target_reached\` iter 1, 110s | 0 inline SG blocks |
| aws-full-stack | \`target_reached\` iter 4, 1467s | 0 inline SG blocks, 2 \`aws_db_subnet_group\` resources; slow iters were on an unrelated \`aws_kms_alias\` naming-policy quirk the LLM self-resolved |

Per ADR-0018 Category A: rules redundant — delete with no follow-up.

13th and 14th N11 retirements since the arc chain began.

## Test plan
- [x] 3 AWS scenarios all \`target_reached\`
- [x] Generated HCL inspected: 0 inline SG self-ref blocks, correct \`aws_db_subnet_group\` resources
- [x] Pre-commit hook green

🤖 Generated with [Claude Code](https://claude.com/claude-code)