### PR TITLE
S98: retire GCP phase3 rule #13 (region restriction — OPA duplicate)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -8,8 +8,8 @@ Last updated: 2026-06-03
 - **Active arc**: `docs/plans/post-sustain-tightening-plan.md` (second Option C arc).
   - **S96 ✅** (fakeaws#7): aws-route53 fix — sort records lexicographically before maxitems=1 filter; add ChangeTagsForResource POST handler. End-to-end validated: aws-route53 converges iter 1.
   - **S97 in flight (this PR)**: transport-failure classification in `sweep_39.sh`. Heuristic (dur < 30s AND only `_generate` stage fails) reclassifies pre-iter-1 LLM transport failures as `transport_failed` distinct from `repair_budget_exhausted`. Dry-run on sweep-3 data: 5 reclassifications (5/9 of the sweep-3 tail correctly identified).
-  - **S98 next**: retire GCP phase3 self-review rule #13 + AWS/Scaleway audit.
-  - **S99 last**: extend OPA-dup ratchet to `prompts/*.md` + arc close-out.
+  - **S98 ✅ (this PR)**: retired GCP phase3 self-review rule #13 (region restriction — verbatim OPA duplicate). AWS/Scaleway phase3 audited: zero same-shape candidates. Validated: gcp-cloud-run converges iter 2 post-retirement, OPA `region_restriction.rego` enforces correctly.
+  - **S99 next**: extend OPA-dup ratchet to `prompts/*.md` + arc close-out.
 - **Last arc complete**: `docs/plans/sustain-and-n13-durability-plan.md` — Option C's first goal-named arc. S94 landed `cmd/pitfall-merge/` (selectively preserves N13 entries through sweep teardown). S95 ran 3 sustain sweeps + folded close-out. N13 zero emissions across all 3 sweeps (no organic deletion-as-fix this cycle).
 
 ## Recent arcs

--- a/prompts/gcp/phase3_self_review.md
+++ b/prompts/gcp/phase3_self_review.md
@@ -54,7 +54,6 @@ Verify compliance with these known pitfalls:
 2. **Syntax**: Is the HCL valid? Are all blocks properly closed?
 3. **Provider**: Is the `hashicorp/google` provider configured correctly? No `credentials` attribute in the provider block (env vars supply auth)?
 7. **No public IPs on instances**: Unless the scenario explicitly requires one, `google_compute_instance.network_interface` should NOT include an `access_config` block (which would assign an ephemeral public IP).
-13. **Region restriction**: Are all `region` and `location` values in the allowed list (default: `us-central1`, `europe-west1`, `europe-west4`)? Zones must be children of an allowed region (e.g. `us-central1-a`). The `region_restriction` OPA policy enforces this.
 14. **Acceptance criteria**: Will the generated infrastructure pass each criterion?
     - Connectivity checks: are subnetworks and firewall rules configured correctly?
     - HTTP probes: are `google_compute_forwarding_rule` / backend services / health checks set up?


### PR DESCRIPTION
## Summary

Closes S98 from `docs/plans/post-sustain-tightening-plan.md`.

GCP phase3 self-review rule #13 explicitly cited the OPA policy that enforces it:

> **Region restriction**: ... The `region_restriction` OPA policy enforces this.

Textbook Category B per ADR-0018 — load-bearing but a replacement carrier already exists (`policies/gcp/region_restriction.rego`). Identified during a user-prompted audit mid-arc-89-93; never executed. This PR runs the N11 retirement protocol.

**AWS + Scaleway phase3 audit**: zero same-shape candidates.

- `prompts/aws/phase3_self_review.md`: zero OPA citations.
- `prompts/scaleway/phase3_self_review.md`: one conditional constraint reference (`no_public_database: true` — scenario-bound, not naming the policy as the enforcement mechanism). Category C.

## Test plan

- [x] End-to-end: gcp-cloud-run converges `target_reached iter 2` post-retirement. OPA `region_restriction.rego` correctly enforces `europe-west1`.
- [x] Pre-commit hook ran full suite — green.

## Next

S99 extends `TestPitfallsNoOPADuplication` to scan `prompts/*.md` so future rule-#13 shapes get caught by CI automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)