### PR TITLE
S105: sustain under renamed vocab — 117/117 across 3 sweeps + close-out

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,14 +1,11 @@
 # STATUS
 
-Last updated: 2026-06-04
+Last updated: 2026-06-05
 
 ## Current phase
 
-- 🎯 **Baseline: 38-39/39 deterministic, 0 panics** — last probe sweep 2026-06-04: 38/39 deterministic (one scenario stuck on Scaleway DNS zone declaration, now resolvable under the S102 enriched mockway 404).
-- **Last arc complete**: `docs/plans/mock-gaps-and-rename-plan.md` (fourth Option C arc). Three slices.
-  - **S102** (mockway#5, merged): mockway domain handlers now return `resource` + `resource_id` in 404 responses. scaleway-sdk-go's ResourceNotFoundError formats Error() using these — without them the SDK printed `resource  with ID  is not found` (empty fields). Verified live: web-app-paris now reports `resource dns_zone with ID example.com is not found`.
-  - **S103** (#84, merged): 13 stale historical `docs/mock-gaps.md` entries verified non-reproducible (probe sweep passed every `discovered_from`); file moved to `.gitignore` as per-host runtime artifact. Drainage protocol documented.
-  - **S104 (this PR)**: atomic rename of the auto-learning vocabulary. `IsMockActionable → IsMockServerBug`, `ExtractPrescriptive{Fix,Avoid} → Extract{Fix,Avoid}Pitfall`, `ExtractLearnedPitfall → ExtractDescriptivePitfall`. `cmd/n10extract → cmd/extract-pitfall`. YAML `source:` enum: `learned → descriptive`, `learned_from_diff → fix`, `learned_from_diff_avoid → avoid`. Sweep summary `N13_EMISSIONS → AVOID_EMISSIONS`. Code + binary + YAML + sweep harness + 4 READMEs + AGENTS.md + auto-learning-loop.md all migrated in one PR. Arc close-out folded in.
+- 🎯 **Baseline: 39/39 deterministic, 0 panics** — sustain-validated 2026-06-05 across 3 consecutive sweeps under the renamed auto-learning vocabulary: 39/39 + 39/39 + 39/39 (117/117 total).
+- **Last arc complete**: `docs/plans/sustain-under-renamed-vocab-plan.md` (fifth Option C arc). Single slice (S105). Three consecutive `make sweep-39` runs all clean; zero leaks of the legacy source-enum literals or summary-line names anywhere; classifier routed an organic mock-gap (aws-secrets-manager KMS DescribeKey 404) in sweep 3 confirming `IsMockServerBug` works live. Arc close-out folded in.
 - **Last arc complete**: `docs/plans/post-sustain-tightening-plan.md` (second Option C arc). Five PRs landed.
   - **S96** (fakeaws#7): fakeaws Route 53 — sort records lexicographically before `maxitems=1` filter; add `ChangeTagsForResource` POST handler. aws-route53 converges iter 1 end-to-end.
   - **S97** (#78): transport-failure classifier in `sweep_39.sh`. Reclassifies pre-iter-1 Claude CLI failures as `transport_failed` distinct from `repair_budget_exhausted`. Dry-run on sweep-s95-3 data: 5/7 correctly reclassified.

--- a/docs/NEXT_SESSION.md
+++ b/docs/NEXT_SESSION.md
@@ -12,15 +12,13 @@ Self-contained brief for a fresh Claude / engineer starting in this repo.
 
 ## Last arc complete
 
-`docs/plans/mock-gaps-and-rename-plan.md` — fourth Option C arc. Full close-out: `docs/status/ARCHIVE.md` § "2026-06-04 mock-gaps drain + learning-system rename".
+`docs/plans/sustain-under-renamed-vocab-plan.md` — fifth Option C arc. Full close-out: `docs/status/ARCHIVE.md` § "2026-06-05 sustain under renamed vocabulary".
 
-- ✅ **S102** (mockway#5): enriched mockway domain 404s with `resource` + `resource_id` so scaleway-sdk-go formats `Error()` readably. Verified live on web-app-paris.
-- ✅ **S103** (#84): 13 stale `docs/mock-gaps.md` entries pruned; file moved to `.gitignore`; drainage protocol documented.
-- ✅ **S104** (this PR): atomic rename of the auto-learning vocabulary. `IsMockActionable → IsMockServerBug`; `ExtractPrescriptive{Fix,Avoid} → Extract{Fix,Avoid}Pitfall`; `ExtractLearnedPitfall → ExtractDescriptivePitfall`. Binary `cmd/n10extract → cmd/extract-pitfall`. YAML `source:` enum migrated atomically (`learned → descriptive`, `learned_from_diff → fix`, `learned_from_diff_avoid → avoid`).
+- ✅ **S105** (this PR): three consecutive `make sweep-39` runs under the renamed vocabulary. All 39/39 deterministic (117/117 total). Zero panics, zero transport retries needed. Zero hits for legacy source-enum literals (`learned` / `learned_from_diff` / `learned_from_diff_avoid`) in post-merge `pitfalls/*.yaml`. Zero hits for legacy summary names (`N13_EMISSIONS` / `learned_from_diff* lines` / `N13 durability`) in master logs. Classifier routed an organic mock-gap (aws-secrets-manager KMS DescribeKey 404) in sweep 3, confirming `IsMockServerBug` live. One stale-vocab leak found + fixed: local `docs/mock-gaps.md` header (the writer code already uses `IsMockServerBug`; only the boilerplate I wrote during S103 was pre-rename text).
 
 ## Suggested next arc
 
-- **Sustain another 3 sweeps under the renamed vocabulary** — confirms classifier + extractors + selective-discard still route correctly post-rename. ~2-3 hr wallclock. Smallest scope; validates the rename in production conditions.
+- **fakeaws aws-secrets-manager KMS DescribeKey 404 after key destroy** — S105 surfaced this as a mock-gap. ~30-60 min single-slice arc against fakeaws.
 - **Layer 3 real-cloud validation** — open since S93. Genuinely deploys to real AWS/GCP/Scaleway. Big arc (cloud credentials, money, cleanup discipline). High value but high coordination cost.
 
 ## Open tickets

--- a/docs/plans/sustain-under-renamed-vocab-plan.md
+++ b/docs/plans/sustain-under-renamed-vocab-plan.md
@@ -1,0 +1,95 @@
+# Arc: sustain under the renamed vocabulary
+
+Status: planned (2026-06-04)
+Owner: next-session claude (designed for autonomous execution)
+Follows: `mock-gaps-and-rename-plan.md` (closed 2026-06-04 with S102 + S103 + S104)
+Shape: goal-named variable-length arc per AGENTS.md (1 slice, ~2-3 hr wallclock; mostly sweep time)
+
+## Big picture
+
+S104 renamed the auto-learning vocabulary atomically: `IsMockServerBug` / `ExtractFixPitfall` / `ExtractAvoidPitfall` / `ExtractDescriptivePitfall` in code, `descriptive` / `fix` / `avoid` in the YAML `source:` enum, `AVOID_EMISSIONS=N` in the sweep summary, `bin/pitfall-merge --keep avoid` in the sweep harness. Unit + integration tests covered the mechanism, and a probe sweep ran on 2026-06-04 immediately before the rename, but the rename hasn't been exercised under live sweep conditions yet.
+
+The risk is low (atomic refactor, tests green) but the surface area is large (every emission path, the loader, the merger, the sweep harness). A 3-sweep sustain run validates:
+
+1. **Classifier still routes correctly.** `IsMockServerBug` matches the same signals it matched as `IsMockActionable`; nothing routes to `docs/mock-gaps.md` that should have stayed a pitfall, and vice versa.
+2. **Extractors still emit with new source values.** Any organic `fix` or `avoid` entry that surfaces during a sweep gets the new enum value (not the old literal).
+3. **Selective-discard still preserves `avoid`.** `bin/pitfall-merge --keep avoid` correctly preserves `avoid` entries through teardown and discards `fix` + `descriptive` as noise.
+4. **Sweep summary lines emit with new names.** `AVOID_EMISSIONS=N` appears; `RETRY_TRANSPORT` + `RETRY_RECOVERED` (S101) still work.
+5. **No regression on the 38-39/39 deterministic baseline.**
+
+## Standing rules
+
+Inherit all rules from prior arcs (slices-54-62 through `mock-gaps-and-rename-plan.md`):
+
+- **Selective pitfall discard** (post-S104): `avoid` survives via `bin/pitfall-merge`; `fix` + `descriptive` discarded as before.
+- **Transport retry**: `scripts/sweep_39.sh` retries `transport_failed` shape once before recording (S101 behavior).
+- **Fix at source**: mock bugs go to fakeaws/fakegcp/mockway, never hand-edit `pitfalls/*.yaml`.
+- **Mandatory close-out per Option C**: folded into the single slice.
+
+## Slice
+
+| Slice | Title | Effort |
+|---|---|---|
+| S105 | 3 consecutive `make sweep-39` runs under renamed vocab + close-out | ~2-3 hr (mostly wallclock) |
+
+## S105 — three consecutive sustain sweeps + close-out
+
+### Motivation
+
+The rename was atomic and tests pass. This slice confirms the rename holds under live sweep conditions. If 3 sweeps come back clean, the rename is durable and the loop can move on. If any signal fails to emit or any scenario flaps, that's a rename regression — fix-forward in-slice.
+
+### Tickets
+
+| ID | Description | Priority | Deps |
+|---|---|---|---|
+| S105-T1 | `make mocks-restart` for a clean baseline. Run `make sweep-39` three consecutive times into distinct `SWEEP_DIR`s (`/tmp/sweep-s105-1`, `-2`, `-3`). Capture per-scenario pass/fail, `AVOID_EMISSIONS=N` per run, panic counts, `RETRY_TRANSPORT=N` + `RETRY_RECOVERED=M` per run. | P0 | — |
+| S105-T2 | After each sweep, grep the post-merge `pitfalls/*.yaml` for the old source-enum literals (`learned\|learned_from_diff\|learned_from_diff_avoid`). Any hit is a rename regression — the writer or loader still produces the old values. | P0 | T1 |
+| S105-T3 | After each sweep, grep the master log for the old summary-line names (`N13_EMISSIONS\|learned_from_diff\* lines`). Any hit is a sweep-harness rename regression. | P0 | T1 |
+| S105-T4 | Build a comparison table per-scenario across the 3 sweeps. Flag any scenario that flapped. | P0 | T1 |
+| S105-T5 | If `avoid` entries surface organically: confirm they get preserved through `bin/pitfall-merge` (cross-reference pre vs post YAML diffs). If `AVOID_EMISSIONS=0` across all 3 sweeps, that's a soft watchdog — note it but don't treat as failure (S100 showed N13 can stay silent across sustain cycles). | P0 | T1 |
+| S105-T6 | If any rename regression surfaces (T2 / T3 / T5): fix-forward in-slice. Re-run the failing sweep stage to confirm. | P0 | T2-T5 |
+| S105-T7 | One PR. **Arc close-out folded in** (STATUS + NEXT_SESSION + ARCHIVE per Option C). | P0 | T1-T6 |
+
+### Exit criteria
+
+- Three consecutive sweeps complete (any combination of 38/39 or 39/39 deterministic, transport tail allowed).
+- Zero hits for old source-enum literals in post-merge `pitfalls/*.yaml`.
+- Zero hits for old summary-line names in any sweep master log.
+- Per-scenario stability documented; flapping scenarios investigated (if any).
+- ARCHIVE close-out for the arc lands.
+
+## Why this shape
+
+Single slice because the work is one logical action (3 sweeps under a fixed configuration) and the verification is mechanical (grep for old literals; cross-reference YAML diffs). Splitting into two slices would force an artificial boundary mid-validation. If a regression surfaces, fix-forward IN the slice — the slice's PR carries both the sweep evidence AND the fix together, which is the right granularity for the auditor.
+
+If the work expands beyond fix-forward (e.g. a deeper structural problem with the rename surfaces and needs a re-architect), spawn a separate arc and close this one out as "validated except X".
+
+## Autonomous-execution loop prompt
+
+```
+/loop until S105 in docs/plans/sustain-under-renamed-vocab-plan.md is complete: exit criteria met, PR merged with green CI, STATUS + NEXT_SESSION updated.
+
+Read docs/NEXT_SESSION.md first for the prior arc's handoff, then docs/plans/sustain-under-renamed-vocab-plan.md for the slice definition. All prior standing rules apply (slices-54-62 through mock-gaps-and-rename). Standing rule (post-S104): `avoid` survives via bin/pitfall-merge; `fix` + `descriptive` discarded as sweep noise.
+
+S105 folds the mandatory ARCHIVE + NEXT_SESSION close-out per the Option C arc shape — no separate close-out slice.
+
+Authority: open + merge PRs with `gh pr merge <N> --squash --admin --delete-branch` once CI is green.
+
+Exit decision matters: if any of the three sweeps shows an old source-enum literal (`learned`, `learned_from_diff`, `learned_from_diff_avoid`) in post-merge pitfalls/*.yaml, or an old summary-line name (`N13_EMISSIONS`, `learned_from_diff* lines`) in the master log, that's a rename regression — fix-forward in-slice before closing out. Otherwise proceed to close-out directly.
+
+Stop only when: (a) S105 complete OR (b) you genuinely cannot proceed (document the blocker in NEXT_SESSION + stop).
+
+Before stopping for any reason, update docs/NEXT_SESSION.md with: what landed, what's blocked, what next session should do FIRST.
+```
+
+## Fresh-context checklist
+
+The autonomous prompt assumes the agent reads, in order:
+1. `AGENTS.md` (Option C goal-named arcs; sweep-protocol bullet — already in the renamed vocabulary)
+2. `docs/NEXT_SESSION.md`
+3. This file (`docs/plans/sustain-under-renamed-vocab-plan.md`)
+4. `STATUS.md`
+5. `docs/status/ARCHIVE.md` § "2026-06-04 mock-gaps drain + learning-system rename" (the rename specifics S105 validates)
+6. `docs/decisions/0019-learning-system-vocabulary.md` (the ADR that codifies what the rename was)
+7. `scripts/sweep_39.sh` (the file S105 invokes; verifies `--keep avoid` + `AVOID_EMISSIONS=N` text)
+8. `docs/auto-learning-loop.md` (the explainer; written in the renamed vocabulary)

--- a/docs/status/ARCHIVE.md
+++ b/docs/status/ARCHIVE.md
@@ -2,6 +2,33 @@
 
 Historical snapshots and older session notes can be moved here to keep `STATUS.md` concise.
 
+## 2026-06-05 sustain under renamed vocabulary arc close-out
+
+Fifth Option C arc. Single slice (S105). The S104 rename was atomic and unit-test-validated; this slice exercised it under live sweep conditions across three consecutive `make sweep-39` runs.
+
+| Sweep | Result | AVOID_EMISSIONS | RETRY_TRANSPORT | Panics | Notes |
+|---|---|---|---|---|---|
+| 1 | 39/39 deterministic | 0 | 0 | 0 | web-app-paris converged in 2 iterations under the S102 mockway fix |
+| 2 | 39/39 deterministic | 0 | 0 | 0 | — |
+| 3 | 39/39 deterministic | 0 | 0 | 0 | Organic mock-gaps emission: aws-secrets-manager KMS DescribeKey 404 (classifier routing verified live) |
+
+**Total: 117/117 deterministic across three sweeps. Zero panics. Zero transport retries needed.**
+
+**Vocabulary leak audit** (after each sweep):
+- `grep -nE "source: (learned|learned_from_diff|learned_from_diff_avoid)$" pitfalls/*.yaml` → 0 hits
+- `grep -nE "N13_EMISSIONS|learned_from_diff\* lines|N13 durability" master.log` → 0 hits
+- All `pitfalls/*.yaml` `source:` values use the renamed enum (`descriptive` / `fix` / `avoid`)
+- All sweep summary lines use renamed names (`AVOID_EMISSIONS=N`, `+N diff-derived lines`, `avoid-pitfall durability`, `kept_new=N (sources: avoid)`)
+- `bin/pitfall-merge --keep avoid` invoked correctly per-cloud
+
+**One stale-vocab fix**: local `docs/mock-gaps.md` header (boilerplate written during S103, before the rename) still referenced `IsMockActionable` and "N3 classifier". The writer in `pitfalls_learn.go:213-221` already uses `IsMockServerBug`, so a fresh-environment regen would have been correct; only the locally-written header was stale. Fixed in place.
+
+`AVOID_EMISSIONS=0` across all three sweeps mirrors the S95 + S100 + probe-sweep pattern. Per S100's note: zero is a soft watchdog — could be the LLM stopped making deletion-recoverable mistakes OR the extractor broke. Tests confirm the extractor still fires correctly on synthetic input; the LLM under current pitfall load isn't producing the deletion-as-fix shape organically. Not treated as a regression.
+
+**Follow-up surfaced (not blocking)**: sweep 3's organic mock-gap (`aws-secrets-manager` → `KMS DescribeKey` returning 404 after key destroy) is a latent fakeaws fidelity issue — should be fixed at source in a future arc.
+
+Arc closed: the rename is durable under live sweep conditions.
+
 ## 2026-06-04 mock-gaps drain + learning-system rename arc close-out
 
 Fourth Option C arc. Three slices: S102 (web-app-paris diagnosis + mockway fix), S103 (drain stale mock-gaps entries), S104 (rename N3/N10/N13/M97 → Fix/Avoid + close-out).


### PR DESCRIPTION
## Summary
Three consecutive `make sweep-39` runs validating the S104 rename in production conditions.

| Sweep | Result | AVOID_EMISSIONS | RETRY_TRANSPORT | Panics |
|---|---|---|---|---|
| 1 | 39/39 deterministic | 0 | 0 | 0 |
| 2 | 39/39 deterministic | 0 | 0 | 0 |
| 3 | 39/39 deterministic | 0 | 0 | 0 |

**Total: 117/117 deterministic. Zero transport retries needed.**

## Vocabulary leak audit (after each sweep)
- `grep -nE "source: (learned\|learned_from_diff\|learned_from_diff_avoid)$" pitfalls/*.yaml` → **0 hits**
- `grep -nE "N13_EMISSIONS\|learned_from_diff\* lines\|N13 durability" master.log` → **0 hits**
- All sweep summary lines use renamed names (`AVOID_EMISSIONS=N`, `+N diff-derived lines`, `avoid-pitfall durability`, `kept_new=N (sources: avoid)`)
- `bin/pitfall-merge --keep avoid` invoked correctly per-cloud

## Notable
- Sweep 3 surfaced an organic mock-gap (aws-secrets-manager KMS DescribeKey 404 after key destroy) — proves `IsMockServerBug` routes correctly under the renamed code. Filed as follow-up arc candidate; not blocking.
- One stale-vocab leak found + fixed: local `docs/mock-gaps.md` header (boilerplate written during S103, before S104's rename). The writer code (`pitfalls_learn.go:213-221`) already uses `IsMockServerBug` — only the locally-written header was pre-rename text. File remains git-ignored.

## Test plan
- [x] Three `make sweep-39` runs completed
- [x] `go test ./...` green; Playwright UI suite green
- [x] All renamed signals emit correctly
- [x] No legacy vocabulary leaks anywhere in active surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)