### PR TITLE
docs: tighten active-surface slice-ID leaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 For AI coding agents. Human contributors should use `CONTRIBUTING.md`.
 
 ## Mission
-Build `infrafactory`, a Go CLI + SvelteKit UI that generates and validates OpenTofu across **AWS**, **GCP**, and **Scaleway** with deterministic, testable behavior. Each cloud's scenarios validate against a deterministic HTTP-level mock (fakeaws / fakegcp / mockway); S3 routes through a small in-repo shim (`cmd/s3router/`, S80) that fans traffic between SeaweedFS (data plane) and fakeaws (`?publicAccessBlock` subresource SeaweedFS doesn't model). See `CONCEPT.md` § "Third-Party Mock Integration".
+Build `infrafactory`, a Go CLI + SvelteKit UI that generates and validates OpenTofu across **AWS**, **GCP**, and **Scaleway** with deterministic, testable behavior. Each cloud's scenarios validate against a deterministic HTTP-level mock (fakeaws / fakegcp / mockway); S3 routes through a small in-repo shim (`cmd/s3router/`) that fans traffic between SeaweedFS (data plane) and fakeaws (`?publicAccessBlock` subresource SeaweedFS doesn't model). See `CONCEPT.md` § "Third-Party Mock Integration".
 
 ## Source of Truth
 1. `scenario.schema.json`

--- a/README.md
+++ b/README.md
@@ -254,10 +254,12 @@ make mocks-up-containers   # build + start fakeaws + fakegcp + mockway
 make mocks-down-containers
 make mocks-pull            # refresh published GHCR images
 
-# canonical 39-scenario sustain-ratchet sweep (S78). Drives
-# `infrafactory run` across every scenario under scenarios/training/
-# with `infrafactory mock reset` between scenarios. Output lands in
-# /tmp/sweep-39/summary.tsv. Discards pitfall additions (sweep noise).
+# canonical sustain-ratchet sweep. Drives `infrafactory run` across
+# every scenario under scenarios/training/ with `infrafactory mock reset`
+# between scenarios. Output lands in /tmp/sweep-N/summary.tsv. Discards
+# pitfall additions (sweep noise); preserves `avoid` entries via
+# bin/pitfall-merge. Renames `make sweep-39` → `make sweep-N` when a new
+# cloud lands; current N = 39.
 make sweep-39
 
 # session-close hygiene — sweeps lingering sweep scripts, log tails,


### PR DESCRIPTION
## Summary
Two small slice-ID-leak fixes in active surfaces:

- AGENTS.md mission line drops "(S80)" attribution from cmd/s3router/ description.
- README.md sweep block drops "(S78)" + reframes the rename ("\`make sweep-39\` → \`make sweep-N\` when a new cloud lands") as forward-looking instead of historical.

Both per the convention: slice IDs are for ARCHIVE / commits / memory pointers, not active reader-facing text. Part of a docs-optimization pass.

## Test plan
- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)