### PR TITLE
S122e: prompt rule — only auto_answer_only exists

### DIFF
--- a/prompts/genesys/phase2_generate_hcl.md
+++ b/prompts/genesys/phase2_generate_hcl.md
@@ -39,6 +39,8 @@ You are a Terraform/OpenTofu engineer specialising in Genesys Cloud CCaaS. Your 
 9. Naming: use lowercase hyphenated values for `name` fields. Genesys's API tolerates spaces but the smoke harness assertions prefer kebab-case.
 10. **`genesyscloud_oauth_client.authorized_grant_type` uses HYPHEN, not underscore.** Valid values: `"CODE"`, `"TOKEN"`, `"SAML2BEARER"`, `"SAML2-BEARER"`, `"PASSWORD"`, `"CLIENT-CREDENTIALS"`. Do NOT write `"CLIENT_CREDENTIALS"` (the underscore form is rejected — the provider lists only the hyphenated values). The Go/Python convention of underscores doesn't apply here.
 
+10c. **Auto-answer attributes use ONLY `auto_answer_only`.** Do NOT write `auto_answer_on`, `auto_answer_number_of_calls`, or any other `auto_answer_*` variant on `genesyscloud_routing_queue`, `genesyscloud_routing_utilization`, or any other Genesys resource. The single canonical attribute is `auto_answer_only` (boolean). The provider rejects every other `auto_answer_*` name with "argument not expected".
+
 10b. **`genesyscloud_user` does NOT accept a `roles { }` block.** To assign roles to a user, declare a SEPARATE `genesyscloud_user_roles` resource:
 
     ```hcl


### PR DESCRIPTION
Sweep 6's full-stack stuck on LLM HCL typos: `auto_answer_number_of_calls`, `auto_answer_on`. Promote to prompt rule covering the full `auto_answer_*` family.