### PR TITLE
docs: catch up NEXT_SESSION + ARCHIVE for post-S135 follow-up (fresh-agent readiness)

### DIFF
--- a/docs/NEXT_SESSION.md
+++ b/docs/NEXT_SESSION.md
@@ -7,13 +7,28 @@ Self-contained brief for a fresh Claude / engineer starting in this repo.
 ### Baseline
 
 - **44/44 deterministic** (full scope, sweep 8, 2026-06-10).
-- **fakegenesys v0.2.0 tagged + pushed** (commit `3e5dc55`). v0.1.0 GitHub release flipped from Draft → published.
+- **fakegenesys v0.2.0 tagged + pushed** (commit `3e5dc55`). v0.1.0 GitHub release published (duplicate Draft cleaned up).
 - **27 paired contracts CI-enforced across all 4 sibling fakes** via `handlers/contract_audit_test.go`. Convention is `CRITICAL[<id>]:` docstring ↔ `TestContract_<id>` test.
+- **ADR-0021 cloud-prefix lockstep CI-enforced** via `internal/cli/cloud_prefix_lockstep_test.go`. The three sites (`resourceNameRe` / `addressRe` / `pitfallResourceMatchesCloud`) are parsed at test time; disagreement on the cloud-prefix set fails CI with a per-site diff. Same shape as the sibling-fake contract audit.
 - Smoke check post-S135: genesys-full-stack target_reached in 329s / 2 iters (no LLM-layer regression).
+
+### "Drift becomes failed `go test`" — the durable enforcement pattern
+
+Three CI-enforced audits now cover wire-shape and pipeline conventions across the project:
+
+| Audit | Where | What it catches |
+|---|---|---|
+| Sibling contract audit | `handlers/contract_audit_test.go` in mockway, fakegcp, fakeaws, fakegenesys | Missing `TestContract_<id>` for a `CRITICAL[<id>]:` docstring (or vice versa) |
+| Cloud-prefix lockstep | `internal/cli/cloud_prefix_lockstep_test.go` | The three auto-learning regex sites disagree on the cloud-prefix set |
+| OPA-dup ratchet | `internal/generator/pitfalls_opa_dedup_test.go` + `prompts_opa_dedup_test.go` | Pitfalls or prompts duplicate an OPA-policy citation verbatim |
+
+Pattern: convention as code, not convention as doc. Each is empty-state-safe (zero coverage passes trivially) and self-tested where applicable. The convention is opt-in — adding a `CRITICAL[<id>]:` tag opts a handler in; handlers without one are invisible to the audit.
 
 ### Last arcs complete
 
-**S128–S135 (this session, 2026-06-10)** — sibling CRITICAL sweep + AGENTS+README cleanup + smoke. 8 PRs across all 5 repos. Bridged 10 new paired contracts in mockway (2) + fakegcp (4) + fakeaws (4) — combined with fakegenesys's 17 = 27 family-wide. Cross-repo AGENTS/README normalization with new Contract-coverage convention sections in each sibling's docs. Full close-out in `docs/status/ARCHIVE.md` § "2026-06-10 sibling CRITICAL sweep + AGENTS/README cleanup".
+**Post-S135 follow-up (2026-06-10)** — two paper-cut fixes: lockstep audit (`internal/cli/cloud_prefix_lockstep_test.go`) brings ADR-0021 from code-review-enforced to CI-enforced; duplicate v0.1.0 GitHub release Draft cleaned up. One PR (infrafactory#105). ADR-0021 amended with the enforcement note. AGENTS.md § 3 cross-references the test.
+
+**S128–S135 (2026-06-10)** — sibling CRITICAL sweep + AGENTS+README cleanup + smoke. 8 PRs across all 5 repos. Bridged 10 new paired contracts in mockway (2) + fakegcp (4) + fakeaws (4) — combined with fakegenesys's 17 = 27 family-wide. Cross-repo AGENTS/README normalization with new Contract-coverage convention sections in each sibling's docs. Full close-out in `docs/status/ARCHIVE.md` § "2026-06-10 sibling CRITICAL sweep + AGENTS/README cleanup".
 
 **S123–S127 (earlier 2026-06-10)** — fakegenesys v0.2 hardening (full arc detail below).
 

--- a/docs/status/ARCHIVE.md
+++ b/docs/status/ARCHIVE.md
@@ -2,6 +2,24 @@
 
 Historical snapshots and older session notes can be moved here to keep `STATUS.md` concise.
 
+## 2026-06-10 post-S135 follow-up: cloud-prefix lockstep audit + v0.1.0 release cleanup
+
+Single-PR follow-up (infrafactory#105) to the v0.2 + S128–S135 work. Closes two leftover paper-cuts:
+
+- **`internal/cli/cloud_prefix_lockstep_test.go::TestCloudPrefixLockstep`** brings ADR-0021's three-site lockstep rule from "enforced by code review only" to "fails CI with a per-site diff." Same shape as the sibling-fake `handlers/contract_audit_test.go` — parses each source file, extracts the cloud-prefix set, asserts equality (sites 1 ↔ 3) and superset (site 2 may add `random_` for provider-less resources via `permittedExtras`). Synthetic-drift verified by injecting a phantom `azure` into site 1 and confirming the per-site diagnostic.
+- **v0.1.0 GitHub release Draft duplicate deleted** — the first release workflow had failed and left a phantom Draft alongside the now-published v0.1.0. `gh api -X DELETE repos/redscaresu/fakegenesys/releases/337091171`.
+
+ADR-0021 amended with an "Amendment 2026-06-10: CI-enforced lockstep audit" section explaining the test's behaviour + drift diagnostic.
+
+**Pattern note — convention as code, not convention as doc**: three CI-enforced audits now cover wire-shape and pipeline conventions across the project:
+- 27 sibling-fake wire-shape contracts (S123 + S128–S130) via `handlers/contract_audit_test.go`
+- ADR-0021 cloud-prefix lockstep (post-S135) via `internal/cli/cloud_prefix_lockstep_test.go`
+- OPA-dup ratchet (S99) via `internal/generator/pitfalls_opa_dedup_test.go` + `prompts_opa_dedup_test.go`
+
+All follow the "drift becomes failed `go test`" pattern. Future enforcement gaps at this layer should default to a small audit test rather than a written-down rule.
+
+---
+
 ## 2026-06-10 sibling CRITICAL sweep + AGENTS/README cleanup (S128–S135)
 
 Follow-up to the v0.2 hardening close — bridges the existing wire-shape invariants in mockway/fakegcp/fakeaws into the `CRITICAL[<id>]:` convention so their `handlers/contract_audit_test.go` audits report `>0 contracts paired` rather than empty-state pass. Plus the 2026-06-05 carried AGENTS+README cleanup sweep across all 5 repos. Plus a final smoke check (genesys-full-stack) to confirm no LLM-layer regression. Plus the v0.1.0 release Draft → published cleanup.


### PR DESCRIPTION
## Summary

The lockstep audit + v0.1.0 release cleanup landed in PR #105 AFTER the S128–S135 close-out PR #104. STATUS.md was caught up in #105 itself (to pass doc-hygiene), but ARCHIVE / NEXT_SESSION / MEMORY weren't. This PR closes the gap so any fresh agent picking the project up reads the current state, not the pre-#105 state.

## Changes

- `docs/NEXT_SESSION.md`: baseline grows the lockstep-audit bullet + a new "Drift becomes failed `go test`" section listing the three CI-enforced audits (sibling contracts + cloud-prefix lockstep + OPA-dup). The pattern is durable + auditable; the section gives a fresh agent the why-and-where in one read.
- `docs/status/ARCHIVE.md`: new entry "2026-06-10 post-S135 follow-up: cloud-prefix lockstep audit + v0.1.0 release cleanup" documenting the lockstep audit + v0.1.0 cleanup, including the "convention as code, not convention as doc" pattern note.

(`MEMORY.md` auto-memory updated separately under `~/.claude/projects/.../memory/MEMORY.md` — not in the repo tree.)

## Verification

- Sibling AGENTS Contract-coverage sections (S132-S135 additions) spot-checked — still current; each lists the exact contracts S128/S129/S130 bridged.
- The lockstep-audit cross-reference in infrafactory AGENTS.md § 3 already exists (added in PR #105).
- STATUS.md was already updated in PR #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)