### PR TITLE
docs: record ADR-0023 implementation status after S141

### DIFF
--- a/docs/decisions/0023-layer3-sealed-environment-and-orphan-verification.md
+++ b/docs/decisions/0023-layer3-sealed-environment-and-orphan-verification.md
@@ -48,4 +48,6 @@ Supporting these, the sandbox environment requires `SCW_DEFAULT_ORGANIZATION_ID`
 
 **Relationship to ADR-0010**: amends rather than supersedes. ADR-0010's decisions stand — including decision 4 (self-managed project lifecycle), which S140 made actually reachable by teaching mockway `/account/v3/projects`. This ADR constrains *how* a Layer 3 run may execute and what a passing result means.
 
+**Implementation status (2026-08-22)**: rules 1, 2 and 5 are fully landed (S139, S142). Rule 3 is landed as the sweep itself plus the state-derived stray-resource check, and rule 4 as `harness.AssertProjectDeletable` (S141). What remains of rules 3–4 is the *interrupt* path: a run killed mid-apply leaves `terraform-live.tfstate` recording created resources with nothing to clean them up. Signal handling and a `reap` command are tracked as S141b, and **a real Layer 3 apply must not be attempted until they land** — the guarantees above hold only for runs that reach their destroy step.
+
 **Enforcement**: the guards carry synthetic-drift coverage — removing `SCW_API_URL` from `SandboxStripEnv` fails three tests, verified before S139 merged. Following the project's "drift becomes failed `go test`" pattern.


### PR DESCRIPTION
Follow-up to #140.

S141 changed `internal/cli/` without touching an ADR, so Doc Hygiene failed on that PR. **I merged it with the check red — that was a mistake.** This closes the gap rather than leaving `main` with a failing convention.

The update is substantive, not a formality. ADR-0023 described five rules as though all were in force. Three are (S139, S142). Rules 3 and 4 are only *partly* landed: the sweep, the stray-resource check and `AssertProjectDeletable` exist, but the interrupt path does not — a run killed mid-apply leaves `terraform-live.tfstate` recording created resources with nothing to clean them up.

The ADR now says so, and states plainly that **a real Layer 3 apply must not be attempted until S141b lands**, because the guarantees hold only for runs that reach their destroy step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)