### PR TITLE
fix(ui): restore libc fields stripped from package-lock.json

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -248,6 +248,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -265,6 +268,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -282,6 +288,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -299,6 +308,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -316,6 +328,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -333,6 +348,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
#144 accidentally carried an unrelated lockfile change: six `libc` entries (`"glibc"`/`"musl"`) removed from optional platform-specific dev dependencies.

**Not an intentional dependency change.** Local npm (11.4.2) rewrites the lockfile as a side effect of `npm ci` *and* of `make test`, dropping `libc` fields that dependabot's newer npm wrote. In #144 the file was restored in the working tree but only *after* `git add -A` had already staged it, so the amend captured the stripped version.

The field is load-bearing on Linux: npm uses it to choose between glibc and musl builds of native optional deps, so dropping it can select the wrong binary or skip a needed one in CI and container builds. macOS never notices — which is why nothing local caught it.

Restored verbatim from `14dca8c~1`. No other content differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)