### PR TITLE
fix(ui): make the run-mode card layout independent of mock reachability (M99)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -6,7 +6,7 @@ Legend: `todo` | `in_progress` | `blocked` | `done` | `wontfix`
 
 | id | title | priority | status | owner |
 |---|---|---|---|---|
-| M99 | Scenario-page visual baselines are environment-dependent (pass/fail flips on whether mockway is listening on :8080) | P2 | todo | — |
+| M99 | Scenario-page visual baselines are environment-dependent (pass/fail flips on whether mockway is listening on :8080) | P2 | done | — |
 | M100 | mockway instance examples 501 on `/instance/v2alpha1/.../private-network-interfaces` (provider drift) | P2 | todo | — |
 
 **M100 detail.** Three env-gated mockway examples — `basic_instance`, `vpc_and_private_network`, `rename_server` — fail against the current `scaleway/scaleway` provider, which calls `GET /instance/v2alpha1/zones/{zone}/private-network-interfaces`. mockway 501s that route. Verified pre-existing on clean `main` (not caused by the S140 account/v3 work). Invisible in CI because the example suite sits behind `MOCKWAY_ENABLE_E2E=1`, so nothing catches it until someone runs the gated suite. This is the example-drift layer described in `feedback_example_hcl_drift.md`, not the contract layer. Surfaced 2026-08-22 during S140.

--- a/ui/e2e/visual.spec.ts
+++ b/ui/e2e/visual.spec.ts
@@ -18,6 +18,14 @@ const VOLATILE_SELECTORS = [
   // changes sidebar height on every page, which would otherwise force
   // a re-baseline for unrelated scenario additions.
   'aside section[data-testid^="sidebar-cloud-"] ul',
+  // Run-mode tiles + error line: their TEXT depends on whether the mock
+  // is reachable and on local run artifacts. M99 made the card's LAYOUT
+  // stable (always three tiles, always one error line, all truncated);
+  // masking handles the remaining content variance so the baseline no
+  // longer depends on whether mockway happens to be running.
+  '[data-testid="scenario-tfstate-status"]',
+  '[data-testid="scenario-previous-run-status"]',
+  '[data-testid="scenario-run-mode-error"]',
 ];
 
 test.describe('Visual regression baselines', () => {

--- a/ui/src/routes/scenarios/[...path]/+page.svelte
+++ b/ui/src/routes/scenarios/[...path]/+page.svelte
@@ -199,22 +199,41 @@
         {layer3Enabled ? "mock + real" : runMode?.mode || "unknown"}
       </span>
     </div>
+    <!-- M99: this card must render the SAME NUMBER OF ELEMENTS whether or
+         not the run-mode API answered. It previously rendered one grid
+         tile when the API was unreachable and three when it responded,
+         plus a conditional error line — so page height, and therefore
+         the visual-regression baselines, depended on whether mockway
+         happened to be running. Masking cannot fix that: masks hide
+         content but do not constrain layout height.
+
+         Every tile is always present (value "unavailable" when unknown)
+         and `truncate` keeps each to exactly one line regardless of
+         content length. -->
     <div class="mt-4 grid gap-2 text-xs text-slate-600 md:grid-cols-3">
-      <div class="rounded bg-slate-100 px-3 py-2" data-testid="scenario-mock-status">
+      <div class="truncate rounded bg-slate-100 px-3 py-2" data-testid="scenario-mock-status">
         {#if runMode}
           {runMode.mock_provider || "mockway"} state: {runMode.has_mock_resources ? "yes" : "no"}
         {:else}
           {detailCloud === "gcp" ? "fakegcp" : "mockway"} state: unavailable
         {/if}
       </div>
-      {#if runMode}
-        <div class="rounded bg-slate-100 px-3 py-2">terraform.tfstate: {runMode.has_tfstate ? "yes" : "no"}</div>
-        <div class="rounded bg-slate-100 px-3 py-2">Previous success: {runMode.has_previous_successful_run ? "yes" : "no"}</div>
-      {/if}
+      <div class="truncate rounded bg-slate-100 px-3 py-2" data-testid="scenario-tfstate-status">
+        terraform.tfstate: {runMode ? (runMode.has_tfstate ? "yes" : "no") : "unavailable"}
+      </div>
+      <div class="truncate rounded bg-slate-100 px-3 py-2" data-testid="scenario-previous-run-status">
+        Previous success: {runMode ? (runMode.has_previous_successful_run ? "yes" : "no") : "unavailable"}
+      </div>
     </div>
-    {#if runModeError}
-      <p class="mt-3 text-sm text-red-700">{runModeError}</p>
-    {/if}
+    <!-- Always rendered, always one line: a conditional error paragraph
+         is another height variance. Full text on hover when truncated. -->
+    <p
+      class="mt-3 truncate text-sm text-red-700"
+      data-testid="scenario-run-mode-error"
+      title={runModeError}
+    >
+      {runModeError || "\u00a0"}
+    </p>
     <div class="mt-4 rounded border border-slate-200 bg-slate-50 px-3 py-3 text-xs text-slate-700">
       <div class="flex flex-wrap items-center gap-3">
         <label class="flex items-center gap-2 rounded border border-slate-300 bg-white px-3 py-2 text-xs text-slate-800">


### PR DESCRIPTION
Closes **M99**, and unblocks unattended Layer 3 work.

## The deadlock

Scenario-page visual baselines flipped on whether mockway happened to be listening on `:8080`. During the Layer 3 canary that became a real deadlock:

- a Layer 3 run needs mockway **up** (Layer 2 gates Layer 3)
- committing needs mockway **down** (the baselines encoded the down state)

I worked around it by hand today — stop mockway, commit, restart. Fragile when attended; a blocker for anything unattended.

## Root cause was layout, not content

The Next Run Mode card rendered **one** grid tile when the run-mode API was unreachable and **three** when it answered, plus a conditional error paragraph. So page height — and a full-page screenshot — depended on backend reachability.

Masking cannot fix this. Masks hide content but don't constrain layout height, exactly as the `ui-baseline-update` Makefile comment already warns.

## Fix

The card now renders the same elements either way: all three tiles always present (showing `unavailable` when unknown), and the error line always rendered. Everything `truncate`d to exactly one line so content length can't change height either; full error text via `title`. Remaining *content* variance is masked, since those values legitimately differ per environment.

## No baseline change needed — and that's the tell

The regenerated PNGs came out byte-identical, which is the right result rather than a surprise: the grid is `md:grid-cols-3`, so 1 tile → 3 tiles fills the same row at the same height, and the always-present error line makes the mockway-**up** rendering match the mockway-**down** baseline that already existed. The fix converged the two states onto one image instead of moving the target.

## Verification

7/7 visual tests pass in all three states:

| state | result |
|---|---|
| mockway down | ✅ 7/7 |
| mockway up, empty | ✅ 7/7 |
| mockway up, with resources | ✅ 7/7 |

And `make test` — the pre-commit gate — now passes end to end **with mockway running**, which is the thing that unblocks unattended Layer 3 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)