### PR TITLE
Unblock dependency PRs: exempt manifest-only changes from the STATUS.md rule

### DIFF
--- a/.github/workflows/doc-hygiene.yml
+++ b/.github/workflows/doc-hygiene.yml
@@ -13,6 +13,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Test the doc-hygiene rules themselves
+        # The dependency carve-out relaxes a rule, so its guard against
+        # being used as a bypass is worth pinning in CI.
+        run: bash scripts/check_doc_hygiene_test.sh
+
       - name: Validate STATUS/ADR sync
         run: |
           bash scripts/check_doc_hygiene.sh \

--- a/STATUS.md
+++ b/STATUS.md
@@ -15,7 +15,9 @@ Deltas in `docs/layer3-real-vs-mock-deltas.md`. Close-out in `docs/status/ARCHIV
 
 Codex review loop now runs on every PR (2 consecutive clean passes to converge; passes recorded in `docs/review-passes/`). Pass 1 on the arc caught one real defect: the `infrafactory reap` recovery hint was not shell-quoted, so a scenario path containing a space produced a command that would not run.
 
-**Next-arc opener**: `lb-paris` as probe canary — the real-probe path is still unexercised against real infrastructure. Costs materially more than the block canary (a load balancer plus its IP), so scope it deliberately.
+**Dependency pipeline unblocked** (2026-08-23). Doc Hygiene required a `STATUS.md` edit for any `go.mod`/`go.sum` change — which dependabot cannot make — so with required status checks on `main`, **every Go dependency PR was permanently unmergeable**; eight had piled up, the oldest three weeks old. Dependency-manifest-only changes are now exempt, all-or-nothing: a PR that bumps `go.mod` *and* touches `internal/` still needs `STATUS.md`. `scripts/check_doc_hygiene_test.sh` pins both halves and runs in CI.
+
+**Next-arc opener**: `lb-paris` as probe canary — but note it currently declares **no probes** (only `region_restriction` + `no_orphans`), so the arc needs probe criteria added to the scenario first; it is not just a run. The five scenarios that do declare probes (`compute-lb-multi-paris`, `mysql-ha-paris`, `redis-xlarge-session-paris`, `web-app-paris`, `gcp-cloud-sql`) are all substantially more expensive. Costs real money either way, so scope it deliberately.
 
 ## Recent arcs
 

--- a/docs/review-passes/pass2.md
+++ b/docs/review-passes/pass2.md
@@ -1,0 +1,20 @@
+# Codex review pass 2 — doc-hygiene dependency carve-out
+
+Base: `main` (390d059). Scope: `scripts/check_doc_hygiene.sh` carve-out,
+its new test, CI wiring.
+
+## Passes
+
+| Pass | Findings | Note |
+|---|---|---|
+| 1 | none | "The dependency-manifest exemption is scoped to manifest-only changes, and the added self-tests exercise both the allowed and rejected cases." |
+| 2 | none | "Cleanly add an all-or-nothing dependency-manifest exemption and pin it with focused shell tests." |
+
+**Converged** — two consecutive clean passes.
+
+## Note
+
+Nothing to triage, which is the expected shape for a small change with its
+own tests. Worth recording anyway: the loop is required on every PR, and a
+converged-with-no-findings record is evidence the loop ran, not evidence it
+was skipped.

--- a/scripts/check_all.sh
+++ b/scripts/check_all.sh
@@ -9,7 +9,8 @@ else
 	go test -tags noui ./...
 fi
 
-echo "[2/3] doc hygiene (--staged)"
+echo "[2/3] doc hygiene (rules test, then --staged)"
+bash scripts/check_doc_hygiene_test.sh
 bash scripts/check_doc_hygiene.sh --staged
 
 echo "[3/3] benchmark guard (env-gated)"

--- a/scripts/check_doc_hygiene.sh
+++ b/scripts/check_doc_hygiene.sh
@@ -94,6 +94,21 @@ any_changed_matching_regex() {
 STATUS_REQUIRED_PREFIXES=("cmd/" "internal/" "prompts/" "policies/" "scenarios/" "testdata/")
 STATUS_REQUIRED_FILES=("go.mod" "go.sum" "scenario.schema.json" "infrafactory.yaml")
 
+# Dependency manifests are exempt from the STATUS.md rule -- but only when
+# they are the ONLY thing that changed.
+#
+# The rule exists so a human records what a code change means. A dependabot
+# bump has no such meaning to record, and dependabot cannot edit STATUS.md,
+# so requiring it made every Go dependency PR permanently red -- and with
+# required status checks on main, permanently unmergeable. Eight of them had
+# piled up, the oldest three weeks old, which is the opposite of the
+# "keep dependencies updated" posture this repo wants.
+#
+# The exemption is deliberately all-or-nothing: a PR that bumps go.mod AND
+# edits internal/ still needs STATUS.md, so a real change cannot smuggle
+# itself in behind a lockfile.
+DEPENDENCY_MANIFESTS=("go.mod" "go.sum" "ui/package.json" "ui/package-lock.json")
+
 DECISION_PREFIXES=("cmd/infrafactory/" "internal/cli/")
 DECISION_FILES=("scenario.schema.json" "infrafactory.yaml" "docs/architecture.md")
 
@@ -122,6 +137,27 @@ if any_changed_in_prefixes "${DECISION_PREFIXES[@]}"; then
       decision_required=true
     fi
   done
+fi
+
+only_dependency_manifests() {
+  for f in "${CHANGED[@]}"; do
+    local matched=false
+    for manifest in "${DEPENDENCY_MANIFESTS[@]}"; do
+      if [[ "${f}" == "${manifest}" ]]; then
+        matched=true
+        break
+      fi
+    done
+    if [[ "${matched}" == "false" ]]; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+if [[ "${status_required}" == "true" ]] && only_dependency_manifests; then
+  echo "Dependency-manifest-only change: STATUS.md not required."
+  status_required=false
 fi
 
 if [[ "${status_required}" == "true" ]] && ! contains_file "STATUS.md"; then

--- a/scripts/check_doc_hygiene_test.sh
+++ b/scripts/check_doc_hygiene_test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Tests for check_doc_hygiene.sh.
+#
+# The dependency carve-out relaxes a rule that exists to keep code changes
+# documented, so it needs a test proving it cannot be used as a bypass: a
+# bump that also touches real code must still be rejected.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/check_doc_hygiene.sh"
+FAILURES=0
+
+# run_case <name> <expected: pass|fail> <file>...
+# Builds a throwaway repo with one baseline commit and one commit touching
+# the named files, then runs the real check across that range.
+run_case() {
+  local name="$1" expected="$2"
+  shift 2
+
+  local dir
+  dir="$(mktemp -d)"
+  (
+    cd "${dir}" || exit 1
+    git init -q .
+    git config user.email t@t.t
+    git config user.name t
+    mkdir -p cmd/infrafactory internal/cli internal/harness docs/decisions ui
+    echo baseline > README.md
+    git add -A && git commit -qm baseline
+    local base
+    base="$(git rev-parse HEAD)"
+
+    for f in "$@"; do
+      mkdir -p "$(dirname "${f}")"
+      echo "change $(date +%s%N)" >> "${f}"
+    done
+    git add -A && git commit -qm change
+    local head
+    head="$(git rev-parse HEAD)"
+
+    bash "${SCRIPT}" "${base}" "${head}" > /dev/null 2>&1
+  )
+  local rc=$?
+  rm -rf "${dir}"
+
+  local actual="pass"
+  [[ ${rc} -ne 0 ]] && actual="fail"
+
+  if [[ "${actual}" == "${expected}" ]]; then
+    echo "  ok    ${name}"
+  else
+    echo "  FAIL  ${name}: expected ${expected}, got ${actual} (exit ${rc})"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "check_doc_hygiene.sh"
+
+# The carve-out itself. Dependabot cannot edit STATUS.md, and a lockfile bump
+# has no meaning to record, so these must not be blocked.
+run_case "go.mod+go.sum only is exempt"            pass go.mod go.sum
+run_case "ui lockfile only is exempt"              pass ui/package.json ui/package-lock.json
+run_case "all manifests together are exempt"       pass go.mod go.sum ui/package.json ui/package-lock.json
+
+# The carve-out must not become a bypass.
+run_case "go.mod + internal code still needs STATUS"     fail go.mod internal/harness/x.go
+run_case "lockfile + internal code still needs STATUS"   fail ui/package-lock.json internal/harness/x.go
+
+# Pre-existing behaviour must be unchanged.
+run_case "internal change without STATUS is rejected"    fail internal/harness/x.go
+run_case "internal change with STATUS is accepted"       pass internal/harness/x.go STATUS.md
+run_case "internal/cli needs an ADR too"                 fail internal/cli/x.go STATUS.md
+# A *new* ADR must also be indexed; amending an existing one need not be.
+run_case "new ADR without README index is rejected"      fail internal/cli/x.go STATUS.md docs/decisions/0001-x.md
+run_case "new ADR with README index is accepted"         pass internal/cli/x.go STATUS.md docs/decisions/0001-x.md docs/decisions/README.md
+run_case "docs-only change is accepted"                  pass docs/whatever.md
+
+if [[ ${FAILURES} -gt 0 ]]; then
+  echo "${FAILURES} case(s) failed."
+  exit 1
+fi
+echo "All doc-hygiene cases passed."


### PR DESCRIPTION
Eight dependabot PRs had piled up across infrafactory and mockway, the oldest three weeks old. This fixes the structural reason for the Go ones.

## The bug is in our own rule

Doc Hygiene lists `go.mod` and `go.sum` in `STATUS_REQUIRED_FILES`, so any dependency bump must come with a `STATUS.md` edit. **Dependabot cannot make one.** With required status checks now on `main`, that made every Go dependency PR permanently red and unmergeable — not "needs attention", but *structurally impossible to merge*. #134 has been failing `check-doc-hygiene` since 2026-08-10 for exactly this reason.

That is the opposite of the "keep dependencies updated" posture the repo wants, and it's self-inflicted.

## The fix, and its limit

The rule itself is right — a human should record what a code change means. A lockfile bump has no such meaning to record, so it's exempt.

The exemption is **all-or-nothing**, which is the part that matters:

- touches only dependency manifests → exempt
- touches `go.mod` **and** `internal/` → still requires `STATUS.md`

So a real change can't smuggle itself in behind a lockfile.

## It relaxes a rule, so it gets a test

`scripts/check_doc_hygiene_test.sh` builds throwaway git repos and runs the real script over 11 cases:

- 3 exempt shapes (go manifests, ui lockfile, all together)
- **2 bypass attempts that must still be rejected**
- 6 pinning pre-existing behaviour that had no test at all until now — including the ADR rules and the new-ADR-needs-README-index rule

Drift-verified: making the carve-out permissive (any manifest rather than all) fails the two bypass cases plus one more. Runs in the Doc Hygiene workflow and in `check_all.sh`.

Worth noting the script had **zero tests** before this, despite gating every PR in the repo.

## Also

Corrects the next-arc opener in `STATUS.md`. `lb-paris` was nominated as the "probe canary", but it declares no probes today — only `region_restriction` and `no_orphans`, exactly like `block-paris`. That arc needs probe criteria added to the scenario first; it isn't just a run.

## Codex loop

Converged in 2 passes, both clean. Recorded in `docs/review-passes/pass2.md`.

## Checks

`scripts/check_all.sh` green; `make test` green. No `package-lock.json` churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YL3XSCQBzwSpqqPWiEgRbG