### PR TITLE
Run Layer 3 as a dedicated IAM application, not the owner key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,12 +178,23 @@ Layer 3 spends real money. It applies to `api.scaleway.com` — first proven end
 
 Self-managed project lifecycle per ADR-0010: generated HCL includes `scaleway_account_project`, so each run creates and destroys its own project. No pre-existing sandbox required, and that project-per-run is what keeps the blast radius to one disposable project.
 
-**User must provide:**
-1. An API key with **project-manager** rights (IAM → API Keys, organization-level). A resource-scoped key 403s on the very first resource.
-2. Env vars: `SCW_ACCESS_KEY`, `SCW_SECRET_KEY`, `SCW_DEFAULT_ORGANIZATION_ID`. The org id is **required** — a project has to be created somewhere — and preflight fails closed without it.
-3. Enable Layer 3: `validation.layers.sandbox_deploy.enabled: true` in `infrafactory.yaml`.
-4. `validation.layers.sandbox_deploy.allow_resource_types` — **deny-by-default**. Empty or absent denies everything. Checked after generation and before apply, so a denied type costs nothing.
-5. `scaleway.fallback_project_id` — a dedicated disposable project. A generated resource that omits `project_id` lands wherever the provider resolves the default, which on a normal account sits next to real infrastructure. Refused if set to the organization id.
+**Credentials — use the dedicated application key, not your own:**
+
+Layer 3 authenticates as the `infrafactory-layer3` IAM **application**, whose key lives in `~/.config/infrafactory/scw-layer3.env` (mode `0600`):
+
+```bash
+set -a; . ~/.config/infrafactory/scw-layer3.env; set +a
+```
+
+Do **not** fall back to the default `scw` profile. On a normal developer machine that is a personal key, and here it was the organization **owner** — full rights over every project, including live infrastructure. S139 strips `SCW_PROFILE`/`SCW_CONFIG_PATH` to stop a profile redirecting the endpoint, which also forces the default profile, so "just use the default profile" silently means "run as whoever that is".
+
+The application's policy grants `ProjectManager` plus only the allowlisted product families. Instances, IAM, registry, serverless and object storage are absent, so a guardrail bug cannot reach `openclaw-prod` — the API refuses first. Widening it is a blast-radius decision; see ADR-0023.
+
+**User must also provide:**
+1. `SCW_DEFAULT_ORGANIZATION_ID` — required, since a project has to be created somewhere. Preflight fails closed without it. (The env file above sets it.)
+2. Enable Layer 3: `validation.layers.sandbox_deploy.enabled: true` in `infrafactory.yaml`.
+3. `validation.layers.sandbox_deploy.allow_resource_types` — **deny-by-default**. Empty or absent denies everything. Checked after generation and before apply, so a denied type costs nothing.
+4. `scaleway.fallback_project_id` — a dedicated disposable project. A generated resource that omits `project_id` lands wherever the provider resolves the default, which on a normal account sits next to real infrastructure. Refused if set to the organization id.
 
 **Operational notes:**
 - The sandbox subprocess environment is *sealed*, not merely overridden (`harness.SandboxStripEnv`). An inherited `SCW_API_URL` cannot retarget a "real" apply at mockway — that false-green was the arc's opening blocker.

--- a/docs/NEXT_SESSION.md
+++ b/docs/NEXT_SESSION.md
@@ -86,7 +86,7 @@ Both carry synthetic-drift coverage. ADR-0023 amended with the reasoning.
 
 ### Setup, if you need to run Layer 3 again
 
-- **Credentials**: `~/.config/scw/config.yaml` default profile. Export `SCW_ACCESS_KEY` / `SCW_SECRET_KEY` / `SCW_DEFAULT_ORGANIZATION_ID` from it — read the **top-level** keys, not the `myProfile:` block, whose `api_url` points elsewhere.
+- **Credentials**: `set -a; . ~/.config/infrafactory/scw-layer3.env; set +a`. This is the dedicated `infrafactory-layer3` IAM application. **Do not use the `scw` default profile** — that is the org owner's `openclaw-terraform` key, which every Layer 3 run used until 2026-08-23 and which can reach live infrastructure. See ADR-0023's credential amendment.
 - **Config**: `/tmp/l3run/infrafactory.yaml` (ephemeral; recreate if gone). Needs `constraint_policies` mapped to **absolute** policy paths or `mock_deploy/state_policy` fails.
 - **mockway must be running** on :8080 built from current main: `go -C ../mockway build -o /tmp/mockway ./cmd/mockway && /tmp/mockway --port 8080 &`
 - Layer 3 artifacts land in `.infrafactory/runs/<scenario>/<run_id>/` (git-ignored) — `plan-live.txt` and `run.json` (`layer3_enabled`) are the ones worth reading.

--- a/docs/decisions/0023-layer3-sealed-environment-and-orphan-verification.md
+++ b/docs/decisions/0023-layer3-sealed-environment-and-orphan-verification.md
@@ -82,4 +82,16 @@ The canary demonstrated it rather than arguing it: `scaleway_account_project` an
 
 Note what did work, on first real use: the failure arrived as `insufficient permissions: read loadbalancer` rather than `exit status 1`, and the retry reported `failed 2 attempts, so not a transient blip`. Both landed the previous day and both paid for themselves here.
 
+**Amendment — the credential is part of the blast radius (2026-08-23).** Rules 3 and 4 bound what a run *does*; nothing bounded what its credential *could* do. Every Layer 3 run so far authenticated as `openclaw-terraform` — an API key belonging to the organization **owner**, with full rights over every project including the one holding live infrastructure. The sealed-environment rule made that inevitable rather than accidental: S139 strips `SCW_PROFILE` and `SCW_CONFIG_PATH` so a developer profile cannot redirect the endpoint, which also forces the *default* profile, and on this machine the default profile is the owner.
+
+So the entire "blast radius is one disposable project" guarantee rested on software: `AssertProjectDeletable`, the sweep, the allowlist. Correct code, but one bug away from reaching real infrastructure, with nothing behind it.
+
+Layer 3 now authenticates as a dedicated IAM **application** (`infrafactory-layer3`), never a user, with a policy granting `ProjectManager` plus only the allowlisted product families (`BlockStorageFullAccess`, `LoadBalancersFullAccess`, `VPCFullAccess`). Instances, IAM, registry, serverless, object storage and billing are all absent, verified by probe: creating an Instance flexible IP, a registry namespace, or an IAM application all return 403, while an LB IP returns 200.
+
+That last point is what makes it defence in depth rather than decoration: `openclaw-prod` and its flexible IP are Instances resources, so a guardrail bug can no longer reach them **at all** — the API refuses before any of our checks run.
+
+Two limits worth stating rather than discovering later. Product permission sets are project-scoped and each run creates its own project, so the rules are organization-scoped to cover projects that do not exist yet; the key can therefore still act on block/LB/VPC resources in *existing* projects. And `scaleway_iam*` and `scaleway_registry_namespace` remain in the default allowlist but will now fail — deliberately, since a sandbox that can mint IAM credentials is not a sandbox.
+
+Widening the policy is a cost-and-blast-radius decision, exactly like widening the allowlist, and belongs in the same review.
+
 **Enforcement**: the guards carry synthetic-drift coverage — removing `SCW_API_URL` from `SandboxStripEnv` fails three tests, verified before S139 merged. Following the project's "drift becomes failed `go test`" pattern.

--- a/docs/decisions/0023-layer3-sealed-environment-and-orphan-verification.md
+++ b/docs/decisions/0023-layer3-sealed-environment-and-orphan-verification.md
@@ -90,8 +90,10 @@ Layer 3 now authenticates as a dedicated IAM **application** (`infrafactory-laye
 
 That last point is what makes it defence in depth rather than decoration: `openclaw-prod` and its flexible IP are Instances resources, so a guardrail bug can no longer reach them **at all** — the API refuses before any of our checks run.
 
-Two limits worth stating rather than discovering later. Product permission sets are project-scoped and each run creates its own project, so the rules are organization-scoped to cover projects that do not exist yet; the key can therefore still act on block/LB/VPC resources in *existing* projects. And `scaleway_iam*` and `scaleway_registry_namespace` remain in the default allowlist but will now fail — deliberately, since a sandbox that can mint IAM credentials is not a sandbox.
+Two limits worth stating rather than discovering later. Product permission sets are project-scoped and each run creates its own project, so the rules are organization-scoped to cover projects that do not exist yet; the key can therefore still act on block/LB/VPC resources in *existing* projects.
 
-Widening the policy is a cost-and-blast-radius decision, exactly like widening the allowlist, and belongs in the same review.
+And three entries in the default `allow_resource_types` are now **allowed locally but refused by the API**: `scaleway_iam*`, `scaleway_registry_namespace`, and `scaleway_domain*`. The first two are obvious — a sandbox that can mint IAM credentials is not a sandbox. Domains are excluded for the same least-privilege reason and a specific one: `DomainsDNSFullAccess` would let a canary modify real DNS, and no scenario in the suite manages domains today. (`dns_resolution` probes only *resolve* names; they need no domain permission.)
+
+A run that generates one of those types will pass the allowlist and then fail at the real API with a 403, which reads like a bug unless you know this. Widening the policy is the fix when a scenario genuinely needs one — and it is a blast-radius decision, exactly like widening the allowlist, belonging in the same review.
 
 **Enforcement**: the guards carry synthetic-drift coverage — removing `SCW_API_URL` from `SandboxStripEnv` fails three tests, verified before S139 merged. Following the project's "drift becomes failed `go test`" pattern.

--- a/docs/review-passes/pass5.md
+++ b/docs/review-passes/pass5.md
@@ -1,0 +1,35 @@
+# Codex review pass 5 — dedicated Layer 3 credential
+
+Base: `main`. Scope: ADR-0023 credential amendment, AGENTS.md and
+NEXT_SESSION.md credential guidance. Documentation-only.
+
+| Pass | Findings | Outcome |
+|---|---|---|
+| 1 | 1 (P2) | accepted |
+| 2 | none | — |
+| 3 | none | **converged** |
+
+## Pass 1 — `scaleway_domain*` left unaccounted for — accepted
+
+The amendment named `scaleway_iam*` and `scaleway_registry_namespace` as
+types the new credential deliberately cannot create, but omitted
+`scaleway_domain*`, which sits in exactly the same position: still in the
+default `allow_resource_types`, not covered by the policy. A run
+generating one would pass the local allowlist and then fail at the real
+API with a 403 that reads like a bug.
+
+A documentation gap with an operational cost, so worth fixing rather than
+waving through.
+
+**Documented rather than granted.** `DomainsDNSFullAccess` would let a
+canary modify real DNS, and nothing in the suite manages domains today —
+`dns_resolution` probes only resolve names, which needs no permission.
+Granting a capability nothing uses, on a key whose entire purpose is
+minimal privilege, would have been the wrong direction.
+
+## Note
+
+Documentation-only changes still go through the loop, and this one earned
+it: the finding was about a mismatch between two documents and a live IAM
+policy, which is exactly the kind of thing that is invisible until someone
+hits the 403 months later.


### PR DESCRIPTION
Every Layer 3 run so far authenticated as **`openclaw-terraform`** — an API key belonging to the organization **owner**, with full rights over every project including the one holding live infrastructure.

You spotted this by asking whether there was a separate key. There is — several, in fact — but infrafactory wasn't using one.

## Why it happened

Not an oversight so much as an emergent consequence. S139 strips `SCW_PROFILE` and `SCW_CONFIG_PATH` so a developer profile can't redirect the endpoint. That also forces the *default* profile — and on this machine the default profile is the owner. "Use the default profile" silently means "run as whoever that is".

So the whole "blast radius is one disposable project" guarantee rested entirely on software: `AssertProjectDeletable`, the orphan sweep, the allowlist. Correct code, but one bug away from real infrastructure with nothing behind it.

## What changed

Layer 3 now authenticates as the `infrafactory-layer3` IAM **application** (never a user), with a policy granting `ProjectManager` plus only the allowlisted product families: `BlockStorageFullAccess`, `LoadBalancersFullAccess`, `VPCFullAccess`. Instances, IAM, registry, serverless, object storage and billing are absent.

The secret lives in `~/.config/infrafactory/scw-layer3.env` (`0600`), outside the repo. **Your owner key and `~/.config/scw/config.yaml` are untouched.**

## Verified, and the first method was wrong

Delete-by-id returns `404` *before* the permission check, so it can't distinguish "denied" from "absent" — proven by IAM returning `403` on create and `404` on delete. Creates *are* permission-checked:

| Probe | Result |
|---|---|
| create Instance flexible IP | **403 denied** |
| create container registry namespace | **403 denied** |
| create IAM application (escalation) | **403 denied** |
| create LB IP | 200 allowed |

Full lifecycle confirmed working: create project → block volume → LB IP → delete all → delete project.

That's what makes it defence in depth rather than decoration. `openclaw-prod` and its flexible IP are Instances resources, so a guardrail bug can no longer reach them **at all** — the API refuses before any of our checks run.

## Two limits, stated rather than left to be discovered

- Product permission sets are project-scoped and each run creates its own project, so the rules are **organization-scoped** to cover projects that don't exist yet. The key can therefore still act on block/LB/VPC resources in existing projects.
- Three default-allowlist entries are now allowed locally but refused by the API: `scaleway_iam*`, `scaleway_registry_namespace`, `scaleway_domain*`. The first two are obvious. Domains are excluded because `DomainsDNSFullAccess` would let a canary modify real DNS and nothing in the suite manages domains — `dns_resolution` probes only resolve names.

## Also corrected

My earlier claim that "the IAM key needs Load Balancer permissions" was wrong — it has them; I created and deleted an LB IP with it. It also wasn't a propagation delay (0.4s in a fresh project). **The cause of that `insufficient permissions: read loadbalancer` failure remains unexplained**, and I'd rather leave it open than offer a third theory.

## Codex loop

Converged in 3 passes; one finding, accepted. Record in `docs/review-passes/pass5.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YL3XSCQBzwSpqqPWiEgRbG