### PR TITLE
docs: cost out Layer 3 expansion per scenario

### DIFF
--- a/docs/layer3-coverage.md
+++ b/docs/layer3-coverage.md
@@ -83,18 +83,35 @@ and the expensive class the allowlist exists to keep out.
 
 ### Two families that are easy to miss
 
-Neither shows up as a headline resource, and both need their own permission set:
+Neither appears in any scenario's `resources:` block, and each needs its own
+permission set:
 
-- **`scaleway_ipam_ip`** → `IPAMFullAccess`. The generator emits it alongside
-  private-network attachments, so any scenario with private networking pulls it
-  in even though nothing in the scenario YAML mentions IPAM.
+- **`scaleway_ipam_ip`** → `IPAMFullAccess`. Emitted by `compute-lb-multi-paris`
+  and `web-app-paris`.
 - **`scaleway_vpc_public_gateway`, `scaleway_vpc_public_gateway_ip`,
   `scaleway_vpc_gateway_network`** → `VPCGatewayFullAccess`, and a public
-  gateway **bills hourly**. Note the allowlist entries are the exact strings
-  `scaleway_vpc` and `scaleway_vpc_private_network`, *not* a `scaleway_vpc*`
-  glob, so the gateway types are already denied locally. That is the allowlist
-  working as intended rather than an oversight — widening it to `scaleway_vpc*`
-  would silently admit an hourly-billed resource.
+  gateway **bills hourly**. Emitted by `web-app-paris` only.
+
+The allowlist entries are the exact strings `scaleway_vpc` and
+`scaleway_vpc_private_network`, *not* a `scaleway_vpc*` glob, so the gateway
+types are already denied locally. That is the allowlist working as intended —
+widening it to a glob would silently admit an hourly-billed resource.
+
+### The types are not stable across runs
+
+Worth internalising before trusting any row here: **10 scenarios declare
+private networking, but only 2 emitted `scaleway_ipam_ip` and only 1 emitted
+gateway resources.** Topologically similar scenarios diverge because the LLM
+writes the HCL — `mysql-ha-paris` and `private-lb-db-paris` both attach servers
+to a private network and neither pulled in IPAM, while `compute-lb-multi-paris`
+did.
+
+So this table is a snapshot of what the generator *has produced*, not a
+guarantee of what it *will* produce. A scenario currently marked runnable could
+emit a new type on its next run and be refused by the allowlist — which is the
+allowlist doing its job, and is why it is deny-by-default rather than a warning.
+Re-run the refresh command after any regeneration rather than trusting a
+months-old row.
 
 **Consequence for `http_probe`.** Proving infrastructure actually *serves*
 traffic rather than merely accepting TCP needs a backend behind the load

--- a/docs/layer3-coverage.md
+++ b/docs/layer3-coverage.md
@@ -1,0 +1,124 @@
+# Layer 3 coverage: which Scaleway scenarios can run against the real API
+
+Audit date: 2026-08-23. Derived from the **actually generated HCL** in
+`.infrafactory/runs/<scenario>/<run_id>/generated/*.tf`, not inferred from
+`mappings.yaml` — every one of the 16 Scaleway scenarios has prior run
+artifacts.
+
+The point of this file is to stop "let's expand Layer 3" being a vague
+ambition. Expansion is a cost-and-blast-radius decision per scenario, and
+this is the costed list.
+
+## The two gates
+
+A scenario reaches the real API only if **both** allow it:
+
+1. **`validation.layers.sandbox_deploy.allow_resource_types`** — deny-by-default,
+   checked after generation and before apply (ADR-0023 rule 5). Repo default:
+   `scaleway_account_project`, `scaleway_block_volume`, `scaleway_block_snapshot`,
+   `scaleway_vpc`, `scaleway_vpc_private_network`, `scaleway_lb*`,
+   `scaleway_domain*`, `scaleway_iam*`, `scaleway_registry_namespace`.
+2. **The `infrafactory-layer3` IAM policy** — `ProjectManager`,
+   `BlockStorageFullAccess`, `LoadBalancersFullAccess`, `VPCFullAccess`.
+   Nothing else (ADR-0023, credential amendment).
+
+They do not agree, deliberately. Three allowlisted families —
+`scaleway_iam*`, `scaleway_registry_namespace`, `scaleway_domain*` — pass the
+local check and are then refused by the API with a 403. That looks like a bug
+if you do not know it; it is the credential doing its job.
+
+## Coverage
+
+| Scenario | Status | Class | Blocked on |
+|---|---|---|---|
+| `block-paris` | **runnable** | instant | — (run 2026-08-22) |
+| `lb-paris` | **runnable** | hourly | — (run 2026-08-23) |
+| `registry-paris` | key only | instant | Registry |
+| `iam-policies-paris` | key only | instant | IAM |
+| `public-registry-iam-paris` | key only | instant | IAM + Registry |
+| `domain-paris` | key only | instant | DomainsDNS **+ a registered domain** |
+| `compute-lb-multi-paris` | allowlist + key | hourly | Instances, IPAM |
+| `incremental-project-paris` | allowlist + key | hourly | Instances |
+| `k8s-cluster-paris` | allowlist + key | slow + expensive | Kubernetes |
+| `k8s-medium-override-paris` | allowlist + key | slow + expensive | Kubernetes |
+| `mysql-ha-paris` | allowlist + key | slow + expensive | Instances + RDB |
+| `private-lb-db-paris` | allowlist + key | slow + expensive | Instances + RDB |
+| `redis-paris` | allowlist + key | slow + expensive | Redis |
+| `redis-xlarge-session-paris` | allowlist + key | slow + expensive | Instances + Redis |
+| `web-app-paris` | allowlist + key | slow + expensive | Instances, RDB, DomainsDNS, IPAM, VPCGateway |
+| `full-stack-paris` | allowlist + key | slow + expensive | IAM, Instances, K8s, RDB, Redis, Registry |
+
+**2 runnable, 4 blocked by the key alone, 10 blocked by both.**
+
+Class is provisioning cost, not money: *instant* is seconds and negligible
+(project, block volume, VPC, registry namespace); *hourly* bills for as long as
+it exists (load balancer, instance); *slow + expensive* takes minutes to
+provision and destroy and costs materially more (RDB, Redis, k8s). No euro
+figures here on purpose — ADR-0010 deferred cost estimation because there is no
+reliable Scaleway pricing source to code against, and inventing numbers would
+be worse than none.
+
+## The finding: the cheap end of the pool is empty
+
+The two runnable scenarios are the two already run. There is no free
+expansion, and three of the four "key only" entries are not the easy wins they
+look like:
+
+- **`domain-paris` is not a permission problem.** The account holds no
+  registered public domain — only the auto-created `privatedns` zone for
+  private networks. `scaleway_domain_zone` needs a real one, so this is a
+  purchase, not a policy line.
+- **`iam-policies-paris` and `public-registry-iam-paris` should stay
+  blocked.** Granting IAM to the sandbox credential defeats the credential:
+  a sandbox that can mint API keys is not a sandbox. Keep them as Layer 2
+  scenarios.
+- **`registry-paris` is the only defensible near-free expansion** — one
+  permission set, instant provisioning. Note it still widens org-scoped
+  registry access over the existing `funcscwblognolj7nc9` namespace, because
+  product permission sets are project-scoped and per-run projects do not exist
+  yet, so the rules must be organization-scoped.
+
+Everything else needs Instances, RDB, Redis or Kubernetes — both gates widened,
+and the expensive class the allowlist exists to keep out.
+
+### Two families that are easy to miss
+
+Neither shows up as a headline resource, and both need their own permission set:
+
+- **`scaleway_ipam_ip`** → `IPAMFullAccess`. The generator emits it alongside
+  private-network attachments, so any scenario with private networking pulls it
+  in even though nothing in the scenario YAML mentions IPAM.
+- **`scaleway_vpc_public_gateway`, `scaleway_vpc_public_gateway_ip`,
+  `scaleway_vpc_gateway_network`** → `VPCGatewayFullAccess`, and a public
+  gateway **bills hourly**. Note the allowlist entries are the exact strings
+  `scaleway_vpc` and `scaleway_vpc_private_network`, *not* a `scaleway_vpc*`
+  glob, so the gateway types are already denied locally. That is the allowlist
+  working as intended rather than an oversight — widening it to `scaleway_vpc*`
+  would silently admit an hourly-billed resource.
+
+**Consequence for `http_probe`.** Proving infrastructure actually *serves*
+traffic rather than merely accepting TCP needs a backend behind the load
+balancer, so `scaleway_instance_server`, so Instances on both gates. It is not
+a tidy-up; it sits in the same bucket as everything else here.
+
+## Caveat on the data
+
+14 of the 16 artifacts date from 2026-06-07, before ADR-0010's
+`scaleway_account_project` requirement was enforced — only `block-paris` and
+`lb-paris` contain one. Regenerating those scenarios for Layer 3 would add a
+project resource, which is both allowlisted and permitted, so no classification
+changes. Their other resource types are what the generator actually produced
+and are the basis of this table.
+
+## Refreshing this
+
+```bash
+# resource types per scenario, from real generated HCL
+for s in $(grep -l 'cloud: scaleway' scenarios/training/*.yaml | xargs -n1 basename | sed 's/.yaml//'); do
+  echo "$s: $(grep -ho 'resource "[a-z0-9_]*"' .infrafactory/runs/$s/*/generated/*.tf 2>/dev/null \
+    | sort -u | tr '\n' ' ')"
+done
+```
+
+Re-run it after any change to the allowlist, the IAM policy, or a scenario's
+`resources:` block.

--- a/docs/layer3-coverage.md
+++ b/docs/layer3-coverage.md
@@ -130,10 +130,18 @@ and are the basis of this table.
 ## Refreshing this
 
 ```bash
-# resource types per scenario, from real generated HCL
+# Resource types per scenario, from real generated HCL.
+# Scans BOTH the final snapshot and per-iteration snapshots: a scenario that
+# converged on iteration 3 still generated -- and would have applied -- the
+# types from iterations 1 and 2. compute-lb-multi-paris emits
+# scaleway_ipam_ip only in an iteration snapshot, and web-app-paris does the
+# same for its VPC gateway resources, so scanning only generated/*.tf drops
+# real blockers.
 for s in $(grep -l 'cloud: scaleway' scenarios/training/*.yaml | xargs -n1 basename | sed 's/.yaml//'); do
-  echo "$s: $(grep -ho 'resource "[a-z0-9_]*"' .infrafactory/runs/$s/*/generated/*.tf 2>/dev/null \
-    | sort -u | tr '\n' ' ')"
+  echo "$s: $(grep -ho 'resource "[a-z0-9_]*"' \
+    .infrafactory/runs/$s/*/generated/*.tf \
+    .infrafactory/runs/$s/*/iterations/*/generated/*.tf 2>/dev/null \
+    | sed 's/resource "//;s/"//' | sort -u | tr '\n' ' ')"
 done
 ```
 

--- a/docs/review-passes/pass6.md
+++ b/docs/review-passes/pass6.md
@@ -1,0 +1,53 @@
+# Codex review pass 6 — docs/layer3-coverage.md
+
+Documentation-only. 5 passes, 3 findings, all accepted — unusually
+productive for a doc, because the doc makes factual claims that drive
+real-money decisions.
+
+| Pass | Findings | Outcome |
+|---|---|---|
+| 1 | 1 (P2) | accepted in part, refuted in part |
+| 2 | 1 (P2) | accepted |
+| 3 | 1 (P2, same issue) | accepted |
+| 4 | none | — |
+| 5 | none | **converged** |
+
+## Pass 1 — half right, and the half that was right mattered
+
+Codex claimed `scaleway_ipam_ip` and the VPC gateway types did not appear
+in the artifacts at all. **Refuted**: `ipam_ip` is emitted by
+`compute-lb-multi-paris` and `web-app-paris`, the gateway trio by
+`web-app-paris`. The table was accurate.
+
+**But the prose was overstated**, and that part was correct: it said "any
+scenario with private networking pulls it in", when 10 scenarios declare
+private networking and only 2 emit IPAM.
+
+Checking it surfaced something worth more than the correction: because the
+LLM writes the HCL, topologically similar scenarios diverge.
+`mysql-ha-paris` and `private-lb-db-paris` both attach servers to a private
+network and pulled in no IPAM; `compute-lb-multi-paris` did. The table is a
+snapshot of what the generator *has* produced, not a guarantee of what it
+*will*. Now stated in the doc.
+
+## Passes 2 and 3 — the refresh command contradicted its own table
+
+Same finding twice. The documented refresh scanned only each run's final
+`generated/*.tf`, while the table came from that plus
+`iterations/*/generated/*.tf` — so following the procedure would silently
+drop real blockers, including the two IPAM/gateway rows above.
+
+A document whose refresh contradicts its own table is worse than no
+document: the next reader trusts the command over the prose.
+
+Scanning iteration snapshots is also the correct semantics rather than a
+reproducibility patch. A scenario that converged on iteration 3 still
+generated the types from iterations 1 and 2, and Layer 3 would have
+attempted to apply them. The gates must cover what the generator might emit
+*on the way to* converging, not only what it landed on.
+
+## Note
+
+Three findings on a document with no executable code. Worth remembering
+before treating docs-only PRs as loop-exempt — this one asserted facts
+about which real cloud permissions to widen.


### PR DESCRIPTION
"Let's expand Layer 3" has been a vague ambition since the arc closed. This costs it out per scenario, from the **actually generated HCL** in `.infrafactory/runs` rather than inferred from `mappings.yaml` — all 16 Scaleway scenarios have prior run artifacts.

## The finding argues against expanding

**2 of 16 are runnable, and they're the two already run.** The cheap end of the pool is empty.

Three of the four scenarios blocked by the credential alone are not the easy wins they look like:

- **`domain-paris` isn't a permission problem.** The account holds no registered public domain — only the auto-created `privatedns` zone — so `scaleway_domain_zone` needs a purchase.
- **`iam-policies-paris` / `public-registry-iam-paris` should stay blocked.** Granting IAM to the sandbox credential defeats the credential.
- **`registry-paris` is the only defensible near-free expansion**, and it still widens org-scoped registry access over the existing blog namespace.

Everything else needs Instances, RDB, Redis or Kubernetes — both gates widened, and the expensive class the allowlist exists to keep out. That includes the `http_probe` upgrade.

## Two families that are easy to miss

`scaleway_ipam_ip` (IPAMFullAccess) and the `vpc_public_gateway` trio (VPCGatewayFullAccess, **bills hourly**). Neither appears in any scenario's `resources:` block. The allowlist lists `scaleway_vpc` exactly rather than a `scaleway_vpc*` glob, so the gateway types are already denied — worth knowing before someone "tidies" that into a glob.

## Generator instability, recorded

10 scenarios declare private networking; only 2 emitted IPAM. Topologically similar scenarios diverge because the LLM writes the HCL. The table is a snapshot of what the generator *has* produced, not a guarantee — so a currently-runnable scenario can emit a new type next run and be refused. That's the allowlist working.

## Codex loop: 5 passes, 3 findings

Unusually productive for a docs-only PR. Pass 1 was **half right** — it claimed the IPAM/gateway types don't appear (refuted; they do), but correctly caught that my prose generalised them to all private-network scenarios. Passes 2 and 3 caught that the documented refresh command scanned only final snapshots while the table used iteration snapshots too — so following the procedure would silently drop blockers. Fixed, and it's the correct semantics anyway: Layer 3 would have applied the types from non-final iterations.

Record in `docs/review-passes/pass6.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YL3XSCQBzwSpqqPWiEgRbG