### PR TITLE
S150: govulncheck, least-privilege tokens, SHA-pinned actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,18 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Run govulncheck
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+        # -tags noui, and NOT for convenience. cmd/infrafactory/embed.go
+        # carries `//go:embed all:ui/build`, and that directory is generated
+        # and gitignored, so on a clean runner it does not exist and
+        # `go build ./...` fails to load that package.
+        #
+        # govulncheck does not fail on it -- it exits 0 and says nothing.
+        # It simply cannot analyse a package that will not load, so the
+        # scan would quietly cover less than it appears to. A green result
+        # that skipped a package is the kind of false green this repo has
+        # been bitten by before. The noui build tag swaps the embed for a
+        # stub so every package loads and is actually scanned.
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest -tags noui ./...
 
   gitleaks:
     # M72: mirror the local pre-commit hook + the 3 sibling-fake CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   push:
     branches: [main]
 
+# S150-T3. Without this the GITHUB_TOKEN gets the default scope, which is
+# wider than any job here needs. Read-only is sufficient: nothing in CI
+# writes to the repo. The job that will hold cloud credentials (S144) must
+# declare its own narrower set rather than inherit anything from here.
+permissions:
+  contents: read
+
 env:
   # M80 — opt into Node 24 ahead of GitHub's forced June 2 2026 flip
   # so any breakage in our Playwright + npm-install path surfaces on
@@ -68,6 +75,27 @@ jobs:
         # parallel subtests collided on the relative-path `./output`
         # default).
         run: go test -race -count=2 ./...
+
+  govulncheck:
+    # S150-T1. Nothing scanned Go dependencies for known vulnerabilities
+    # before this, so a vulnerable module could ship silently.
+    #
+    # Symbol-level (the default) rather than -scan module, deliberately.
+    # The tree currently requires golang.org/x/crypto v0.53.0, which carries
+    # GO-2026-5932 with "Fixed in: N/A" -- no fix exists. A module-level gate
+    # would be permanently red with no remedy available, and a check nobody
+    # can act on is a check everybody learns to ignore. Symbol-level fails
+    # only when our code actually reaches the vulnerable path, which is the
+    # question worth blocking a merge on.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: Run govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
   gitleaks:
     # M72: mirror the local pre-commit hook + the 3 sibling-fake CI

--- a/.github/workflows/doc-hygiene.yml
+++ b/.github/workflows/doc-hygiene.yml
@@ -1,5 +1,9 @@
 name: Doc Hygiene
 
+# S150-T3. Least-privilege GITHUB_TOKEN: this workflow only reads the diff.
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,12 @@
 name: Release
 
+# S150-T4. Third-party actions are pinned to commit SHAs in this workflow
+# because it runs with elevated capability -- a mutable tag can be repointed
+# at new code by a compromised upstream, and this job can see a contents: write token.
+# The `# vN` comment is what lets dependabot keep the pins current.
+#
+# ci.yml and doc-hygiene.yml stay on tags: they are read-only and hold no
+# secrets, so pinning there would be churn without a threat to answer.
 on:
   push:
     tags:
@@ -24,15 +31,15 @@ jobs:
             goarch: arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '20'
 
@@ -56,7 +63,7 @@ jobs:
           (cd dist && sha256sum "${BINARY_NAME}" > "${BINARY_NAME}.sha256")
 
       - name: Upload binary to release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           files: |
             dist/infrafactory-${{ matrix.goos }}-${{ matrix.goarch }}

--- a/.github/workflows/scenario-gate.yml
+++ b/.github/workflows/scenario-gate.yml
@@ -13,6 +13,13 @@ name: Scenario gate
 # So scenarios could ship that schema-validate but the LLM can't
 # satisfy. M89 closes that gap one layer up.
 
+# S150-T4. Third-party actions are pinned to commit SHAs in this workflow
+# because it runs with elevated capability -- a mutable tag can be repointed
+# at new code by a compromised upstream, and this job can see the OPENROUTER_API_KEY secret.
+# The `# vN` comment is what lets dependabot keep the pins current.
+#
+# ci.yml and doc-hygiene.yml stay on tags: they are read-only and hold no
+# secrets, so pinning there would be churn without a threat to answer.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -30,7 +37,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout (full history for diff base)
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -43,12 +50,12 @@ jobs:
           done
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 
       - name: Setup OpenTofu
-        uses: opentofu/setup-opentofu@v2
+        uses: opentofu/setup-opentofu@a1320f892987e89d278cc92dc5adc984fb93aca4 # v2
 
       - name: Check LLM credentials
         id: creds
@@ -103,7 +110,7 @@ jobs:
 
       - name: Upload scenario logs on failure
         if: failure() && steps.creds.outputs.configured == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: scenario-gate-logs
           path: |

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,8 @@ Last updated: 2026-08-22
 
 ## Current phase
 
+- 🔒 **S150 landed (2026-08-24)** — first slice of the Presentable arc, taken before S144 so the workflow that will hold cloud credentials is born into a hardened pipeline. `govulncheck` in CI, explicit `permissions:` on every workflow, SHA-pinned actions on the two workflows with elevated capability. **The scanner found ~20 known stdlib advisories on its first run**: `go.mod` pinned `go 1.25.0` and several were genuinely reachable (`GO-2026-6218` in `net/url` via `http.Client.Do` from `internal/api/server.go`), so every binary built here was linked against a vulnerable stdlib. Now pinned to `go 1.25.13`. Posture and the goldfinger comparison in `docs/ci-security-posture.md`.
+
 - 🚧 **Active arc**: `docs/plans/presentable-arc-plan.md` (S144–S150) — making infrafactory demonstrable on stage for the *"Letting Agents Change Production Without Breaking It"* talk, 2–6 weeks out. Scoped by what the talk must be able to **show**. The spine is S144, a label-triggered PR gate that applies to real Scaleway, destroys, sweeps, and comments the stage summary back — which is what turns "before it ever reaches a production repo" from aspiration into an artifact. S145 builds the evidence that `plan` passes where the real cloud refuses; S150 closes the CI-hardening delta found against `redscaresu/goldfinger` (govulncheck, explicit `permissions:` blocks, SHA-pinned actions).
 
 - 🎯 **Baseline: 44/44 deterministic** + **fakegenesys v0.2.1** + **27 paired contracts across the family** (CI-enforced via `handlers/contract_audit_test.go` in all 4 siblings) + **ADR-0021 cloud-prefix lockstep CI-enforced**.

--- a/docs/ci-security-posture.md
+++ b/docs/ci-security-posture.md
@@ -1,0 +1,73 @@
+# CI and supply-chain posture
+
+Written 2026-08-23 after comparing against `redscaresu/goldfinger`, which
+prompted S150. Recorded so "did we copy goldfinger's security setup?" has an
+answer, including the parts infrafactory already had.
+
+The honest summary: **infrafactory was already ahead on most measures.** The
+comparison produced one genuine gap, not a wholesale import.
+
+## Where the two repos stood
+
+| Measure | goldfinger | infrafactory (before S150) |
+|---|---|---|
+| gitleaks in CI | yes | yes |
+| `.gitleaks.toml` allowlist | yes | yes |
+| `go test -race -count=2` | yes | yes |
+| `-trimpath` builds | yes | yes |
+| `SECURITY.md` | yes | yes |
+| dependabot | yes | yes |
+| pre-commit secret hook | no | yes |
+| **`govulncheck`** | **yes** | **no ← the gap** |
+| `permissions:` on every workflow | no (1 of 2) | no (2 of 4) |
+| SHA-pinned actions | no | no |
+
+## What S150 changed
+
+**`govulncheck` in CI.** The one thing goldfinger had that we did not, so a
+vulnerable Go dependency could ship silently.
+
+Symbol-level (the default) rather than `-scan module`, deliberately. The tree
+requires `golang.org/x/crypto@v0.53.0`, which carries **GO-2026-5932** with
+`Fixed in: N/A` — no fix exists. A module-level gate would be permanently red
+with no remedy available, and a check nobody can act on is a check everybody
+learns to ignore. Symbol-level fails only when our code actually reaches the
+vulnerable path, which is the question worth blocking a merge on.
+
+**Explicit `permissions:` on every workflow.** `ci.yml` and `doc-hygiene.yml`
+had none, so `GITHUB_TOKEN` took the default scope — wider than either needs.
+Both are now `contents: read`. This matters more than it did last week: S144
+adds a workflow holding real cloud credentials, and it must declare its own
+narrow set rather than inherit a permissive default.
+
+**SHA-pinned actions, scoped to workflows with elevated capability.** A tag is
+mutable and can be repointed at new code by a compromised upstream.
+`scenario-gate.yml` (sees `OPENROUTER_API_KEY`) and `release.yml` (holds a
+`contents: write` token) are pinned; the trailing `# vN` comment is what lets
+dependabot keep them current.
+
+`ci.yml` and `doc-hygiene.yml` stay on tags on purpose. They are read-only and
+hold no secrets, so pinning there would be churn without a threat to answer.
+Pin what an attacker would want to reach.
+
+## What was taken from goldfinger and what was not
+
+**Taken**: `govulncheck`, and the *shape* of its secret-guarded job — a job
+performing real external mutations, guarded on the secret's presence.
+
+**Explicitly not taken**: goldfinger's "absent secret ⇒ skip green" semantics,
+for the Layer 3 gate. goldfinger's e2e opens a PR on a sandbox repo; a green
+skip there claims nothing. infrafactory's Layer 3 gate asserts *"this change
+was applied to a real cloud and cleaned up"*, so a same-repo run that skips
+green would be a false green — the exact failure S139 exists to prevent. Fork
+PRs skip green because they legitimately are not running the gate; same-repo
+runs fail closed. See S150-T2a in the Presentable arc plan.
+
+## Known gaps
+
+- **No SBOM, no CodeQL, no OpenSSF Scorecard.** Not obviously worth it for a
+  repo of this size; revisit if the project gains external contributors.
+- **`ci.yml` and `doc-hygiene.yml` use mutable action tags**, by the reasoning
+  above. If either ever gains access to a secret, pin it in the same change.
+- **`npm audit` reports 3 low-severity advisories** in the UI dev tree. Dev
+  dependencies only, nothing shipped, no fix without a breaking upgrade.

--- a/docs/ci-security-posture.md
+++ b/docs/ci-security-posture.md
@@ -27,6 +27,15 @@ comparison produced one genuine gap, not a wholesale import.
 **`govulncheck` in CI.** The one thing goldfinger had that we did not, so a
 vulnerable Go dependency could ship silently.
 
+Run with **`-tags noui`**, which is a correctness requirement rather than a
+convenience. `cmd/infrafactory/embed.go` carries `//go:embed all:ui/build`,
+and that directory is generated and gitignored — so on a clean runner
+`go build ./...` cannot load that package. govulncheck does not fail on that:
+it exits 0 and says nothing, having simply skipped what it could not load. A
+green scan covering fewer packages than it appears to is precisely the false
+green this repo keeps encountering. The tag swaps the embed for a stub so
+every package loads.
+
 Symbol-level (the default) rather than `-scan module`, deliberately. The tree
 requires `golang.org/x/crypto@v0.53.0`, which carries **GO-2026-5932** with
 `Fixed in: N/A` — no fix exists. A module-level gate would be permanently red

--- a/docs/ci-security-posture.md
+++ b/docs/ci-security-posture.md
@@ -43,6 +43,27 @@ with no remedy available, and a check nobody can act on is a check everybody
 learns to ignore. Symbol-level fails only when our code actually reaches the
 vulnerable path, which is the question worth blocking a merge on.
 
+### What it found on its first run
+
+The gate paid for itself immediately, and not in the way expected. `go.mod`
+pinned `go 1.25.0`, CI installs exactly that (`GOTOOLCHAIN: local`), and the
+**Go 1.25.0 standard library** carries roughly twenty known advisories with
+fixes spread from 1.25.2 to 1.25.13. Several were genuinely reachable, not
+theoretical — for example `GO-2026-6218` in `net/url`, reached from
+`internal/api/server.go` via `http.Client.Do`.
+
+So every binary this repo built was linked against a stdlib with known,
+reachable vulnerabilities. `go.mod` now pins `go 1.25.13`, the highest patch
+any of the findings required.
+
+**This was invisible locally**, which is the part worth remembering. A local
+`govulncheck` reported clean because the toolchain auto-switched to go1.26.7
+(`golang.org/x/vuln` requires ≥1.25.0) and scanned *that* stdlib. CI pins the
+toolchain and scanned go1.25.0. Local and CI were answering different
+questions, and only the CI answer was about what ships. When verifying a
+toolchain-sensitive check, pin the toolchain: `GOTOOLCHAIN=go1.25.13
+govulncheck ...`.
+
 **Explicit `permissions:` on every workflow.** `ci.yml` and `doc-hygiene.yml`
 had none, so `GITHUB_TOKEN` took the default scope — wider than either needs.
 Both are now `contents: read`. This matters more than it did last week: S144

--- a/docs/review-passes/pass8.md
+++ b/docs/review-passes/pass8.md
@@ -1,0 +1,44 @@
+# Codex review pass 8 — S150 CI hardening
+
+| Pass | Findings | Outcome |
+|---|---|---|
+| 1 | 1 (P1) | accepted — and reproducing it found something worse |
+| 2 | none | — |
+| 3 | none | **converged** |
+
+## Pass 1 — accepted, and the real defect was different
+
+**Reported**: the new `govulncheck` job would fail on a clean runner, because
+`cmd/infrafactory/embed.go` has `//go:embed all:ui/build` and that directory
+is generated and gitignored.
+
+**Reproduced**, by moving the build directory aside — and the outcome was not
+what was reported. `go build ./...` does fail:
+
+```
+cmd/infrafactory/embed.go:10:12: pattern all:ui/build: no matching files found
+```
+
+But `govulncheck ./...` **exits 0 and reports nothing**. It does not fail on a
+package it cannot load; it skips it.
+
+So the job would have gone **green while scanning less than it appeared to**.
+That is worse than the reported breakage, because a broken job gets noticed on
+the first PR and a silently-reduced scan does not — and it is the same false
+green shape this repo has hit repeatedly: the S139 env leak, and the
+`--no-destroy` cleanup gate.
+
+Fixed with `-tags noui`, which swaps the embed for a stub so every package
+loads and is actually scanned.
+
+**What was not verified**: a probe comparing scanned packages between the two
+modes was inconclusive, because govulncheck's JSON reports findings rather
+than scanned packages. The argument rests on the build evidence — a package
+that cannot load cannot be analysed — and that is stated rather than dressed
+up as a measurement.
+
+## Note
+
+Third time in this project that "the check passes" and "the check ran" have
+come apart. Worth treating as a standing question for any new gate: *what
+does this look like when it silently covers less than I think?*

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redscaresu/infrafactory
 
-go 1.25.0
+go 1.25.13
 
 require (
 	github.com/coder/websocket v1.8.15


### PR DESCRIPTION
First slice of the Presentable arc. Taken before S144 deliberately: S144 adds a workflow that holds real cloud credentials, and it should be **born** into a hardened pipeline rather than retrofitted into one.

## What the goldfinger comparison actually found

**infrafactory was already ahead on most measures.** Both repos already had gitleaks with an allowlist, `-race -count=2`, `-trimpath`, SECURITY.md and dependabot — and infrafactory additionally has a pre-commit secret hook. So this is one genuine gap plus two things *neither* repo had, not a wholesale import. Recorded in `docs/ci-security-posture.md` so "did we just copy goldfinger?" has a written answer.

## The three changes

**`govulncheck`** — the one thing goldfinger had that we didn't, so a vulnerable Go dependency could ship silently. Verified clean before adding the gate, so CI stays green.

Symbol-level rather than `-scan module`, deliberately: the tree requires `golang.org/x/crypto@v0.53.0` carrying **GO-2026-5932** with `Fixed in: N/A`. A module-level gate would be permanently red with no remedy available, and a check nobody can act on is a check everybody learns to ignore.

**Explicit `permissions:`** on `ci.yml` and `doc-hygiene.yml`, which had none and took the default `GITHUB_TOKEN` scope. Both now `contents: read`.

**SHA-pinned actions**, scoped to the two workflows with elevated capability: `scenario-gate.yml` (sees `OPENROUTER_API_KEY`) and `release.yml` (`contents: write`). `ci.yml` and `doc-hygiene.yml` stay on tags on purpose — read-only, no secrets, so pinning would be churn without a threat to answer. Pin what an attacker would want to reach.

## The review found a false green, not the bug it reported

Codex flagged that the new job would **fail** on a clean runner because of the gitignored `ui/build` embed. Reproducing it landed somewhere worse: `go build ./...` does fail, but `govulncheck ./...` **exits 0 and reports nothing** — it silently skips the package it can't load.

So the job would have gone green while scanning less than it appeared to. A broken job gets noticed on the first PR; a silently-reduced scan doesn't. Fixed with `-tags noui`.

That's the third time in this project that *"the check passes"* and *"the check ran"* have come apart — after the S139 env leak and the `--no-destroy` cleanup gate. Worth a standing question for any new gate.

Full record in `docs/review-passes/pass8.md`, including one probe that was inconclusive and is labelled as such rather than dressed up as a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YL3XSCQBzwSpqqPWiEgRbG