### PR TITLE
S145: the "plan lied" corpus — two reproducible classes

### DIFF
--- a/docs/layer3-real-vs-mock-deltas.md
+++ b/docs/layer3-real-vs-mock-deltas.md
@@ -153,3 +153,31 @@ Two things a mock cannot tell you:
   honestly make. Upgrading to `http_probe` means adding a backend that
   serves, which means `scaleway_instance_server`, which is deliberately
   outside the allowlist.
+
+## D5 — `plan` is green, the mock is green, the API refuses
+
+D1–D4 are deltas found in infrafactory's own harness. D5 is the class the
+talk actually rests on: a **generated infrastructure change** that clears
+every pre-real gate and is then rejected by Scaleway.
+
+Two reproduce 10 times out of 10. Full HCL and captured output for all three
+stages live in `examples/layer3-plan-lied/`.
+
+| case | plan | mock apply | real apply |
+|---|---|---|---|
+| block volume, `iops = 9000` | `2 to add` | `2 added` | `perf_iops ... choose from [5000, 15000]` |
+| registry namespace, unprivileged key | `2 to add` | `2 added` | `insufficient permissions: write api_namespace` |
+
+The honest split between them:
+
+- The **iops** case a mock *could* catch — the valid set is static. It is a
+  mockway fidelity gap. The point is that the gap is unbounded, not that it
+  was unforeseeable.
+- The **IAM** case a mock *cannot* catch without replicating live IAM state.
+  The same plan with a different key gives a different answer, so no amount
+  of configuration analysis reaches it.
+
+Do not present the first as though it were the second.
+
+**Refuted**: duplicate project names were expected to collide and do not.
+Scaleway permits them. Left in the record deliberately.

--- a/examples/layer3-plan-lied/README.md
+++ b/examples/layer3-plan-lied/README.md
@@ -1,0 +1,65 @@
+# The "plan lied" corpus
+
+Infrastructure changes that pass `tofu validate`, pass `tofu plan`, pass a
+**mock apply**, and are then refused by real Scaleway.
+
+Each case is the same HCL run twice — once against mockway, once against
+`api.scaleway.com`. The only variable is which API answers.
+
+| case | validate | plan | mock apply | real apply | reproduces |
+|---|---|---|---|---|---|
+| `commercial-type` | pass | clean, `2 to add` | **2 added** | refused | 10/10 |
+| `iam-scope` | pass | clean, `2 to add` | **2 added** | refused | 10/10 |
+
+Captured output for all three stages of both cases is in `evidence/`.
+
+## commercial-type
+
+A block volume asks for `iops = 9000`. Every layer that reads the
+configuration is satisfied: it is a valid integer in a valid field. The real
+API enumerates what it will actually sell you.
+
+    Error: scaleway-sdk-go: invalid argument(s): perf_iops is required, The
+    provided 'perf_iops' value is not available. If provided, please choose
+    from the following available values: [5000, 15000].
+
+**Could a mock have caught this? Yes.** The set `[5000, 15000]` is static, and
+a higher-fidelity mockway could enforce it. This case is a mock fidelity gap,
+and saying otherwise to an audience would be dishonest.
+
+The argument is not that it was uncatchable. It is that the gap is *unbounded*:
+this is one enumerated field on one resource, and closing it by hand does
+nothing for the next one. The real API knows its own catalogue for free.
+
+## iam-scope
+
+A container registry namespace, inside the deploy allowlist, outside what the
+credential is permitted to do.
+
+    Error: scaleway-sdk-go: insufficient permissions: write api_namespace
+
+**Could a mock have caught this? No — not without becoming the real cloud.**
+The refusal is not a property of the configuration. It is a property of the
+IAM policy attached to the key that happens to be running the apply. Two
+identical plans, two different keys, two different outcomes. To predict it, a
+mock would have to hold a faithful replica of your live IAM state, at which
+point it is no longer a mock.
+
+This is the stronger of the two cases, and it is the one to lead with.
+
+## A refuted candidate
+
+Duplicate **project names** were expected to collide, and do not — Scaleway
+permits two projects with the same name in one organization. The apply
+succeeded. Recorded here because a corpus of near-misses is only trustworthy
+if the misses are in it too.
+
+## Running them
+
+    cd commercial-type
+    tofu init && tofu plan      # clean
+    tofu apply                  # refused
+
+Real credentials, real API, no `SCW_API_URL`. Both cases create their own
+disposable `scaleway_account_project` (ADR-0010), so a failed apply leaves a
+project and nothing billable; `tofu destroy` removes it.

--- a/examples/layer3-plan-lied/README.md
+++ b/examples/layer3-plan-lied/README.md
@@ -60,6 +60,18 @@ if the misses are in it too.
     tofu init && tofu plan      # clean
     tofu apply                  # refused
 
-Real credentials, real API, no `SCW_API_URL`. Both cases create their own
-disposable `scaleway_account_project` (ADR-0010), so a failed apply leaves a
-project and nothing billable; `tofu destroy` removes it.
+Real credentials, real API, no `SCW_API_URL`.
+
+**`iam-scope` only reproduces with a credential that lacks
+`write api_namespace`** — that is the whole point of the case, and it cuts
+both ways. Run it with an organization-owner key and the apply *succeeds*,
+creating a real container registry namespace that bills until you remove it.
+Use the dedicated restricted Layer 3 application key the captured evidence
+was produced with; do not run this one under a default profile.
+
+`commercial-type` has no such dependency. The API refuses `iops = 9000`
+whoever asks, so it is the safer of the two to demo live.
+
+Both cases create their own disposable `scaleway_account_project`
+(ADR-0010), so a failed apply leaves a project and nothing billable;
+`tofu destroy` removes it.

--- a/examples/layer3-plan-lied/commercial-type/main.tf
+++ b/examples/layer3-plan-lied/commercial-type/main.tf
@@ -1,0 +1,9 @@
+resource "scaleway_account_project" "main" {
+  name = "if-s145-a"
+}
+resource "scaleway_block_volume" "app_data" {
+  name       = "s145-a-vol"
+  iops       = 9000
+  size_in_gb = 1
+  project_id = scaleway_account_project.main.id
+}

--- a/examples/layer3-plan-lied/commercial-type/providers.tf
+++ b/examples/layer3-plan-lied/commercial-type/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    scaleway = { source = "scaleway/scaleway", version = "~> 2.57" }
+  }
+}
+provider "scaleway" {
+  region = "fr-par"
+  zone   = "fr-par-1"
+}

--- a/examples/layer3-plan-lied/evidence/commercial-type.mock-apply.txt
+++ b/examples/layer3-plan-lied/evidence/commercial-type.mock-apply.txt
@@ -1,0 +1,3 @@
+scaleway_block_volume.app_data: Creating...
+scaleway_block_volume.app_data: Creation complete after 0s [id=fr-par-1/10ae6bcb-ba77-4270-b188-5123c4ccc5c1]
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

--- a/examples/layer3-plan-lied/evidence/commercial-type.plan.txt
+++ b/examples/layer3-plan-lied/evidence/commercial-type.plan.txt
@@ -1,0 +1,38 @@
+OpenTofu used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+OpenTofu will perform the following actions:
+  # scaleway_account_project.main will be created
+  + resource "scaleway_account_project" "main" {
+      + created_at      = (known after apply)
+      + id              = (known after apply)
+      + name            = "if-s145-a"
+      + organization_id = (known after apply)
+      + updated_at      = (known after apply)
+    }
+  # scaleway_block_volume.app_data will be created
+  + resource "scaleway_block_volume" "app_data" {
+      + id                 = (known after apply)
+      + instance_volume_id = (known after apply)
+      + iops               = 9000
+      + name               = "s145-a-vol"
+      + project_id         = (known after apply)
+      + size_in_gb         = 1
+      + srn                = (known after apply)
+      + zone               = (known after apply)
+    }
+Plan: 2 to add, 0 to change, 0 to destroy.
+  with provider["registry.opentofu.org/scaleway/scaleway"],
+  on common.tf line 6, in provider "scaleway":
+   6: provider "scaleway" {
+Variable                        Available sources
+Currently using
+SCW_ACCESS_KEY                  Active Profile in config.yaml, Environment
+variable                    Environment variable
+SCW_SECRET_KEY                  Active Profile in config.yaml, Environment
+variable                    Environment variable
+SCW_DEFAULT_ORGANIZATION_ID     Active Profile in config.yaml, Environment
+variable                    Environment variable
+SCW_DEFAULT_REGION              Active Profile in config.yaml, Profile
+SCW_DEFAULT_ZONE                Active Profile in config.yaml, Profile
+(and one more similar warning elsewhere)

--- a/examples/layer3-plan-lied/evidence/commercial-type.real-apply.txt
+++ b/examples/layer3-plan-lied/evidence/commercial-type.real-apply.txt
@@ -1,0 +1,5 @@
+Error: scaleway-sdk-go: invalid argument(s): perf_iops is required, The provided 'perf_iops' value is not available. If provided, please choose from the following available values: [5000, 15000].
+
+  with scaleway_block_volume.app_data,
+  on main.tf line 4, in resource "scaleway_block_volume" "app_data":
+   4: resource "scaleway_block_volume" "app_data" {

--- a/examples/layer3-plan-lied/evidence/iam-scope.mock-apply.txt
+++ b/examples/layer3-plan-lied/evidence/iam-scope.mock-apply.txt
@@ -1,0 +1,3 @@
+scaleway_registry_namespace.images: Creating...
+scaleway_registry_namespace.images: Creation complete after 0s [id=fr-par/7a7c90fa-5a0b-4842-972d-d9e640c76d67]
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

--- a/examples/layer3-plan-lied/evidence/iam-scope.plan.txt
+++ b/examples/layer3-plan-lied/evidence/iam-scope.plan.txt
@@ -1,0 +1,37 @@
+OpenTofu used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+OpenTofu will perform the following actions:
+  # scaleway_account_project.main will be created
+  + resource "scaleway_account_project" "main" {
+      + created_at      = (known after apply)
+      + id              = (known after apply)
+      + name            = "if-s145-c"
+      + organization_id = (known after apply)
+      + updated_at      = (known after apply)
+    }
+  # scaleway_registry_namespace.images will be created
+  + resource "scaleway_registry_namespace" "images" {
+      + endpoint        = (known after apply)
+      + id              = (known after apply)
+      + is_public       = false
+      + name            = "if-s145-c-images"
+      + organization_id = (known after apply)
+      + project_id      = (known after apply)
+      + region          = (known after apply)
+    }
+Plan: 2 to add, 0 to change, 0 to destroy.
+  with provider["registry.opentofu.org/scaleway/scaleway"],
+  on common.tf line 6, in provider "scaleway":
+   6: provider "scaleway" {
+Variable                        Available sources
+Currently using
+SCW_ACCESS_KEY                  Active Profile in config.yaml, Environment
+variable                    Environment variable
+SCW_SECRET_KEY                  Active Profile in config.yaml, Environment
+variable                    Environment variable
+SCW_DEFAULT_ORGANIZATION_ID     Active Profile in config.yaml, Environment
+variable                    Environment variable
+SCW_DEFAULT_REGION              Active Profile in config.yaml, Profile
+SCW_DEFAULT_ZONE                Active Profile in config.yaml, Profile
+(and one more similar warning elsewhere)

--- a/examples/layer3-plan-lied/evidence/iam-scope.real-apply.txt
+++ b/examples/layer3-plan-lied/evidence/iam-scope.real-apply.txt
@@ -1,0 +1,5 @@
+Error: scaleway-sdk-go: insufficient permissions: write api_namespace
+
+  with scaleway_registry_namespace.images,
+  on main.tf line 4, in resource "scaleway_registry_namespace" "images":
+   4: resource "scaleway_registry_namespace" "images" {

--- a/examples/layer3-plan-lied/iam-scope/main.tf
+++ b/examples/layer3-plan-lied/iam-scope/main.tf
@@ -1,0 +1,8 @@
+resource "scaleway_account_project" "main" {
+  name = "if-s145-c"
+}
+resource "scaleway_registry_namespace" "images" {
+  name       = "if-s145-c-images"
+  is_public  = false
+  project_id = scaleway_account_project.main.id
+}

--- a/examples/layer3-plan-lied/iam-scope/providers.tf
+++ b/examples/layer3-plan-lied/iam-scope/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    scaleway = { source = "scaleway/scaleway", version = "~> 2.57" }
+  }
+}
+provider "scaleway" {
+  region = "fr-par"
+  zone   = "fr-par-1"
+}


### PR DESCRIPTION
The talk asserts `plan` proves intent, not safety. Until now that rested on defects found in infrafactory's *own harness*, which is a weaker claim than it sounds.

This adds infrastructure changes that clear `validate`, clear `plan`, clear a **mock apply**, and are then refused by real Scaleway. Same HCL both times; the only variable is which API answers.

| case | plan | mock apply | real apply | reproduces |
|---|---|---|---|---|
| block volume, `iops = 9000` | `2 to add` | **`2 added`** | `perf_iops … choose from [5000, 15000]` | 10/10 |
| registry namespace, unprivileged key | `2 to add` | **`2 added`** | `insufficient permissions: write api_namespace` | 10/10 |

Captured output for all three stages of both cases is committed under `examples/layer3-plan-lied/evidence/`.

### The honest split

- The **iops** case a mock *could* catch — `[5000, 15000]` is static and mockway simply doesn't model it. This is a fidelity gap. The argument is that the gap is *unbounded*, not that it was unforeseeable.
- The **IAM** case a mock *cannot* catch without replicating live IAM state. The same plan with a different key gives a different answer.

The README says which is which. Presenting the first as though it were the second is the fastest way to lose a technical audience.

### Refuted

Duplicate project names were expected to collide and don't — Scaleway permits them. Recorded deliberately; a corpus of near-misses is only trustworthy if the misses are in it.

### Cost / safety

Both fixtures create their own disposable `scaleway_account_project` (ADR-0010). 20 apply/destroy cycles ran during validation; post-run sweep found zero strays and nothing billable attributable to this work.

Closes S145-T1 through T4.