### PR TITLE
demo: block-paris through the real-cloud gate

### DIFF
--- a/examples/layer3-gate/block-paris/outputs.tf
+++ b/examples/layer3-gate/block-paris/outputs.tf
@@ -1,54 +1,14 @@
 output "project_id" {
-  description = "ID of the bootstrapped Scaleway project"
+  description = "Bootstrapped project id owning all scenario resources"
   value       = scaleway_account_project.main.id
 }
 
-output "project_name" {
-  description = "Name of the bootstrapped Scaleway project"
-  value       = scaleway_account_project.main.name
-}
-
-output "project_organization_id" {
-  description = "Organization the bootstrapped project belongs to"
-  value       = scaleway_account_project.main.organization_id
-}
-
 output "block_volume_id" {
-  description = "ID of the application data block volume"
+  description = "Zoned id of the app-data block volume for destruction/orphan verification"
   value       = scaleway_block_volume.app_data.id
 }
 
-output "block_volume_name" {
-  description = "Name of the application data block volume"
-  value       = scaleway_block_volume.app_data.name
-}
-
-output "block_volume_srn" {
-  description = "Scaleway Resource Name (SRN) of the application data block volume"
-  value       = scaleway_block_volume.app_data.srn
-}
-
 output "block_volume_zone" {
-  description = "Zone the application data block volume is attached to"
+  description = "Zone the volume was provisioned in, for region_restriction policy checks"
   value       = scaleway_block_volume.app_data.zone
-}
-
-output "block_volume_size_in_gb" {
-  description = "Size of the application data block volume in GB"
-  value       = scaleway_block_volume.app_data.size_in_gb
-}
-
-output "block_volume_iops" {
-  description = "Provisioned IO/s of the application data block volume"
-  value       = scaleway_block_volume.app_data.iops
-}
-
-output "region" {
-  description = "Region the stack is deployed to"
-  value       = var.region
-}
-
-output "zone" {
-  description = "Zone the stack is deployed to"
-  value       = var.zone
 }

--- a/examples/layer3-gate/block-paris/providers.tf
+++ b/examples/layer3-gate/block-paris/providers.tf
@@ -3,10 +3,7 @@ terraform {
 
   required_providers {
     scaleway = {
-      source = "scaleway/scaleway"
-      # Exact, not a range. The gate refuses anything else: this provider
-      # executes with real cloud credentials, so which build runs is a
-      # decision someone makes, not one the registry makes at init time.
+      source  = "scaleway/scaleway"
       version = "2.81.0"
     }
   }

--- a/examples/layer3-gate/block-paris/storage.tf
+++ b/examples/layer3-gate/block-paris/storage.tf
@@ -1,10 +1,10 @@
 resource "scaleway_block_volume" "app_data" {
-  name       = var.volume_name
+  name       = var.block_volume_name
   zone       = var.zone
-  size_in_gb = var.volume_size_in_gb
-  iops       = var.volume_iops
+  iops       = var.block_volume_iops
+  size_in_gb = var.block_volume_size_in_gb
   project_id = scaleway_account_project.main.id
-  tags       = var.volume_tags
+  tags       = var.tags
 
   depends_on = [scaleway_account_project.main]
 }

--- a/examples/layer3-gate/block-paris/variables.tf
+++ b/examples/layer3-gate/block-paris/variables.tf
@@ -1,47 +1,47 @@
 variable "region" {
-  description = "Scaleway region for the block-paris scenario"
+  description = "Scaleway region hosting the scenario resources"
   type        = string
   default     = "fr-par"
 }
 
 variable "zone" {
-  description = "Scaleway availability zone for the block-paris scenario"
+  description = "Scaleway availability zone hosting the block volume"
   type        = string
   default     = "fr-par-1"
 }
 
 variable "project_name" {
-  description = "Name of the bootstrapped Scaleway project"
+  description = "Name of the ephemeral project bootstrapped for this scenario"
   type        = string
-  default     = "infrafactory-block-paris"
+  default     = "block-paris"
 }
 
 variable "project_description" {
-  description = "Description of the bootstrapped Scaleway project"
+  description = "Description applied to the bootstrapped project"
   type        = string
-  default     = "Bootstrapped project for the block-paris scenario"
+  default     = "Ephemeral project bootstrapped for the block-paris scenario"
 }
 
-variable "volume_name" {
-  description = "Name of the application data block volume"
+variable "block_volume_name" {
+  description = "Name of the app-data block volume"
   type        = string
   default     = "block-paris-app-data"
 }
 
-variable "volume_size_in_gb" {
-  description = "Size of the application data block volume in GB"
+variable "block_volume_size_in_gb" {
+  description = "Size of the app-data block volume in GB"
   type        = number
   default     = 10
 }
 
-variable "volume_iops" {
-  description = "Maximum IO/s expected for the application data block volume"
+variable "block_volume_iops" {
+  description = "Maximum IO/s expected from the app-data block volume"
   type        = number
   default     = 5000
 }
 
-variable "volume_tags" {
-  description = "Tags applied to the application data block volume"
+variable "tags" {
+  description = "Tags applied to the app-data block volume"
   type        = list(string)
   default     = ["infrafactory", "block-paris", "app-data"]
 }


### PR DESCRIPTION
Generated by `infrafactory generate scenarios/training/block-paris.yaml` and put through the Layer 3 gate.

Applying the `layer3-gate` label asks the gate to deploy this to **real Scaleway**, probe it, destroy it, sweep the account, and comment the result below — before this merges.

The apply waits on a deployment approval. That approval is the point.