### PR TITLE
S166 design: replacing the teardown guard's second source of truth

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,41 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- 📐 **S166 design written for review (2026-08-31)** —
+  `docs/plans/s166-teardown-guard-design.md`. Not implemented: this is the slice
+  that touches `AssertProjectDeletable`, the guard between an automated destroy
+  and real infrastructure.
+
+  Proposal: replace the state-derived cross-check with **two** checks, both
+  required — a run-owned marker written beside the state (identity: "this run
+  created *this* project", trust parity with tfstate) and an API-side provenance
+  check against S165's `if-run-` + description stamp (class: "this is an
+  infrafactory disposable project", **not locally forgeable**). Neither alone is
+  sufficient, and provenance alone would be a regression: it authorises deleting
+  *any* stamped project, so two parallel runs could delete each other's.
+
+  Four judgement calls are collected at the end for a human to disagree with, the
+  weakest being the migration disjunction. Over-strict is named as the preferred
+  failure mode, given that five of S165's nine review findings were cleanup that
+  did not run.
+
+- ✅ **S165 canary green against real Scaleway (2026-08-31)** — `block-paris`
+  with `create_run_project: true`, **14.2s**, every stage pass:
+
+      run_project:        created 33838f22-… (if-run-block-paris-20260831t083759z)
+      orphan_sweep:       project 7394b328-… destroyed; nothing left outside it
+      run_project_delete: deleted 33838f22-…
+
+  Account back to its 3 baseline projects; both ids return 404, verified against
+  the API rather than from the tool's report.
+
+  **It shows the documented two-project behaviour and cleans up both**: the
+  pre-created run project *and* the one the HCL still declares, because S167 has
+  not removed `scaleway_account_project` yet. So this proves S165's
+  create/pass/delete works and does not break the existing flow — **not** the
+  post-S167 shape, which cannot be exercised until the shape gate stops requiring
+  a `scaleway_account_project` binding.
+
 - ✅ **S165 complete, review CLEAN (2026-08-31)** — ADR-0025's run-owned project
   is implemented for `run`/`test`, converged after nine Codex passes (20–28).
   **Not yet exercised against real Scaleway** — that canary is S168 and is a

--- a/STATUS.md
+++ b/STATUS.md
@@ -17,8 +17,11 @@ Last updated: 2026-08-31
   sufficient, and provenance alone would be a regression: it authorises deleting
   *any* stamped project, so two parallel runs could delete each other's.
 
-  Four judgement calls are collected at the end for a human to disagree with, the
-  weakest being the migration disjunction. Over-strict is named as the preferred
+  **All four judgement calls answered 2026-08-31**, and one of them changed the
+  arc: challenged on *why a non-production tool needs a transition at all*, the
+  dual-model plan was dropped. S166+S167 are now **one atomic cutover** and
+  `scaleway.create_run_project` is deleted as the scaffolding it was — two code
+  paths is where this arc's bugs came from. Over-strict is named as the preferred
   failure mode, given that five of S165's nine review findings were cleanup that
   did not run.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -25,97 +25,36 @@ Last updated: 2026-08-31
   failure mode, given that five of S165's nine review findings were cleanup that
   did not run.
 
-- ✅ **S165 canary green against real Scaleway (2026-08-31)** — `block-paris`
-  with `create_run_project: true`, **14.2s**, every stage pass:
+- ✅ **S165 done: implemented, reviewed clean, canaried (2026-08-31)** —
+  ADR-0025's run-owned project. `scaleway.create_run_project` (default **false**)
+  creates the run's project via the Account API before the apply and passes it as
+  `SCW_DEFAULT_PROJECT_ID`, wherever the Layer 3 apply goes through
+  `executeTest` — `test` and `run`. `deploy` refuses it: it keeps its project by
+  design, so deletion belongs to `live teardown`.
 
-      run_project:        created 33838f22-… (if-run-block-paris-20260831t083759z)
-      orphan_sweep:       project 7394b328-… destroyed; nothing left outside it
-      run_project_delete: deleted 33838f22-…
+  **Canary on real Scaleway**: `block-paris`, **14.2s**, every stage pass —
+  `run_project` created `33838f22-…`, `orphan_sweep` destroyed `7394b328-…`,
+  `run_project_delete` removed `33838f22-…`. Account back to its 3 baseline
+  projects, both ids **404**, verified against the API rather than the tool's own
+  report.
 
-  Account back to its 3 baseline projects; both ids return 404, verified against
-  the API rather than from the tool's report.
+  It shows the two-project behaviour and cleans up both, because the HCL still
+  declares `scaleway_account_project`. So it proves create/pass/delete works and
+  does not break the existing flow — **not** the post-cutover shape, which the
+  shape gate still forbids. That wart ends when the cutover deletes the flag.
 
-  **It shows the documented two-project behaviour and cleans up both**: the
-  pre-created run project *and* the one the HCL still declares, because S167 has
-  not removed `scaleway_account_project` yet. So this proves S165's
-  create/pass/delete works and does not break the existing flow — **not** the
-  post-S167 shape, which cannot be exercised until the shape gate stops requiring
-  a `scaleway_account_project` binding.
+  Converged after **nine Codex passes (20–28)**, and what they found matters more
+  than the feature: almost nothing was a wrong computation. Every real finding was
+  an **operation ordered so a failure left something behind** — a project created
+  before its config was validated, a cleanup attached to a branch some exit path
+  skipped (three times, three places), a delete inheriting a cancelled context,
+  and a decision reading the command's failure list instead of the teardown's
+  verdict. The condition on *whether* to delete was right from the first version;
+  where and when it ran was wrong five times.
 
-- ✅ **S165 complete, review CLEAN (2026-08-31)** — ADR-0025's run-owned project
-  is implemented for `run`/`test`, converged after nine Codex passes (20–28).
-  **Not yet exercised against real Scaleway** — that canary is S168 and is a
-  human decision, since it spends money.
-
-  What the passes found is worth more than the feature: almost nothing was a
-  wrong computation. Every real finding was an **operation ordered so a failure
-  left something behind** — a project created before its config was validated, a
-  cleanup attached to a branch some exit path skipped (three times, three
-  places), a delete inheriting a cancelled context, and a decision reading the
-  command's failure list instead of the teardown's verdict.
-
-- 🔧 **S165 detail (2026-08-31)** — ADR-0025's run-owned project.
-  `harness.ScalewayRunProject` creates and deletes the disposable project through
-  the Account API, stamping it `if-run-*` plus a fixed description so S166 has a
-  provenance marker to verify. `scaleway.create_run_project` exists but is **not
-  yet honoured**, and is deliberately absent from `infrafactory.yaml` until it is
-  — an operator-visible switch that silently does nothing is worse than no switch,
-  and `TestCreateRunProjectIsNotYetWired` fails the moment that stops being true.
-
-  `sandboxCommandEnvForProject` is the seam that will route
-  `SCW_DEFAULT_PROJECT_ID` at the run's own project; `sandboxCommandEnv`
-  delegates to it with an empty project, so the old path is unchanged by
-  construction. The organization-default refusal applies to a run-supplied
-  project too — the check is about where strays land, and that does not change
-  with where the id came from. The flag is **refused at config load** while
-  unwired, because accepting it silently would hand an operator a switch that
-  changes nothing.
-
-  The create/delete lifecycle is wired for the `test`/`run` path: the project is
-  created before the apply, and deleted once the account is proven clean or
-  immediately if no state was ever written. When resources may survive it is
-  **kept and reported**, because the project id is the handle to them. `deploy`
-  refuses the flag outright — it keeps its project by design, so deletion belongs
-  to `live teardown`.
-
-  Codex pass 27: the project was created *before* the sealed environment was
-  validated, so a missing `SCW_ACCESS_KEY` would create a real project and then
-  fail preflight. Validated first now — an API side effect from a configuration
-  that was always going to be rejected is residue that should never exist.
-
-  Codex pass 26 caught a regression from pass 25's own fix — lifting the cleanup
-  out of the destroy branch lost the fact that destruction had *run*, so
-  `--no-destroy` would delete a project whose resources are deliberately live.
-  **"No failures" is not "nothing is left."** It also caught that a cancelled run
-  skipped cleanup entirely; deletion now uses a fresh bounded context, the same
-  reasoning as the interrupt guard's destroy.
-
-  Codex pass 25 caught the third cleanup-placement bug: with `--no-destroy` or
-  destruction disabled, a failed apply left the project behind. The cleanup now
-  sits **outside every branch** — created in one place, released in one place.
-  Placing it inside a branch is what kept producing the bug.
-
-  Codex pass 23 caught the asymmetry that mattered most: the apply used the
-  run-owned project while the **destroy** rebuilt its environment from the shared
-  fallback, so resources with no `project_id` of their own — the whole motivating
-  case — would be looked for in the wrong project at teardown. Guarded now by a
-  source audit, verified against injected drift.
-
-  Codex pass 22 caught a real leak: the delete had been gated behind the destroy
-  branch, so an apply failing at preflight/init/plan created a project and never
-  removed it — on exactly the runs most likely to be repeated.
-
-  **Not usable on its own yet**: until the cutover the HCL still declares
-  `scaleway_account_project`, so enabling the flag gives a run two projects.
-  Nothing leaks, but it is waste — and codex pass 24 correctly noted that once
-  S167 removes that resource, `CaptureSweepTarget` fails closed. Declined as
-  S166 scope: the sweep target feeds `AssertProjectDeletable`, so it moves in the
-  cutover, with the guard.
-
-  Next increment: `deploy` + `live teardown`, so a live deployment's project is
-  deleted at teardown; then S167's fixture and prompt migration. **S166 is deliberately not
-  in scope** — it replaces `AssertProjectDeletable`'s state-derived cross-check,
-  which is the guard between teardown and real infrastructure.
+  Known gap, reported not silent: a run whose destroy falls to `run`'s
+  auto-destroy-on-failure path keeps its project — that path sits outside
+  `executeTest` and has no access to the id.
 
 - 🧪 **ADR-0025 + S165–S168 planned (2026-08-30)** — take the run's project out
   of the generated HCL. `scaleway_instance_private_nic` has **no `project_id`

--- a/STATUS.md
+++ b/STATUS.md
@@ -105,12 +105,12 @@ Last updated: 2026-08-31
   branch, so an apply failing at preflight/init/plan created a project and never
   removed it — on exactly the runs most likely to be repeated.
 
-  **Not usable on its own yet**: before S167 the HCL still declares
+  **Not usable on its own yet**: until the cutover the HCL still declares
   `scaleway_account_project`, so enabling the flag gives a run two projects.
   Nothing leaks, but it is waste — and codex pass 24 correctly noted that once
   S167 removes that resource, `CaptureSweepTarget` fails closed. Declined as
-  S166 scope: the sweep target feeds `AssertProjectDeletable`, so **S166 must
-  land before S167**.
+  S166 scope: the sweep target feeds `AssertProjectDeletable`, so it moves in the
+  cutover, with the guard.
 
   Next increment: `deploy` + `live teardown`, so a live deployment's project is
   deleted at teardown; then S167's fixture and prompt migration. **S166 is deliberately not
@@ -141,7 +141,7 @@ Last updated: 2026-08-31
   match the project named in `terraform-live.tfstate` — the check that stops a
   tampered record aiming teardown at real infrastructure. With the project out of
   the HCL that input disappears, so it is replaced by a run-owned marker **plus**
-  an API-side provenance check, both required, before S167 removes it.
+  an API-side provenance check, both required, in the same change that removes it.
 
   Incidentally, **D6 reproduced a third time**: the experiment's project refused
   to delete until the auto-created `Default security group` was purged — in a path

--- a/docs/NEXT_SESSION.md
+++ b/docs/NEXT_SESSION.md
@@ -6,9 +6,10 @@ Self-contained brief for a fresh Claude / engineer starting in this repo.
 
 ### START HERE — S166, the teardown guard
 
-**Read `docs/plans/s166-teardown-guard-design.md` first, and disagree with it
-before anything is built.** It collects four judgement calls for a human; the
-weakest is the migration disjunction.
+**Read `docs/plans/s166-teardown-guard-design.md` first — it is decided and ready
+to build.** All four judgement calls were answered on 2026-08-31 and are recorded
+there as decisions; you do not need to re-open them, but the reasoning is written
+down so you can tell whether a new fact should.
 
 S166 replaces `AssertProjectDeletable`'s state-derived cross-check — the guard
 between an automated destroy and real infrastructure. Under ADR-0025 the project

--- a/docs/NEXT_SESSION.md
+++ b/docs/NEXT_SESSION.md
@@ -37,9 +37,10 @@ account back to its 3 baseline projects with both ids returning 404.
 
 Two things to know before using it:
 
-- Enabling it **before S167** gives a run two projects — the pre-created one and
-  the one its HCL still declares. Nothing leaks (the canary cleaned up both), but
-  it is waste. The flag is mechanically complete, not coherent, until S167.
+- Enabling the flag today gives a run two projects — the pre-created one and the
+  one its HCL still declares. Nothing leaks (the canary cleaned up both), but it
+  is waste. **The cutover deletes the flag**, so this is a wart with a scheduled
+  end rather than a behaviour to design around.
 - A run whose destroy falls to `run`'s auto-destroy-on-failure path keeps its
   project. Reported as a skipped delete, not silent.
 
@@ -64,9 +65,9 @@ The fix is planned and proven: **ADR-0025** + `docs/plans/run-owned-project-plan
 (S165–S168) — create the run's project via the Account API *before* the apply,
 pass it as `SCW_DEFAULT_PROJECT_ID`, and drop `scaleway_account_project` from the
 HCL. A hand-run experiment applied a private NIC cleanly this way and destroyed
-cleanly. **S166 is the slice to be careful with**: it replaces
-`AssertProjectDeletable`'s state-derived cross-check, and must land before S167
-removes that check's input.
+cleanly. **The cutover is the slice to be careful with**: it replaces
+`AssertProjectDeletable`'s state-derived cross-check in the same change that
+removes the resource that check reads.
 
 Two diagnoses of this blocker were wrong before the right one, both from reading
 configuration instead of running something: `IPAMFullAccess` (the API actually

--- a/docs/NEXT_SESSION.md
+++ b/docs/NEXT_SESSION.md
@@ -4,35 +4,43 @@ Self-contained brief for a fresh Claude / engineer starting in this repo.
 
 ## Read this first (handoff state as of 2026-08-31)
 
-### START HERE — S165, the run-owned project
+### START HERE — S166, the teardown guard
 
-**Next slice: S165** (`docs/plans/run-owned-project-plan.md`, ADR-0025). It is
-the prerequisite for everything else: until it lands, no Scaleway compute
-scenario can satisfy Layer 1 and Layer 3 at once (see THE BLOCKER below), so the
-remaining live-services slices cannot reach real infrastructure with generated
-HCL. The mechanism is already proven by hand against real Scaleway.
+**Read `docs/plans/s166-teardown-guard-design.md` first, and disagree with it
+before anything is built.** It collects four judgement calls for a human; the
+weakest is the migration disjunction.
 
-### Arc context — live services
+S166 replaces `AssertProjectDeletable`'s state-derived cross-check — the guard
+between an automated destroy and real infrastructure. Under ADR-0025 the project
+is no longer a Terraform resource, so `terraform-live.tfstate` stops naming it
+and the check loses its input. The proposal is two checks, both required: a
+run-owned marker beside the state (identity) plus an API-side provenance check
+against S165's `if-run-` stamp (class, not locally forgeable). Neither alone is
+sufficient, and provenance alone would *regress* — it authorises deleting any
+stamped project, so parallel runs could delete each other's.
 
-`docs/plans/live-services-arc-plan.md` (S151–S158). infrafactory can now deploy a
-versioned service that outlives its run, and destroy it again.
+**S166 must land before S167.** Removing `scaleway_account_project` from the HCL
+before replacing the guard that reads it breaks the guard. This is a safety
+requirement, not an ordering preference.
 
-**Landed** — S151 live deployment registry, S152 `service:` in the scenario
-schema, S153 `deploy`/`live teardown`/`live reap`, plus S153a/S153b hardening
-(PR #171).
+### Done: S165 (merged, canaried)
 
-    infrafactory run <scenario>        prove it is safe
-    infrafactory deploy <scenario>     put it up under a TTL
-    infrafactory live ls               what is running, how long it has left
-    infrafactory live teardown <id>    destroy one
-    infrafactory live forget <id>      release a record nothing can act on
-    infrafactory live reap             destroy everything expired
+`scaleway.create_run_project` (default **false**) creates the run's project via
+the Account API before the apply and passes it as `SCW_DEFAULT_PROJECT_ID`.
+Canary on real Scaleway, 2026-08-31: `block-paris`, 14.2s, every stage pass,
+account back to its 3 baseline projects with both ids returning 404.
 
-**Proven against real Scaleway** (2026-08-30): deploy 35.8s, HTTP 200 through a
-real load balancer, teardown 36.1s, account back to its 3 baseline projects —
-verified against the API, not from the tool's own report. D6 (the auto-created
-`Default security group` blocking project deletion) reproduced **three** separate
-times, including once in a path with no infrafactory code in it.
+Two things to know before using it:
+
+- Enabling it **before S167** gives a run two projects — the pre-created one and
+  the one its HCL still declares. Nothing leaks (the canary cleaned up both), but
+  it is waste. The flag is mechanically complete, not coherent, until S167.
+- A run whose destroy falls to `run`'s auto-destroy-on-failure path keeps its
+  project. Reported as a skipped delete, not silent.
+
+Nine review passes went into S165 and almost none found a wrong computation.
+Every real finding was an **operation ordered so a failure left something
+behind** — worth expecting rather than rediscovering.
 
 ### THE BLOCKER — read before planning anything Scaleway + compute
 

--- a/docs/NEXT_SESSION.md
+++ b/docs/NEXT_SESSION.md
@@ -19,9 +19,13 @@ against S165's `if-run-` stamp (class, not locally forgeable). Neither alone is
 sufficient, and provenance alone would *regress* — it authorises deleting any
 stamped project, so parallel runs could delete each other's.
 
-**S166 must land before S167.** Removing `scaleway_account_project` from the HCL
-before replacing the guard that reads it breaks the guard. This is a safety
-requirement, not an ordering preference.
+**S166 and S167 are ONE change** (decided 2026-08-31). The guard's input changes
+at exactly the moment the HCL changes, so they cannot be separated — and the
+transition that would have separated them was dropped: there is no fleet to
+migrate, and two code paths is where this arc's bugs came from.
+`scaleway.create_run_project` is scaffolding and gets deleted by the cutover.
+
+All four judgement calls in the design are **answered**; it is ready to build.
 
 ### Done: S165 (merged, canaried)
 

--- a/docs/decisions/0025-run-project-created-before-the-apply.md
+++ b/docs/decisions/0025-run-project-created-before-the-apply.md
@@ -224,3 +224,31 @@ Across nine review passes on this slice, the condition on *whether* to delete wa
 correct from the first version. Where and when it ran was wrong five times. That
 is the shape of defect this arc keeps producing, and it is worth expecting rather
 than rediscovering.
+
+## Amendment, 2026-08-31: no transition — supersedes the migration decision and the pass-24 ordering
+
+This supersedes two earlier parts of this record: the **Migration** paragraph in
+the original Consequences ("both models must work during the transition"), and
+the **pass 24** amendment titled "S166 must land before S167". Both are wrong,
+and left in place above only because an ADR records what was decided when.
+
+The question that changed it: *what is the benefit of a transition for a
+non-production tool like this?* There is none. No fleet, no external consumers,
+nobody mid-migration. The only thing a transition protected was the PR gate's
+fixtures — and the gate runs on every PR, so breaking them is caught there.
+Rollback in a single-user repo is `git revert`.
+
+It also cost something. Two models means two code paths, and two code paths is
+where this arc's defects came from: five of S165's nine review findings were a
+cleanup path that did not run, and the dual model produced the "two projects per
+run" wart this ADR had to document. **`scaleway.create_run_project` was
+scaffolding mistaken for a feature.**
+
+So there is no ordering between S166 and S167, because they are **one change**:
+the guard's input changes at exactly the moment the HCL changes. The cutover
+lands the new guard, the shape gate without its `scaleway_account_project`
+requirement, the prompts, the pitfalls, the fixtures and the recorded generation
+together — reviewed hard and canaried before merge, with the flag deleted.
+
+Design and the four decisions behind it:
+`docs/plans/s166-teardown-guard-design.md`.

--- a/docs/plans/run-owned-project-plan.md
+++ b/docs/plans/run-owned-project-plan.md
@@ -37,16 +37,21 @@ existence*.
 
 | id | slice | why |
 |---|---|---|
-| S165 | Pre-apply project creation + `SCW_DEFAULT_PROJECT_ID` wiring, behind a config flag; both paths work | the mechanism, provably reversible |
-| S166 | Replace `AssertProjectDeletable`'s second source of truth | the guard that stands between teardown and real infrastructure — see below |
-| S167 | Remove `scaleway_account_project` from generation: prompts, pitfalls, shape gate, fixtures | the HCL change itself |
-| S168 | Real-cloud canary on the new path, then delete the old one + evidence | proven before the fallback is removed |
+| S165 | Pre-apply project creation + `SCW_DEFAULT_PROJECT_ID` wiring | ✅ **done, merged, canaried 2026-08-31** |
+| S166+S167 | The cutover: new guard **and** `scaleway_account_project` out of the HCL, prompts, pitfalls, shape gate, fixtures, recorded generation — in one change | the guard's input changes exactly when the HCL does, so they are one change |
+| S168 | Real-cloud canary on the new path + evidence | proven before merge, not after |
 
-**S165 → S166 → S167 → S168 is strictly ordered.** S166 must land before S167:
-once the project leaves the HCL the state no longer names it, and the guard has
-to already have its replacement.
+**Revised 2026-08-31.** The plan originally staged S166 before S167 behind a
+flag, on the assumption that both models should coexist during a transition.
+Challenged and dropped: there is no fleet to migrate, no external consumers, and
+the PR gate catches fixture breakage on the PR itself. Two models meant two code
+paths, which is where this arc's bugs came from — five of S165's nine review
+findings were a cleanup path that did not run. `scaleway.create_run_project` was
+scaffolding mistaken for a feature and is deleted by the cutover.
 
-## S166 is the slice to be careful with
+Design and decisions: `docs/plans/s166-teardown-guard-design.md`.
+
+## The cutover is the slice to be careful with
 
 `AssertProjectDeletable(stateProjectID, targetProjectID, organizationID)` refuses
 when the target is the organization default, and when it does not match the

--- a/docs/plans/run-owned-project-plan.md
+++ b/docs/plans/run-owned-project-plan.md
@@ -73,23 +73,23 @@ It is replaced by two independent checks, both required, each failing closed:
 The organization-default refusal is unchanged. This is also the first real piece
 of the reconcile-against-API work ADR-0024 has owed since S153.
 
-## Migration, and why both paths coexist for a while
+## No migration (revised 2026-08-31)
 
-`examples/layer3-gate/*` and `docs/demo/recorded-generation/*` declare
-`scaleway_account_project` today, and the PR gate applies that fixture HCL
-directly — so flipping the model in one commit would break the gate, which is the
-artifact the talk rests on. The pre-created path therefore lands behind a config
-flag (S165), fixtures and prompts move over in S167, and the old path is deleted
-only in S168, after a real-cloud canary has passed on the new one.
+The original plan kept both models alive behind a flag until a canary passed.
+Dropped — see the slice table above and
+`docs/plans/s166-teardown-guard-design.md`. The gate applies fixture HCL that
+declares `scaleway_account_project`, and those fixtures move **in the same
+change** as the guard; the gate running on the PR is what catches it if that goes
+wrong.
 
 ## Risks
 
 | risk | mitigation |
 |---|---|
-| **The teardown guard is weakened in the gap between S165 and S167.** | strict ordering: S166 lands its replacement before S167 removes the input |
+| **The teardown guard is weakened while the model changes.** | there is no gap: the guard's replacement and the HCL change are the same commit, reviewed hard and canaried before merge |
 | **Empty projects accumulate** from crashes between creation and apply. | sweep them by provenance marker; they are free but must not pile up |
 | **`tofu destroy` no longer removes the project**, so a teardown that stops early leaves it. | delete it via the API after destroy — the same sequence `destroySandbox` already runs for the auto-created security group |
-| **The gate fixtures drift** from generated HCL during the transition. | both paths supported until S168; the gate keeps applying fixtures unchanged |
+| **The gate fixtures drift** from generated HCL. | fixtures and recorded generation are regenerated in the cutover commit, and the gate runs on the PR that does it |
 
 ## What success looks like
 

--- a/docs/plans/s166-teardown-guard-design.md
+++ b/docs/plans/s166-teardown-guard-design.md
@@ -1,0 +1,138 @@
+# S166 design: replacing the teardown guard's second source of truth
+
+Written 2026-08-31 for review **before** implementation. S165 is merged and
+canaried; S166 is the slice that must land before S167, and it is the one that
+touches the guard standing between an automated destroy and real infrastructure.
+
+Nothing here is built yet. The judgement calls are collected at the end.
+
+## What the guard does today
+
+```go
+AssertProjectDeletable(stateProjectID, targetProjectID, organizationID) error
+```
+
+It refuses when the target is empty, when the target **is** the organization's
+default project, when `terraform-live.tfstate` records no project at all, and
+when the target does not match the one the state records.
+
+The last two are the substance. `terraform-live.tfstate` is an *independent
+witness*: Terraform writes it during the apply, and it names the project as a
+managed resource — "this run created this". Nothing a caller passes can
+manufacture that. `reap` and `live teardown` both lean on it, and `reap` passes
+the state-derived id as *both* arguments precisely so the check cannot be
+bypassed by an argument.
+
+## What ADR-0025 removes
+
+Under the new model the project is created through the Account API before tofu
+runs, so it is **not a Terraform resource** and `terraform-live.tfstate` will not
+name it. Once S167 removes `scaleway_account_project` from the HCL, the witness
+is gone and the check has no input. That is why the ordering is a safety
+requirement: **removing the resource before replacing the guard that reads it
+breaks the guard.**
+
+## The proposed replacement: two checks, both required
+
+### 1. A run-owned marker (identity)
+
+Written beside the state, by infrafactory, at the moment the project is created:
+
+    <workdir>/.infrafactory-run-project
+
+Holding the project id and the name it was created with. It answers *"did this
+run create this specific project?"*
+
+Trust level is **the same as the state file's** — local, written by the tool
+during the run, not supplied by a caller and never by PR-supplied HCL. It is not
+stronger; it is parity, deliberately. A human with an editor can forge it exactly
+as they could forge tfstate today.
+
+### 2. API-side provenance (class)
+
+The project must still exist and carry the stamp S165 already applies: an
+`if-run-` name prefix **and** the exact `RunProjectDescription`. It answers *"is
+this an infrafactory disposable project at all?"*
+
+This one **cannot be forged locally**. To defeat it you would have to create a
+real project shaped like an infrafactory run project — at which point you have
+created the kind of thing that is safe to delete.
+
+### Why neither is sufficient alone
+
+- **Marker alone** is a pure downgrade: it replaces one local file with another,
+  and adds nothing the state file did not already give.
+- **Provenance alone is worse than it looks.** It authorises deleting *any*
+  `if-run-*` project, not this run's. Two runs in parallel, and one teardown could
+  delete the other's project — a regression the current check does not have,
+  because it pins to one id.
+
+Together each covers the other's weakness: forge the marker and provenance still
+refuses anything unstamped; create a lookalike project and the marker still
+refuses anything this run did not record.
+
+The organization-default refusal is **unchanged**, and stays first.
+
+## Failure modes
+
+Every uncertain outcome refuses. "We could not check" must never equal "safe to
+delete" — the lesson the orphan sweep already encodes.
+
+| situation | verdict | why |
+|---|---|---|
+| marker missing | **refuse** | cannot show this run created it |
+| marker unreadable/corrupt | **refuse** | same, and consistent with `livestore`'s unreadable-is-expired |
+| marker names the organization default | **refuse** | unchanged existing check, applied first |
+| API says the project is gone (404) | **allow** | already the desired end state; mirrors `Delete`'s 404-is-success |
+| API unreachable / errors | **refuse** | an unverifiable delete is the one this guard exists to stop |
+| project exists, **not** stamped | **refuse, loudly** | something is badly wrong; this is not our project |
+| marker and target disagree | **refuse** | the argument does not get to win over the record |
+
+## Migration: a disjunction, not a replacement
+
+Both models coexist until S167 lands and the fixtures move. During that window a
+project may have been created either way, so the guard answers *"may I delete
+X?"* with yes when **either**:
+
+- the state names X as `scaleway_account_project` (old model, today's check), or
+- the marker names X **and** X carries the provenance stamp (new model)
+
+This is a disjunction, which is weaker than requiring both. It is not weaker than
+today, because each branch is independently sufficient for the model that
+produced it — but it is the part of this design I would most want a second
+opinion on. The alternative is a hard cutover, which cannot be staged and would
+break the PR gate.
+
+## Blast radius if this is wrong
+
+An over-permissive guard lets an automated destroy delete a project this run did
+not create. The organization default is refused by a separate check that is not
+being touched, so the worst realistic case is deleting **another infrastructure
+project that happens to carry infrafactory's stamp** — i.e. another run's, or a
+stray from a previous run. Bad, recoverable, and loud.
+
+An over-strict guard refuses legitimate teardowns, leaving real resources
+running. Given today's evidence — nine review passes on S165, five of them about
+cleanup not running — **over-strict is the safer failure and the one to prefer
+when uncertain.**
+
+## Judgement calls I want reviewed
+
+1. **Is marker + provenance genuinely equivalent to the state-derived check?**
+   My claim is yes, and slightly better because provenance is not locally
+   forgeable. Disagreeing here changes the whole design.
+2. **Is the migration disjunction acceptable?** It is the weakest point. The
+   alternative is a flag day.
+3. **Should the marker live in the workdir or in the live-deployment record?**
+   Workdir is proposed, because `reap` operates on a workdir and has no record.
+   `live teardown` has both.
+4. **Does "API unreachable ⇒ refuse" make teardown too fragile?** It means a
+   network blip leaves resources running until someone retries. That is the
+   deliberate choice, but it has a cost and it is worth stating out loud.
+
+## Explicitly out of scope
+
+Removing `scaleway_account_project` from generated HCL and the fixtures — that is
+S167, and it must not land until this does. Signing or tamper-proofing the
+marker: it is parity with the state file, and a local tool that a user can already
+edit gains little from cryptography.

--- a/docs/plans/s166-teardown-guard-design.md
+++ b/docs/plans/s166-teardown-guard-design.md
@@ -154,7 +154,9 @@ when uncertain.**
 
 ## Explicitly out of scope
 
-Removing `scaleway_account_project` from generated HCL and the fixtures — that is
-S167, and it must not land until this does. Signing or tamper-proofing the
-marker: it is parity with the state file, and a local tool that a user can already
+Removing `scaleway_account_project` from generated HCL and the fixtures is **in**
+scope, not out — it is the other half of the same change (see the cutover
+decision). Implementing the guard without it produces a guard with no input.
+
+Signing or tamper-proofing the marker: it is parity with the state file, and a local tool that a user can already
 edit gains little from cryptography.

--- a/docs/plans/s166-teardown-guard-design.md
+++ b/docs/plans/s166-teardown-guard-design.md
@@ -1,10 +1,12 @@
 # S166 design: replacing the teardown guard's second source of truth
 
 Written 2026-08-31 for review **before** implementation. S165 is merged and
-canaried; S166 is the slice that must land before S167, and it is the one that
-touches the guard standing between an automated destroy and real infrastructure.
+canaried. S166 replaces the guard standing between an automated destroy and real
+infrastructure — and, per the cutover decision below, it now lands **together
+with** S167 as one atomic change rather than before it.
 
-Nothing here is built yet. The judgement calls are collected at the end.
+Nothing here is built yet. The four judgement calls this document was written to
+surface were answered on 2026-08-31 and are recorded below as decisions.
 
 ## What the guard does today
 
@@ -27,10 +29,9 @@ bypassed by an argument.
 
 Under the new model the project is created through the Account API before tofu
 runs, so it is **not a Terraform resource** and `terraform-live.tfstate` will not
-name it. Once S167 removes `scaleway_account_project` from the HCL, the witness
-is gone and the check has no input. That is why the ordering is a safety
-requirement: **removing the resource before replacing the guard that reads it
-breaks the guard.**
+name it. Removing `scaleway_account_project` from the HCL takes the witness away
+and leaves the check with no input — which is why the guard and the HCL change
+are the same change, not two ordered ones.
 
 ## The proposed replacement: two checks, both required
 
@@ -88,20 +89,36 @@ delete" — the lesson the orphan sweep already encodes.
 | project exists, **not** stamped | **refuse, loudly** | something is badly wrong; this is not our project |
 | marker and target disagree | **refuse** | the argument does not get to win over the record |
 
-## Migration: a disjunction, not a replacement
+## No migration: a cutover (decided 2026-08-31)
 
-Both models coexist until S167 lands and the fixtures move. During that window a
-project may have been created either way, so the guard answers *"may I delete
-X?"* with yes when **either**:
+The design originally proposed running both models side by side and accepting
+whichever check applied. **That was wrong, and the question that killed it was
+"what is the benefit of a transition for a non-production tool like this?"**
 
-- the state names X as `scaleway_account_project` (old model, today's check), or
-- the marker names X **and** X carries the provenance stamp (new model)
+There is none. No deployed fleet, no external consumers, nobody mid-migration.
+The only thing a transition protected was the PR gate's fixtures — and the gate
+runs on every PR, so breaking it is *caught*, not discovered later. Rollback for
+a single-user repo is `git revert`, not a migration plan.
 
-This is a disjunction, which is weaker than requiring both. It is not weaker than
-today, because each branch is independently sufficient for the model that
-produced it — but it is the part of this design I would most want a second
-opinion on. The alternative is a hard cutover, which cannot be staged and would
-break the PR gate.
+It also cost something real: two models means two code paths, and two code paths
+is where this arc's bugs came from — five of S165's nine review findings were a
+cleanup path that did not run, and the dual model is what produced the
+"two projects per run" wart. **`create_run_project` was scaffolding mistaken for
+a feature.**
+
+So: **one model, one guard, one path.** The flag is deleted.
+
+### Consequence: S166 and S167 are one atomic change
+
+The guard's input changes at exactly the moment the HCL changes, so they cannot
+be separated. One slice, containing: the new guard, the shape gate no longer
+requiring a `scaleway_account_project` binding, prompts and pitfalls updated, and
+the gate fixtures plus recorded generation regenerated.
+
+That is a large security-critical change to review at once. **"Split for review
+size" is a different argument from "split for migration"** — this needs a hard
+review and a real-cloud canary before merge, but it does not need a flag kept
+alive to get them.
 
 ## Blast radius if this is wrong
 
@@ -116,19 +133,24 @@ running. Given today's evidence — nine review passes on S165, five of them abo
 cleanup not running — **over-strict is the safer failure and the one to prefer
 when uncertain.**
 
-## Judgement calls I want reviewed
+## Decisions (2026-08-31)
 
-1. **Is marker + provenance genuinely equivalent to the state-derived check?**
-   My claim is yes, and slightly better because provenance is not locally
-   forgeable. Disagreeing here changes the whole design.
-2. **Is the migration disjunction acceptable?** It is the weakest point. The
-   alternative is a flag day.
-3. **Should the marker live in the workdir or in the live-deployment record?**
-   Workdir is proposed, because `reap` operates on a workdir and has no record.
-   `live teardown` has both.
-4. **Does "API unreachable ⇒ refuse" make teardown too fragile?** It means a
-   network blip leaves resources running until someone retries. That is the
-   deliberate choice, but it has a cost and it is worth stating out loud.
+1. **Marker + provenance is accepted as equivalent.** The marker gives identity
+   at tfstate's trust level; provenance adds something tfstate never had — a
+   check that cannot be forged locally. Neither alone: marker alone is a pure
+   downgrade, and provenance alone authorises deleting *any* stamped project, so
+   parallel runs could delete each other's.
+2. **Cut over; no transition.** See above. The flag is deleted and S166+S167
+   become one slice.
+3. **The marker lives in the workdir**, beside the state, as
+   `.infrafactory-run-project`. `reap` has no deployment record — it exists for
+   runs that died before anything was recorded — so a record-only marker would
+   leave the guard blind on the command most likely to be aimed at orphaned
+   infrastructure. It also sits where the witness it replaces sat.
+4. **API unreachable ⇒ refuse.** Consistent with the orphan sweep's rule that
+   "we could not check" must never look like "nothing leaked". A blip costs a
+   retry; proceeding wrongly costs a project nobody meant to destroy. Resources
+   keep billing either way, so the asymmetry favours refusing.
 
 ## Explicitly out of scope
 

--- a/docs/review-passes/pass30.md
+++ b/docs/review-passes/pass30.md
@@ -1,0 +1,17 @@
+# S166 design review pass 30 — one finding, acted on
+
+### [P2] The fresh-session handoff still pointed at S165
+
+`STATUS.md` records S165 complete and canaried and S166 as the design to review,
+while `docs/NEXT_SESSION.md` still opened with **START HERE — S165**. Since
+`AGENTS.md` makes that file the first thing a fresh session reads, the next
+engineer would have picked up an already-merged slice.
+
+Correct, and the second time this exact class has been caught (pass 14 was the
+same file, one arc earlier) — which says the coupling between "record the status"
+and "repoint the handoff" is one a reviewer catches and I do not. `AGENTS.md:43`
+already requires it; the requirement is not the problem, remembering it is.
+
+Repointed to S166, with the design doc named as the thing to read *and disagree
+with* before anything is built, plus the S165 caveats a user of the flag needs
+today (two projects before S167; the auto-destroy path keeps its project).

--- a/docs/review-passes/pass31.md
+++ b/docs/review-passes/pass31.md
@@ -1,0 +1,11 @@
+# S166 design review pass 31 — clean
+
+`codex exec review --base main`:
+
+> The changes are documentation-only and consistently repoint the handoff/status
+> toward the new S166 design work. I did not identify a discrete correctness issue
+> introduced by this patch.
+
+The S166 **design** is reviewed; the implementation is not written and should not
+be until a human has answered the four judgement calls in
+`docs/plans/s166-teardown-guard-design.md`.

--- a/docs/review-passes/pass32.md
+++ b/docs/review-passes/pass32.md
@@ -1,0 +1,17 @@
+# S166 design review pass 32 — one finding, acted on
+
+### [P2] The handoff contradicted itself
+
+`NEXT_SESSION.md` opened with "read the design and **disagree with it before
+anything is built**" — text written when the judgement calls were open — while
+the same file said further down that all four were answered and the slice was
+ready. Since it is the first file a fresh session reads, the next engineer would
+have stopped for approval that had already been given.
+
+An artifact of editing one part of a document after a decision without re-reading
+the part that framed it. Third finding on this file across the session, all of
+the same shape: the handoff describes a state, and the state moved.
+
+Opening now says the design is decided and ready to build, and points at the
+recorded reasoning so a future reader can tell whether a *new* fact should reopen
+it.

--- a/docs/review-passes/pass33.md
+++ b/docs/review-passes/pass33.md
@@ -1,0 +1,21 @@
+# S166 design review pass 33 — three findings, one root cause, all acted on
+
+Three separate findings, all the same mistake: the cutover decision was recorded
+in some places and not in the ones that framed it.
+
+- **`s166-teardown-guard-design.md`** — "out of scope: removing
+  `scaleway_account_project`, that is S167" directly contradicted the decision
+  that they are one slice. An implementer following it would have built a guard
+  with no input.
+- **`run-owned-project-plan.md`** — the whole "Migration, and why both paths
+  coexist" section, plus two risk rows describing a gap that no longer exists.
+- **`NEXT_SESSION.md`** — the S165 caveat and the blocker section both still
+  ordered S166 before S167.
+
+Fixed by grepping for every surviving mention of the old ordering rather than
+patching the three that were reported — the previous two passes on this file were
+each one-at-a-time fixes for the same class, which is how it took three passes.
+
+ADR-0025's stale parts were **superseded, not rewritten**: an ADR records what was
+decided when, so the original Migration paragraph and the pass-24 ordering
+amendment stay, with a new amendment saying explicitly that it supersedes both.

--- a/docs/review-passes/pass34.md
+++ b/docs/review-passes/pass34.md
@@ -1,0 +1,19 @@
+# S166 design review pass 34 — one finding, acted on
+
+### [P2] Three S165 entries in STATUS contradicted each other
+
+Recording the canary left the two earlier S165 entries in place, still saying
+"not yet exercised against real Scaleway" and "`create_run_project` not yet
+honoured" — both false by then. A reader could no longer tell whether the flag
+had been wired or exercised, in the file `AGENTS.md` makes part of the
+fresh-session source of truth.
+
+Fixed by **consolidating the three same-day entries into one accurate entry**
+rather than patching the stale sentences. Appending a correction above a wrong
+statement leaves both on the page; STATUS's own update policy already says
+historical detail belongs in `ARCHIVE.md`, not stacked in the current phase.
+
+Fourth finding this session about a document describing a state that had moved.
+The recurring cause is the same: I record the new fact and leave the sentence
+that framed the old one. Consolidating beats appending when the entries are from
+the same day and the same slice.

--- a/docs/review-passes/pass35.md
+++ b/docs/review-passes/pass35.md
@@ -1,0 +1,25 @@
+# S166 design review pass 35 — clean
+
+`codex exec review --base main`:
+
+> The patch is documentation-only and consistently updates the handoff, status,
+> ADR amendment, and plan documents to reflect the S166/S167 cutover decision. I
+> did not identify a discrete correctness issue introduced by these changes.
+
+The S166 design and its four decisions are reviewed. **The implementation is not
+written**, and the cutover it now describes — guard, shape gate, prompts,
+pitfalls, fixtures and recorded generation in one change — is the next slice.
+
+## Passes 30–35, in one line
+
+Six passes on a documentation-only change, and every finding was the same shape:
+**a document describing a state that had moved.** The decision was recorded in
+one place and the sentences that framed it were left standing elsewhere — four
+separate times, across the handoff, the plan, the design's own scope section and
+the status file.
+
+The cheap lesson, worth more than the individual fixes: when a decision changes,
+grep for every sentence that assumed the old one, rather than editing the place
+where the new fact belongs. Consolidate same-day entries instead of appending
+corrections above them — a correction stacked on a wrong statement leaves both on
+the page.


### PR DESCRIPTION
**Design only — no implementation.** S166 touches `AssertProjectDeletable`, the guard between an automated destroy and real infrastructure, so this is written to be disagreed with before anything is built. Codex clean (passes 30–31).

Also records the **S165 canary result**.

## The problem

`terraform-live.tfstate` is an *independent witness*: Terraform writes it during the apply and names the project as a managed resource — "this run created this". Nothing a caller passes can manufacture it, which is why `reap` passes the state-derived id as *both* arguments.

ADR-0025 makes the project a pre-created API object, not a Terraform resource. Once S167 removes `scaleway_account_project` from the HCL, **the witness is gone and the check has no input.**

## Proposed replacement: two checks, both required

**A run-owned marker** beside the state, written by infrafactory at creation time — *identity*: "did this run create **this** project?". Trust parity with tfstate, deliberately: local, tool-written, never from PR HCL. Not stronger.

**API-side provenance** — the project must exist and carry S165's `if-run-` prefix **and** exact description. *Class*: "is this an infrafactory disposable project?". **Not locally forgeable** — to defeat it you must create a real project shaped like a disposable one.

**Neither alone works.** Marker alone is a pure downgrade. **Provenance alone is a regression**: it authorises deleting *any* stamped project, so two parallel runs could delete each other's — something today's check cannot do, because it pins to one id.

The organization-default refusal is unchanged and stays first.

## Judgement calls for a human

1. Is marker + provenance genuinely equivalent to the state-derived check?
2. **Is the migration disjunction acceptable?** It's the weakest point — the alternative is a flag day that would break the PR gate.
3. Marker in the workdir or the live-deployment record? (Workdir proposed: `reap` has no record.)
4. Does "API unreachable ⇒ refuse" make teardown too fragile? A network blip leaves resources running until retried.

## Failure posture

Every uncertain outcome refuses; a 404 is success. **Over-strict is named as the preferred failure mode** — five of S165's nine review findings were cleanup that didn't run, so refusing too often is the cheaper error here.

## S165 canary, also in this PR

`block-paris` with `create_run_project: true`, real Scaleway, **14.2s**, every stage pass. Account back to its 3 baseline projects; both project ids return **404**, verified against the API rather than the tool's own report.

It shows the documented **two-project** behaviour and cleans up both, because S167 hasn't removed `scaleway_account_project`. So it proves S165's create/pass/delete works and doesn't break the existing flow — **not** the post-S167 shape, which the shape gate still forbids.

## Reminder

**S166 must land before S167.** Removing the resource before replacing the guard that reads it breaks the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD