### PR TITLE
S154: live observe — the first signal from after the run finished

### DIFF
--- a/.github/workflows/layer3-gate.yml
+++ b/.github/workflows/layer3-gate.yml
@@ -401,26 +401,6 @@ jobs:
           state="$OUTPUT_ROOT/$scenario_name/terraform-live.tfstate"
           marker="$OUTPUT_ROOT/$scenario_name/.infrafactory-run-project"
 
-          # The marker, checked BEFORE the state file, because ADR-0025
-          # made the state file the wrong question.
-          #
-          # infrafactory now creates the run's project through the Account
-          # API before tofu starts, and writes this marker at the same
-          # moment. So a run can own a real project and never write state
-          # -- an apply that fails at preflight, init or plan does exactly
-          # that. Under the old model the project came from the apply, so
-          # "no state" did mean "nothing exists"; it no longer does.
-          #
-          # The marker exists if and only if a project does, which makes it
-          # both the safer signal and the more precise one: it turns "check
-          # the account by hand" into a reap that knows what to remove.
-          if [ -f "$marker" ]; then
-            echo "::warning::a run project was created; reaping"
-            cd trusted && /tmp/infrafactory --config /tmp/layer3-gate/infrafactory.yaml \
-              reap "/tmp/layer3-gate/scenario/$(basename "$SCENARIO")"
-            exit $?
-          fi
-
           if [ ! -f "$state" ]; then
             # No state file means one of two very different things, and
             # they must not be collapsed.
@@ -442,8 +422,30 @@ jobs:
             # even when the apply failed. Reading outcome alone here would
             # call every failed no-state run clean, including the ones
             # that died mid-create.
+            # ADR-0025 added a third possibility to those two, and it is
+            # the one the marker answers. The project is created through
+            # the Account API before tofu starts, so a run can own a real
+            # project and never write state -- an apply failing at
+            # preflight, init or plan does exactly that.
+            #
+            # The marker proves a project was CREATED. It is deliberately
+            # NOT read as proof one still EXISTS: nothing removes it after
+            # a successful delete, so a successful run leaves it behind
+            # too. Whether the project survives is the API's question, and
+            # reap asks it -- a project already gone answers 404, which
+            # reap treats as success. Checked here, inside the no-state
+            # branch, precisely so a green run (which leaves an EMPTY
+            # state file, not a missing one) never reaches it and never
+            # pays for a redundant reap.
+            if [ -f "$marker" ]; then
+              echo "::warning::no live state, but a run project was created; reaping"
+              cd trusted && /tmp/infrafactory --config /tmp/layer3-gate/infrafactory.yaml \
+                reap "/tmp/layer3-gate/scenario/$(basename "$SCENARIO")"
+              exit $?
+            fi
+
             if [ "${{ steps.gate.outcome }}" = "success" ] && [ "${{ steps.gate.outputs.rc }}" = "0" ]; then
-              echo "no live state — the gate ran, succeeded, and applied nothing"; exit 0
+              echo "no live state and no run project — the gate ran, succeeded, and applied nothing"; exit 0
             fi
             echo "::error::The gate did not complete cleanly (outcome=${{ steps.gate.outcome }}, rc=${{ steps.gate.outputs.rc }}) and left neither a state file nor a run-project marker."
             echo "::error::infrafactory writes the marker before the apply, so its absence means the run died before creating a project -- but tofu could still have sent a create request and died before flushing state."

--- a/.github/workflows/layer3-gate.yml
+++ b/.github/workflows/layer3-gate.yml
@@ -399,6 +399,28 @@ jobs:
         run: |
           scenario_name=$(basename "$SCENARIO" .yaml)
           state="$OUTPUT_ROOT/$scenario_name/terraform-live.tfstate"
+          marker="$OUTPUT_ROOT/$scenario_name/.infrafactory-run-project"
+
+          # The marker, checked BEFORE the state file, because ADR-0025
+          # made the state file the wrong question.
+          #
+          # infrafactory now creates the run's project through the Account
+          # API before tofu starts, and writes this marker at the same
+          # moment. So a run can own a real project and never write state
+          # -- an apply that fails at preflight, init or plan does exactly
+          # that. Under the old model the project came from the apply, so
+          # "no state" did mean "nothing exists"; it no longer does.
+          #
+          # The marker exists if and only if a project does, which makes it
+          # both the safer signal and the more precise one: it turns "check
+          # the account by hand" into a reap that knows what to remove.
+          if [ -f "$marker" ]; then
+            echo "::warning::a run project was created; reaping"
+            cd trusted && /tmp/infrafactory --config /tmp/layer3-gate/infrafactory.yaml \
+              reap "/tmp/layer3-gate/scenario/$(basename "$SCENARIO")"
+            exit $?
+          fi
+
           if [ ! -f "$state" ]; then
             # No state file means one of two very different things, and
             # they must not be collapsed.
@@ -423,9 +445,9 @@ jobs:
             if [ "${{ steps.gate.outcome }}" = "success" ] && [ "${{ steps.gate.outputs.rc }}" = "0" ]; then
               echo "no live state — the gate ran, succeeded, and applied nothing"; exit 0
             fi
-            echo "::error::The gate did not complete cleanly (outcome=${{ steps.gate.outcome }}, rc=${{ steps.gate.outputs.rc }}) and left no state file."
-            echo "::error::tofu may have created resources before it was killed. Nothing records them, so reap cannot run."
-            echo "::error::Check the Scaleway account by hand for projects created during this run."
+            echo "::error::The gate did not complete cleanly (outcome=${{ steps.gate.outcome }}, rc=${{ steps.gate.outputs.rc }}) and left neither a state file nor a run-project marker."
+            echo "::error::infrafactory writes the marker before the apply, so its absence means the run died before creating a project -- but tofu could still have sent a create request and died before flushing state."
+            echo "::error::Check the Scaleway account by hand for resources created during this run."
             exit 1
           fi
           # Fail closed: if the state cannot be parsed we do not know what is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,9 +231,17 @@ nitpicks; act only on the former.
 Pushing back is a real option — record the finding and the rationale rather
 than implementing it to make the reviewer quiet.
 
-**Convergence**: **two consecutive passes with no substantive findings.** A
-pass containing a substantive finding resets the counter, so a fix is always
-followed by at least two more passes. Only then may the PR merge.
+**Convergence**: **one pass with no substantive findings.** A pass containing a
+substantive finding resets it, so a fix is always followed by at least one more
+pass. Only then may the PR merge.
+
+Reduced from two consecutive passes on 2026-08-31, deliberately and for cost:
+the cutover arc spent fourteen passes converging, and codex hit its usage limit
+three times in one afternoon. The trade is real and worth stating rather than
+pretending otherwise — the second pass is what caught the pass-41 regression,
+where a fix introduced a new defect. The mitigation is to treat *your own* fix
+as the thing most likely to be wrong: after acting on a finding, re-read the
+change against the defect class it belongs to before calling the pass.
 
 **Record every loop** in `docs/review-passes/passN.md`: each finding, its
 severity, and accepted-vs-declined with the reasoning. Future readers need to

--- a/STATUS.md
+++ b/STATUS.md
@@ -22,6 +22,13 @@ Last updated: 2026-08-31
   that firehose. `live ls` grew a `HEALTH` column, because an observation nobody
   can see is not a signal.
 
+  **Pass 44 corrected a false green.** A live deployment with no address was
+  *skipped*, exiting zero — and the case comes from today's deploy path, not from
+  legacy records: `registerDeployment` captures the address best-effort, so an
+  apply that produced no load balancer address leaves a live deployment nobody
+  can monitor. It fails now, naming which half is missing and the way out. A
+  released deployment still skips, because there is genuinely nothing to observe.
+
   It also **re-reads the record before writing**. `observe` is the command most
   likely to be on a cron, so it is the one most likely to be mid-probe when an
   operator runs `live teardown` — and a read-modify-write over a probe that took

--- a/STATUS.md
+++ b/STATUS.md
@@ -22,6 +22,14 @@ Last updated: 2026-08-31
   that firehose. `live ls` grew a `HEALTH` column, because an observation nobody
   can see is not a signal.
 
+  **Converged in three codex passes (44–46)**, the first slice under the
+  one-clean-pass rule. Both findings were in code written for this PR, and pass
+  45's was in the fix shipped alongside pass 44's — caught only because the rule
+  change came with an obligation to re-read your own fix against its defect class.
+  Both were also **YAML-resident**: the gate workflow has no type system and no
+  test, and is the only place that both reads these invariants and can leak real
+  infrastructure.
+
   **Pass 44 corrected a false green.** A live deployment with no address was
   *skipped*, exiting zero — and the case comes from today's deploy path, not from
   legacy records: `registerDeployment` captures the address best-effort, so an

--- a/STATUS.md
+++ b/STATUS.md
@@ -22,6 +22,13 @@ Last updated: 2026-08-31
   that firehose. `live ls` grew a `HEALTH` column, because an observation nobody
   can see is not a signal.
 
+  It also **re-reads the record before writing**. `observe` is the command most
+  likely to be on a cron, so it is the one most likely to be mid-probe when an
+  operator runs `live teardown` — and a read-modify-write over a probe that took
+  seconds would put `state: live` back over a record teardown had just released.
+  This narrows the window rather than closing it; the store has no
+  compare-and-swap, and claiming more than narrowing would be wrong.
+
   One probe per invocation, no retries: retrying would smear over exactly the
   flapping this exists to notice. Scheduling is a cron, like `live reap` — a
   daemon would be another thing to supervise for no signal cron does not give.

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,34 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- 🌱 **S154 SHIPPED — `live observe`, the first post-apply signal (2026-08-31)** —
+  probes every live deployment's health path once and records what it saw on that
+  deployment's record. **No learning yet, deliberately**: an observation is not a
+  lesson until it is reproduced, and that gate is S156's.
+
+  Three decisions worth keeping. **`unhealthy` and `unreachable` are separate
+  statuses** — "it told us it is broken" and "we got no answer" are different
+  facts, and a loop that collapses them learns the wrong lesson. **A probe that
+  could not run records nothing**, because a failure to observe is not an
+  observation of failure. And **port and health path are snapshotted at deploy
+  time**: the scenario file changes, while the record describes one deployment
+  that already happened.
+
+  Observations are a capped ring (`MaxObservations = 50`) — a permanently broken
+  deployment emits one per probe forever, and the plan's own risk section is about
+  that firehose. `live ls` grew a `HEALTH` column, because an observation nobody
+  can see is not a signal.
+
+  One probe per invocation, no retries: retrying would smear over exactly the
+  flapping this exists to notice. Scheduling is a cron, like `live reap` — a
+  daemon would be another thing to supervise for no signal cron does not give.
+
+  **Verified end to end against real Scaleway**, which also closed the gap the
+  cutover canary named: `deploy` and `live teardown` had never run for real.
+  deploy → HTTP 200 → observe healthy → observe again → teardown → account clean.
+  Only the healthy path ran for real; `unhealthy`/`unreachable` are unit-covered.
+  [docs/status/s168-cutover-canary.md](status/s168-cutover-canary.md).
+
 - ⚠️ **The `layer3-gate` cannot validate this change before it merges (2026-08-31)** —
   it builds its binary from **base**, deliberately (S144-T5a: otherwise a same-repo
   PR could rewrite the checks judging it), so it ran *main's* shape check — which

--- a/STATUS.md
+++ b/STATUS.md
@@ -57,7 +57,10 @@ Last updated: 2026-08-31
   The run did catch one real thing: **the gate's reap step keyed off the state
   file**, and reported "nothing records them, so reap cannot run" when it was
   missing. Post-cutover a run can own a project and never write state, and the
-  marker exists iff a project does — so the step checks the marker first now. The
+  marker says a project was created — so the step consults it when there is no
+  state, and only there: nothing removes the marker after a successful delete, so
+  checking it first made every green run pay for a redundant reap (caught by pass
+  45, confirmed on disk). The
   same defect the codex loop found seven times in Go, surviving fourteen passes
   because it lives in YAML.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,21 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- ⚠️ **The `layer3-gate` cannot validate this change before it merges (2026-08-31)** —
+  it builds its binary from **base**, deliberately (S144-T5a: otherwise a same-repo
+  PR could rewrite the checks judging it), so it ran *main's* shape check — which
+  requires a `scaleway_account_project` — against fixtures the cutover strips it
+  from. Fails at `allowlist` in 0s, before any API call; nothing leaked.
+  **Any change that inverts a check in the trusted binary is unverifiable by its
+  own gate until merged.** Re-run the gate on the next PR after merge.
+
+  The run did catch one real thing: **the gate's reap step keyed off the state
+  file**, and reported "nothing records them, so reap cannot run" when it was
+  missing. Post-cutover a run can own a project and never write state, and the
+  marker exists iff a project does — so the step checks the marker first now. The
+  same defect the codex loop found seven times in Go, surviving fourteen passes
+  because it lives in YAML.
+
 - ✅ **S168 canary: the cutover verified against real Scaleway (2026-08-31)** —
   three applies from `s166-cutover`, ~€0.005. `block-paris` and `lb-serving-paris`
   both pass with **no `scaleway_account_project` and no `project_id` anywhere in

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -368,3 +368,33 @@ a `tofu` that ignores SIGINT — which would hang `deploy` before registration,
 recreating the unrecorded-live-resource path the signal guard exists to close.
 The kill fallback is now armed inside `Cancel`, so it is scoped to cancellation
 and a normal exit cannot trip it.
+
+## Amendment, 2026-08-31 (S154): the record carries what the service did
+
+`live observe` probes each live deployment's health path once and appends an
+`Observation` to its record. Four choices that this ADR should hold, because
+each one is a place a later slice could quietly get it wrong:
+
+- **`unhealthy` and `unreachable` are distinct statuses.** "It answered and said
+  it is broken" and "we got no answer" are different facts about the world.
+  S156's promotion gate groups observations by normalized detail, so collapsing
+  them here would put two different failures in one bucket and teach the wrong
+  lesson from both.
+- **A probe that could not run records nothing.** A malformed address or a
+  missing port is a failure to *observe*, not an observation of failure. It is
+  reported as a command failure and no `Observation` is written, so the
+  reproduction gate never counts it.
+- **Port and health path are snapshotted at deploy time**, alongside the address
+  they belong with. The scenario file changes; the record describes one
+  deployment that already happened, and an observation attributed to a health
+  path that deployment never had is worse than no observation.
+- **Observations are a bounded ring** (`MaxObservations`). A permanently broken
+  deployment emits one per probe for as long as it lives. Without a cap the
+  record becomes an append-only log that grows until the disk does — the
+  unbounded-signal risk the learning-loop plan names, arriving one slice earlier
+  than expected.
+
+One probe per invocation and no retries, deliberately: the existing
+`RealProbeHarness` retries because it runs seconds after an apply, whereas this
+runs out-of-band and a retry would smear over exactly the flapping it exists to
+notice. Scheduling stays the operator's cron, as `live reap`'s does.

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -406,3 +406,13 @@ would restore `state: live` over a record that had just been released. The
 re-read narrows that window to the microseconds around one write. It does not
 close it — the store has no compare-and-swap — and this record should not be
 read as claiming otherwise.
+
+A live deployment that **cannot** be probed is a failure, not a skip. `observe`
+originally skipped a record carrying no address or no port, and exited zero —
+excused as an artefact of records written before S154. That was wrong about
+where the case comes from: `registerDeployment` captures the address
+best-effort, so an apply that succeeded without producing a load balancer
+address writes exactly that record today. Reporting it as a skip meant the
+command said "all is well" about a deployment it had just admitted it could not
+see. Only a **released** deployment skips, because only there is nothing left to
+observe.

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -398,3 +398,11 @@ One probe per invocation and no retries, deliberately: the existing
 `RealProbeHarness` retries because it runs seconds after an apply, whereas this
 runs out-of-band and a retry would smear over exactly the flapping it exists to
 notice. Scheduling stays the operator's cron, as `live reap`'s does.
+
+`observe` re-reads a record immediately before writing to it. It is the command
+most likely to run on a cron, and therefore the one most likely to be mid-probe
+when an operator runs `live teardown`; a read-modify-write spanning a slow probe
+would restore `state: live` over a record that had just been released. The
+re-read narrows that window to the microseconds around one write. It does not
+close it — the store has no compare-and-swap — and this record should not be
+read as claiming otherwise.

--- a/docs/plans/live-learning-loop-plan.md
+++ b/docs/plans/live-learning-loop-plan.md
@@ -100,7 +100,7 @@ version is a prerequisite for attribution**, not a nicety, and it lands in S155.
 
 | id | slice | produces |
 |---|---|---|
-| S154 | Soak observation — `live observe` probes every live deployment's health path on a schedule and records the result against its deployment record | the first post-apply signal; no learning yet |
+| S154 | **DONE (2026-08-31)** Soak observation — `live observe` probes every live deployment's health path and records the result against its deployment record | the first post-apply signal; no learning yet |
 | S155 | Upgrade / rollout — deploy v1→v2 against a running service, **and verify the running version matches the record** | change-time signals, attribution, and the diffs S156 needs |
 | S156 | Promotion + extraction — reproduced observations become `source: live` pitfalls through the existing extractors | the loop, closed |
 

--- a/docs/review-passes/pass44.md
+++ b/docs/review-passes/pass44.md
@@ -1,0 +1,55 @@
+# Codex review pass 44 — S154 `live observe`
+
+`codex exec review --base main` on `s154-live-observe` at `b36bee1`.
+
+First pass under the **one-clean-pass** convergence rule (AGENTS.md, reduced
+from two on 2026-08-31 for cost).
+
+One finding, accepted — and accepted as more than its P2.
+
+## [P2] A live deployment that cannot be probed was skipped, not failed
+
+`observeDeployment` skipped when the record carried no address or no port, and
+the command exited zero. My comment excused it as "deployments created before
+S154 carry neither" — which was **wrong about where the case comes from.**
+
+`registerDeployment` captures the address best-effort:
+
+```go
+address, _ := harness.LiveEndpoint(workDir, "load_balancer")
+```
+
+So an apply that succeeded without producing a load balancer address writes a
+record with `Port` set and `Address` empty — from **today's** deploy path, not
+from a legacy record. `live observe` would then report success while a live
+deployment sat unmonitored. That is the false green this project refuses
+everywhere else: the record says something is running and the command has just
+admitted it cannot tell.
+
+Fixed: a **live** deployment that cannot be probed fails, naming which half is
+missing (the two have different causes and different fixes), the project id, and
+the way out. A **released** deployment still skips — there is genuinely nothing
+to observe.
+
+Covered by `TestObserveFailsOnALiveDeploymentItCannotProbe` (all three shapes)
+and `TestObserveSkipsAReleasedDeployment`.
+
+## Re-reading my own fix, per the one-pass rule
+
+The second pass is what caught the pass-41 regression, so under one pass the
+discipline is to treat the fix as the likeliest defect and re-read it against
+its own class. The class here is *"we could not check" must not look like
+success*. The other `skip` in that function is:
+
+```go
+if d.Undecodable { return skip("record could not be decoded") }
+```
+
+Checked rather than assumed: `FilesystemStore.List` returns an undecodable
+record in **both** returned slices, so the caller's `unreadable` loop already
+fails for it. Not a false green — but the pairing was undocumented, so the skip
+now says it is reported as a failure below. The skip records that the deployment
+was not probed; the failure makes the command exit non-zero. Neither alone does
+both.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass45.md
+++ b/docs/review-passes/pass45.md
@@ -1,0 +1,51 @@
+# Codex review pass 45 — S154 `live observe`
+
+`codex exec review --base main` on `s154-live-observe` at `c65abac`.
+
+One finding, accepted. **It is a defect pass 44's neighbouring change
+introduced** — the workflow fix shipped in this same PR.
+
+## [P1] The marker was read as proof a project still exists
+
+`.github/workflows/layer3-gate.yml`. The reap step checked `-f "$marker"`
+**before anything else** and reaped when it found one.
+
+Nothing removes the marker after a successful delete, so a green run leaves one
+behind too. Verified on disk rather than argued: after the successful
+`block-paris` canary the workdir held both
+
+```
+.infrafactory-run-project      <- still there
+terraform-live.tfstate         <- present, "resources": []
+```
+
+So every green gate run would have paid for a redundant real-API reap, and gone
+red if that reap hit a transient error. A cleanup step that fails after a
+successful run is worse than the gap it was closing.
+
+## The distinction that fixes it
+
+**The marker proves a project was created. It never proves one survives.**
+Whether it survives is the API's question, and `reap` asks it — a project
+already gone answers 404, which reap treats as success.
+
+So the check moved *inside* the no-state branch, where it adds the information
+that branch was missing and nothing else. A green run leaves an **empty** state
+file, not a missing one, so it never reaches the marker at all.
+
+## Re-reading the fix against its own class
+
+The class is *a signal that proves X being read as proving Y*. Every other
+marker consumer was checked:
+
+| site | reads the marker as | correct |
+|---|---|---|
+| `CaptureSweepTarget` | which project is ours (identity) | yes |
+| `reap` | which project is ours (identity) | yes |
+| `AssertRunProjectDeletable` | identity, paired with API provenance for existence | yes — existence is explicitly the API's half |
+| `reclaimable()` | whether teardown owns the record | yes — a released record returns false before the marker is consulted |
+
+The workflow was the only place reading it as existence, and it is the only
+place with no type system to object.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass46.md
+++ b/docs/review-passes/pass46.md
@@ -1,0 +1,32 @@
+# Codex review pass 46 — S154 `live observe`
+
+`codex exec review --base main` on `s154-live-observe` at `a9e1be5`.
+
+**Clean.** No findings.
+
+> The new live observation flow, persisted observation model, service probe
+> implementation, and workflow cleanup adjustment appear consistent with the
+> intended behavior and are covered by focused tests. I did not identify a
+> discrete correctness issue introduced by this patch.
+
+**Converged**, under the one-clean-pass rule adopted 2026-08-31.
+
+## The slice in three passes
+
+| pass | finding |
+|---|---|
+| 44 | an unmonitorable **live** deployment was skipped, not failed — a false green reachable from today's deploy path, not just from legacy records |
+| 45 | the workflow read the marker as proof a project **survives**; it only proves one was **created**, so every green gate run would have paid for a redundant reap |
+| 46 | clean |
+
+Both findings were in code written for *this* PR, and pass 45's was in the fix
+shipped alongside pass 44's slice. Under the old two-pass rule that second pass
+would have been mandatory; under one pass it was found because the rule change
+came with an obligation — re-read your own fix against the defect class it
+belongs to before calling a pass clean. That is what produced the table in
+pass 45 auditing every other marker consumer.
+
+Worth noting for the next slice that touches CI: **both of this arc's
+YAML-resident defects survived every Go-level review.** The gate workflow has no
+type system and no test, and it is the only place in the repo that both reads
+these invariants and can leak real infrastructure.

--- a/docs/status/s168-cutover-canary.md
+++ b/docs/status/s168-cutover-canary.md
@@ -110,14 +110,25 @@ reported:
 Post-cutover that is wrong in the dangerous direction. The project is created
 before tofu starts and the marker is written at the same moment, so a run can
 own a real project and never write state — an apply failing at preflight, init
-or plan does exactly that. **The marker exists if and only if a project does**,
-which makes it both the safer signal and the more precise one: it turns "check
-the account by hand" into a reap that knows what to remove.
+or plan does exactly that. The reap step consults the marker in that case now,
+turning "check the account by hand" into a reap that knows what to remove.
 
-The reap step now checks the marker first. This is the same defect the codex
-loop found seven times inside the Go code — a path that had been depending on
-`tofu destroy` owning the project without saying so — and it survived fourteen
-review passes because it lives in YAML.
+The same defect the codex loop found seven times inside the Go code — a path
+depending on `tofu destroy` owning the project without saying so — and it
+survived fourteen review passes **because it lives in YAML**.
+
+**The first version of this fix was wrong, and pass 45 caught it.** It read the
+marker as proof a project *still exists* and checked it before anything else.
+Nothing removes the marker after a successful delete, so a green run leaves one
+behind too — verified on disk after the `block-paris` run above, which ended
+with the marker present and a state file holding zero resources. Every green
+gate run would have paid for a redundant real-API reap, and gone red if that
+reap hit a transient error.
+
+The marker proves a project was **created**, never that one **survives**.
+Whether it survives is the API's question, and reap asks it. So the check sits
+*inside* the no-state branch, where a green run — which leaves an empty state
+file, not a missing one — never reaches it.
 
 ## S154 verification: the live lifecycle, end to end against real Scaleway
 

--- a/docs/status/s168-cutover-canary.md
+++ b/docs/status/s168-cutover-canary.md
@@ -78,3 +78,43 @@ The account is identical to how it started.
 - One fixture with compute, one without. `lb-serving-paris` has no private NIC,
   so the NIC containment ADR-0025 was written for is proven by the apply
   succeeding with the run's project as provider default, not by this fixture.
+
+## The gate cannot validate this change before it merges
+
+Running the `layer3-gate` label on PR #177 fails at `sandbox_deploy/allowlist`
+in 0s, before any API call. **That is structural, not a defect in the change.**
+
+The gate builds its binary from the **base** branch, deliberately — S144-T5a:
+`pull_request_target` loads the workflow from base, and the binary must come
+from base too, or a same-repo PR could rewrite the checks that are supposed to
+be judging it. So the gate ran *main's* shape check, which requires exactly one
+`scaleway_account_project`, against fixtures the cutover strips it from.
+
+Any change that **inverts a check living in the trusted binary** is unverifiable
+by its own gate until it is merged. The alternatives are all worse: building the
+binary from the PR is the exfiltration path the gate exists to close, and a
+compatibility window is the dual model this arc dropped. The honest handling is
+to know it, say it, and re-run the gate on the next PR after merge.
+
+Nothing leaked. The account was checked directly afterwards: three projects,
+all pre-existing.
+
+## What the run did catch: the gate's own cleanup read the wrong signal
+
+The reap step keyed entirely off `terraform-live.tfstate`, and on a missing one
+reported:
+
+> tofu may have created resources before it was killed. Nothing records them, so
+> reap cannot run. Check the Scaleway account by hand.
+
+Post-cutover that is wrong in the dangerous direction. The project is created
+before tofu starts and the marker is written at the same moment, so a run can
+own a real project and never write state — an apply failing at preflight, init
+or plan does exactly that. **The marker exists if and only if a project does**,
+which makes it both the safer signal and the more precise one: it turns "check
+the account by hand" into a reap that knows what to remove.
+
+The reap step now checks the marker first. This is the same defect the codex
+loop found seven times inside the Go code — a path that had been depending on
+`tofu destroy` owning the project without saying so — and it survived fourteen
+review passes because it lives in YAML.

--- a/docs/status/s168-cutover-canary.md
+++ b/docs/status/s168-cutover-canary.md
@@ -118,3 +118,41 @@ The reap step now checks the marker first. This is the same defect the codex
 loop found seven times inside the Go code — a path that had been depending on
 `tofu destroy` owning the project without saying so — and it survived fourteen
 review passes because it lives in YAML.
+
+## S154 verification: the live lifecycle, end to end against real Scaleway
+
+Run 2026-08-31, same account, ~€0.01. This closes the gap the canary above
+named: `deploy`, `live teardown` and `live reap` had **never** touched real
+Scaleway — only the `test` path had.
+
+| step | result |
+|---|---|
+| `deploy web-live-paris --ttl 30m` | **pass**, 36s — project created before the apply, deployment registered with project id, address and expiry |
+| `curl` the recorded address | **HTTP 200**, serving |
+| `live observe` | **healthy**, recorded against the deployment |
+| `live observe` again | second observation appended, ring intact |
+| `live ls` | `HEALTH` column shows `healthy`; the released deployment shows `unobserved` |
+| `live teardown` | **pass**, 39s — destroy, purge, project delete, sweep |
+| account afterwards | 3 projects (all pre-existing), 1 server, 0 LBs — `openclaw-prod` only |
+
+D6's purge fired here too, in `live teardown`, and reported what it removed.
+
+### What this run did NOT verify
+
+Only the **healthy** observation path ran against real infrastructure.
+`unhealthy` and `unreachable` are unit-covered and were not reproduced against a
+real service, because breaking a live backend on purpose costs more than the
+signal is worth at this stage. Worth stating rather than letting the table imply
+otherwise.
+
+### And the falsehood the plan predicted, demonstrated
+
+The record says `nginx:1.27`. What is actually serving is
+`python3 -m http.server` printing that string, because `ubuntu_jammy` has no
+docker and the fixture never installed one. `deploy` recorded the **declared**
+image without checking what runs.
+
+This is exactly the attribution failure `live-learning-loop-plan.md` decision 4
+warns about — a loop that blamed `nginx:1.27` for a failure here would be
+learning a falsehood. It is now demonstrated rather than asserted, and
+**verifying the running version stays a prerequisite for S155**, not a nicety.

--- a/internal/cli/deploy_command.go
+++ b/internal/cli/deploy_command.go
@@ -306,10 +306,15 @@ func registerDeployment(
 		Address:   address,
 		Image:     sc.Service.Image,
 		Tag:       sc.Service.Tag,
-		State:     livestore.StateLive,
-		WorkDir:   workDir,
-		CreatedAt: now,
-		ExpiresAt: now.Add(ttl),
+		// Snapshotted, not looked up later: the scenario file changes,
+		// this record describes one deployment that already happened
+		// (S154).
+		Port:       sc.Service.Port,
+		HealthPath: sc.Service.HealthPath,
+		State:      livestore.StateLive,
+		WorkDir:    workDir,
+		CreatedAt:  now,
+		ExpiresAt:  now.Add(ttl),
 	}
 
 	if err := store.Put(d); err != nil {

--- a/internal/cli/live_command.go
+++ b/internal/cli/live_command.go
@@ -47,6 +47,13 @@ func newLiveCmd(cfg *rootConfig) *cobra.Command {
 		RunE:  cfg.withRuntime("live forget", runLiveForgetCommand),
 	})
 
+	cmd.AddCommand(&cobra.Command{
+		Use:   "observe",
+		Short: "Probe every live deployment's health path once and record what it saw",
+		Args:  cobra.NoArgs,
+		RunE:  cfg.withRuntime("live observe", runLiveObserveCommand),
+	})
+
 	reap := &cobra.Command{
 		Use:   "reap",
 		Short: "Destroy every live deployment whose TTL has run out",
@@ -104,14 +111,15 @@ func renderLiveTable(out io.Writer, deployments []livestore.Deployment, unreadab
 
 	if len(deployments) > 0 {
 		w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "ID\tSCENARIO\tIMAGE\tSTATE\tTTL\tPROJECT\tADDRESS")
+		fmt.Fprintln(w, "ID\tSCENARIO\tIMAGE\tSTATE\tHEALTH\tTTL\tPROJECT\tADDRESS")
 		for _, d := range deployments {
 			state := string(d.State)
 			if d.Undecodable {
 				state = "UNREADABLE"
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-				d.ID, orDash(d.Scenario), imageRef(d), state, ttlLabel(d, now), orDash(d.ProjectID), orDash(d.Address))
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				d.ID, orDash(d.Scenario), imageRef(d), state, healthLabel(d),
+				ttlLabel(d, now), orDash(d.ProjectID), orDash(d.Address))
 		}
 		if err := w.Flush(); err != nil {
 			return err
@@ -126,6 +134,19 @@ func renderLiveTable(out io.Writer, deployments []livestore.Deployment, unreadab
 	}
 
 	return nil
+}
+
+// healthLabel is the last thing `live observe` saw.
+//
+// Surfaced here because an observation nobody can see is not a signal:
+// without this the only way to learn a live service is failing is to
+// read the JSON record by hand, and nobody does that until after they
+// already know.
+func healthLabel(d livestore.Deployment) string {
+	if len(d.Observations) == 0 {
+		return "unobserved"
+	}
+	return string(d.Observations[len(d.Observations)-1].Status)
 }
 
 // liveListJSON is a listing, not a staged run, so it does not pretend to

--- a/internal/cli/live_observe.go
+++ b/internal/cli/live_observe.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+// runLiveObserveCommand probes every live deployment's health path once
+// and records what it saw against that deployment's record (S154).
+//
+// This is the first signal infrafactory gets from infrastructure after
+// the run that created it has finished. It deliberately does **no
+// learning**: an observation is not a lesson until it is reproduced, and
+// that gate is S156's. What this slice owes the loop is an honest,
+// bounded record of what the service actually did.
+//
+// One probe per deployment per invocation, no retries. Scheduling is the
+// operator's -- a cron entry, the same way `live reap` is scheduled --
+// because a daemon would be a second thing to run and supervise for no
+// signal a cron does not already give.
+func runLiveObserveCommand(cmd *cobra.Command, _ []string, runtime *CommandRuntime) error {
+	store := livestore.NewFilesystemStore(runtime.LiveStoreRoot())
+
+	deployments, unreadable, err := store.List()
+	if err != nil {
+		return &CLIError{Op: "live observe", Code: errorCodeCommandFailed, Err: err}
+	}
+
+	var stages []StageSummary
+	var failures []FailureSummary
+	now := time.Now()
+
+	for _, d := range deployments {
+		stage, failure := observeDeployment(cmd.Context(), runtime, store, d, now)
+		stages = append(stages, stage)
+		if failure != nil {
+			failures = append(failures, *failure)
+		}
+	}
+
+	// Same rule `live ls` applies: a record that will not parse may
+	// describe running infrastructure, so it cannot be observed and
+	// cannot be passed over quietly either.
+	for _, u := range unreadable {
+		stages = append(stages, StageSummary{Layer: "live", Stage: "observe", Status: StageStatusFail})
+		failures = append(failures, FailureSummary{
+			Layer: "live", Stage: "observe", Check: "record",
+			Command: "live observe",
+			Detail: fmt.Sprintf(
+				"a live record could not be read, so whatever it describes went unobserved: %v", u),
+		})
+	}
+
+	status := CommandStatusSuccess
+	if len(failures) > 0 {
+		status = CommandStatusFailed
+	}
+	if err := writeCommandOutput(cmd, OutputResult{
+		Command:  "live observe",
+		Status:   status,
+		Stages:   stages,
+		Failures: failures,
+	}); err != nil {
+		return err
+	}
+
+	if status == CommandStatusFailed {
+		return &CLIError{Op: "live observe", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+			"%d live deployment(s) are not serving", len(failures))}
+	}
+	return nil
+}
+
+// observeDeployment probes one deployment and persists the result.
+//
+// Returns exactly one stage, and a failure when the service is not
+// serving. An unhealthy service is reported rather than swallowed: the
+// whole point of observing is that somebody finds out.
+func observeDeployment(
+	ctx context.Context,
+	runtime *CommandRuntime,
+	store *livestore.FilesystemStore,
+	d livestore.Deployment,
+	now time.Time,
+) (StageSummary, *FailureSummary) {
+	skip := func(detail string) (StageSummary, *FailureSummary) {
+		return StageSummary{
+			Layer: "live", Stage: "observe", Status: StageStatusSkip,
+			Detail: fmt.Sprintf("%s: %s", d.ID, detail),
+		}, nil
+	}
+	fail := func(check, detail string) (StageSummary, *FailureSummary) {
+		return StageSummary{Layer: "live", Stage: "observe", Status: StageStatusFail},
+			&FailureSummary{
+				Layer: "live", Stage: "observe", Check: check,
+				Command: "live observe " + d.ID,
+				Detail:  detail,
+			}
+	}
+
+	// A released deployment is gone by definition; probing its old
+	// address would attribute whatever now answers there to a service
+	// that no longer exists.
+	if d.State == livestore.StateReleased {
+		return skip("released")
+	}
+	if d.Undecodable {
+		return skip("record could not be decoded")
+	}
+
+	// Not skipped for being expired. An expired deployment that is still
+	// answering is a fact worth recording -- it means the reaper has not
+	// run, which is exactly the kind of thing this command exists to
+	// surface.
+	if d.Address == "" || d.Port == 0 {
+		return skip("no address and port recorded, so there is nothing to probe. " +
+			"Deployments created before S154 carry neither")
+	}
+
+	if runtime.Deps.ServiceProbe == nil {
+		return fail("dependency", fmt.Sprintf(
+			"%s could not be observed: no service probe is configured", d.ID))
+	}
+
+	result, err := runtime.Deps.ServiceProbe.Probe(ctx, d.Address, d.Port, d.HealthPath)
+	if err != nil {
+		// The probe could not run, which is not the same as the service
+		// being down and must not be recorded as if it were.
+		return fail("probe", fmt.Sprintf("%s could not be probed: %v", d.ID, err))
+	}
+
+	observation := livestore.Observation{At: now, Detail: result.Detail}
+	switch {
+	case result.Healthy:
+		observation.Status = livestore.ObservationHealthy
+	case result.Reachable:
+		observation.Status = livestore.ObservationUnhealthy
+	default:
+		observation.Status = livestore.ObservationUnreachable
+	}
+
+	d.RecordObservation(observation)
+	if err := store.Put(d); err != nil {
+		// The probe ran and the answer is being lost. Reported rather
+		// than dropped, because a silently unrecorded observation is
+		// indistinguishable from one that never happened -- and S156's
+		// reproduction gate counts observations.
+		return fail("record", fmt.Sprintf(
+			"%s was observed as %s but the result could not be recorded: %v",
+			d.ID, observation.Status, err))
+	}
+
+	if observation.Healthy() {
+		return StageSummary{
+			Layer: "live", Stage: "observe", Status: StageStatusPass,
+			Detail: fmt.Sprintf("%s is serving (%s)", d.ID, d.Address),
+		}, nil
+	}
+
+	return fail(string(observation.Status), fmt.Sprintf("%s: %s", d.ID, observation.Detail))
+}

--- a/internal/cli/live_observe.go
+++ b/internal/cli/live_observe.go
@@ -144,8 +144,28 @@ func observeDeployment(
 		observation.Status = livestore.ObservationUnreachable
 	}
 
-	d.RecordObservation(observation)
-	if err := store.Put(d); err != nil {
+	// Re-read before writing. `live observe` is the command most likely
+	// to be on a cron, so it is the one most likely to be mid-probe when
+	// an operator runs `live teardown` -- and a read-modify-write over a
+	// probe that took seconds would put `state: live` back over a record
+	// teardown had just released, resurrecting a deployment that is
+	// already gone.
+	//
+	// This narrows the window rather than closing it; the store has no
+	// compare-and-swap. Narrowing it to the microseconds around one write
+	// is worth doing, and claiming more than that would be wrong.
+	fresh, err := store.Get(d.ID)
+	if err != nil {
+		return fail("record", fmt.Sprintf(
+			"%s was observed as %s but the record could not be re-read to save it: %v",
+			d.ID, observation.Status, err))
+	}
+	if fresh.State == livestore.StateReleased {
+		return skip("released while it was being probed")
+	}
+
+	fresh.RecordObservation(observation)
+	if err := store.Put(fresh); err != nil {
 		// The probe ran and the answer is being lost. Reported rather
 		// than dropped, because a silently unrecorded observation is
 		// indistinguishable from one that never happened -- and S156's

--- a/internal/cli/live_observe.go
+++ b/internal/cli/live_observe.go
@@ -109,17 +109,34 @@ func observeDeployment(
 	if d.State == livestore.StateReleased {
 		return skip("released")
 	}
+	// Skipped here and FAILED by the unreadable loop in the caller --
+	// List returns an undecodable record in both slices. The skip says
+	// this deployment was not probed; the failure says why, and it is
+	// what makes the command exit non-zero. Neither alone would do both.
 	if d.Undecodable {
-		return skip("record could not be decoded")
+		return skip("record could not be decoded; reported as a failure below")
 	}
 
 	// Not skipped for being expired. An expired deployment that is still
 	// answering is a fact worth recording -- it means the reaper has not
 	// run, which is exactly the kind of thing this command exists to
 	// surface.
-	if d.Address == "" || d.Port == 0 {
-		return skip("no address and port recorded, so there is nothing to probe. " +
-			"Deployments created before S154 carry neither")
+
+	// A LIVE deployment that cannot be probed is a failure, not a skip.
+	//
+	// Skipping read as "nothing to see here" and exited zero, which is
+	// the false green this project refuses everywhere else: the record
+	// says something is running and this command just said it could not
+	// tell. Two ways to get here and both matter -- `registerDeployment`
+	// captures the address best-effort, so an apply that never produced a
+	// load balancer address leaves a live deployment nobody can monitor;
+	// and a record written before S154 carries no port at all.
+	if missing := missingProbeTarget(d); missing != "" {
+		return fail("target", fmt.Sprintf(
+			"%s is live but cannot be observed: %s. Its project %s may be running and unmonitored -- "+
+				"tear it down with `infrafactory live teardown %s`, or if it is already gone clear the "+
+				"record with `infrafactory live forget %s`",
+			d.ID, missing, d.ProjectID, d.ID, d.ID))
 	}
 
 	if runtime.Deps.ServiceProbe == nil {
@@ -183,4 +200,20 @@ func observeDeployment(
 	}
 
 	return fail(string(observation.Status), fmt.Sprintf("%s: %s", d.ID, observation.Detail))
+}
+
+// missingProbeTarget names what the record lacks, or "" when it can be
+// probed. Named rather than inlined so the message says WHICH half is
+// missing: "no address" and "no port" have different causes and
+// different fixes.
+func missingProbeTarget(d livestore.Deployment) string {
+	switch {
+	case d.Address == "" && d.Port == 0:
+		return "it records neither an address nor a port"
+	case d.Address == "":
+		return "it records no address, so the apply never produced one to monitor"
+	case d.Port == 0:
+		return "it records no service port (records written before S154 carry none)"
+	}
+	return ""
 }

--- a/internal/cli/live_observe_test.go
+++ b/internal/cli/live_observe_test.go
@@ -265,3 +265,38 @@ func TestHumanSummaryOmitsTheScenarioLineWhenThereIsNoScenario(t *testing.T) {
 	assert.NotContains(t, spanning, "Scenario:")
 	assert.Contains(t, spanning, "Command: live observe")
 }
+
+// `live observe` is the command most likely to be on a cron, so it is the
+// one most likely to be mid-probe when an operator runs `live teardown`.
+// A read-modify-write over a slow probe would put `state: live` back over
+// a record teardown had just released.
+func TestObserveDoesNotResurrectARecordReleasedWhileItWasProbing(t *testing.T) {
+	rt, store := observeRuntime(t, nil)
+	d := observableDeployment(t, store, "dep-racing")
+
+	// The probe stands in for a slow one: teardown lands while it runs.
+	rt.Deps.ServiceProbe = &releasingProbe{store: store, id: d.ID}
+
+	var out strings.Builder
+	require.NoError(t, runObserve(t, rt, &out))
+
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	assert.Equal(t, livestore.StateReleased, got.State, "the release stands")
+	assert.Empty(t, got.Observations, "and no observation is written over it")
+	assert.Contains(t, out.String(), "released while it was being probed")
+}
+
+// releasingProbe releases the deployment during the probe, reproducing
+// the interleaving without a sleep.
+type releasingProbe struct {
+	store *livestore.FilesystemStore
+	id    string
+}
+
+func (p *releasingProbe) Probe(context.Context, string, int, string) (harness.ServiceProbeResult, error) {
+	if err := p.store.MarkReleased(p.id); err != nil {
+		return harness.ServiceProbeResult{}, err
+	}
+	return harness.ServiceProbeResult{Reachable: true, Healthy: true}, nil
+}

--- a/internal/cli/live_observe_test.go
+++ b/internal/cli/live_observe_test.go
@@ -1,0 +1,267 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redscaresu/infrafactory/internal/harness"
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+type fakeServiceProbe struct {
+	result   harness.ServiceProbeResult
+	err      error
+	calls    int
+	lastAddr string
+	lastPort int
+	lastPath string
+}
+
+func (f *fakeServiceProbe) Probe(_ context.Context, address string, port int, healthPath string) (harness.ServiceProbeResult, error) {
+	f.calls++
+	f.lastAddr, f.lastPort, f.lastPath = address, port, healthPath
+	return f.result, f.err
+}
+
+// observeRuntime builds a runtime whose live store is workspace-scoped,
+// so parallel tests cannot share deployment records.
+func observeRuntime(t *testing.T, probe *fakeServiceProbe) (*CommandRuntime, *livestore.FilesystemStore) {
+	t.Helper()
+	h := newCommandTestHarness(t)
+	rt := &CommandRuntime{
+		livestoreRoot: h.LivestoreRoot(),
+		Deps:          RuntimeDependencies{ServiceProbe: probe},
+	}
+	return rt, livestore.NewFilesystemStore(h.LivestoreRoot())
+}
+
+func observableDeployment(t *testing.T, store *livestore.FilesystemStore, id string) livestore.Deployment {
+	t.Helper()
+	now := time.Now()
+	d := livestore.Deployment{
+		ID:         id,
+		Scenario:   "web-live-paris",
+		ProjectID:  "7c98d82e-ad6d-4f4c-99ea-d1886b0f38e5",
+		Address:    "1.2.3.4",
+		Port:       80,
+		HealthPath: "/healthz",
+		Image:      "nginx",
+		Tag:        "1.27",
+		State:      livestore.StateLive,
+		CreatedAt:  now.Add(-time.Hour),
+		ExpiresAt:  now.Add(time.Hour),
+	}
+	require.NoError(t, store.Put(d))
+	return d
+}
+
+func runObserve(t *testing.T, rt *CommandRuntime, out *strings.Builder) error {
+	t.Helper()
+	cmd := &cobra.Command{Use: "observe"}
+	cmd.Flags().String("output", string(OutputModeHuman), "")
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetContext(context.Background())
+	return runLiveObserveCommand(cmd, nil, rt)
+}
+
+func TestObserveRecordsAHealthyProbeAgainstTheDeployment(t *testing.T) {
+	probe := &fakeServiceProbe{result: harness.ServiceProbeResult{Reachable: true, Healthy: true, Status: 200}}
+	rt, store := observeRuntime(t, probe)
+	d := observableDeployment(t, store, "dep-healthy")
+
+	var out strings.Builder
+	require.NoError(t, runObserve(t, rt, &out))
+
+	// Probed at the address and health path the RECORD carries, not
+	// whatever the scenario file says today.
+	assert.Equal(t, "1.2.3.4", probe.lastAddr)
+	assert.Equal(t, 80, probe.lastPort)
+	assert.Equal(t, "/healthz", probe.lastPath)
+
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	require.Len(t, got.Observations, 1)
+	assert.Equal(t, livestore.ObservationHealthy, got.Observations[0].Status)
+	assert.Empty(t, got.Observations[0].Detail, "a healthy probe has nothing to say")
+}
+
+// An unhealthy service is a finding, not a note. A command that exits
+// zero while something it is watching is down has not observed anything
+// useful.
+func TestObserveReportsAnUnhealthyServiceAsAFailure(t *testing.T) {
+	probe := &fakeServiceProbe{result: harness.ServiceProbeResult{
+		Reachable: true, Status: 503,
+		Detail: "health path http://1.2.3.4:80/healthz returned HTTP 503",
+	}}
+	rt, store := observeRuntime(t, probe)
+	d := observableDeployment(t, store, "dep-sick")
+
+	var out strings.Builder
+	err := runObserve(t, rt, &out)
+
+	require.Error(t, err)
+	assert.Contains(t, out.String(), "HTTP 503")
+
+	got, storeErr := store.Get(d.ID)
+	require.NoError(t, storeErr)
+	require.Len(t, got.Observations, 1)
+	assert.Equal(t, livestore.ObservationUnhealthy, got.Observations[0].Status)
+}
+
+// "It told us it is broken" and "we got no answer" are different facts,
+// and the record has to keep them apart or S156 learns the wrong lesson.
+func TestObserveDistinguishesUnreachableFromUnhealthy(t *testing.T) {
+	probe := &fakeServiceProbe{result: harness.ServiceProbeResult{
+		Detail: "health path http://1.2.3.4:80/healthz is unreachable: connection refused",
+	}}
+	rt, store := observeRuntime(t, probe)
+	d := observableDeployment(t, store, "dep-gone")
+
+	require.Error(t, runObserve(t, rt, &strings.Builder{}))
+
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	require.Len(t, got.Observations, 1)
+	assert.Equal(t, livestore.ObservationUnreachable, got.Observations[0].Status)
+}
+
+// A probe that could not run is not a service that is down, and must not
+// be written to the record as if it were.
+func TestObserveRecordsNothingWhenTheProbeItselfFailed(t *testing.T) {
+	probe := &fakeServiceProbe{err: errors.New("no address recorded")}
+	rt, store := observeRuntime(t, probe)
+	d := observableDeployment(t, store, "dep-unprobeable")
+
+	var out strings.Builder
+	require.Error(t, runObserve(t, rt, &out))
+	assert.Contains(t, out.String(), "could not be probed")
+
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	assert.Empty(t, got.Observations, "an observation that did not happen must not be recorded")
+}
+
+// Probing a released deployment's old address would attribute whatever
+// answers there now to a service that no longer exists.
+func TestObserveSkipsReleasedAndUnprobeableRecords(t *testing.T) {
+	probe := &fakeServiceProbe{result: harness.ServiceProbeResult{Reachable: true, Healthy: true}}
+	rt, store := observeRuntime(t, probe)
+
+	released := observableDeployment(t, store, "dep-released")
+	released.State = livestore.StateReleased
+	require.NoError(t, store.Put(released))
+
+	// A record from before S154 carries no port.
+	legacy := observableDeployment(t, store, "dep-legacy")
+	legacy.Port = 0
+	require.NoError(t, store.Put(legacy))
+
+	var out strings.Builder
+	require.NoError(t, runObserve(t, rt, &out), "skipping is not failing")
+	assert.Zero(t, probe.calls)
+	assert.Contains(t, out.String(), "released")
+	assert.Contains(t, out.String(), "nothing to probe")
+}
+
+// An expired deployment that is still answering means the reaper has not
+// run, which is exactly what this command exists to surface.
+func TestObserveStillProbesAnExpiredDeployment(t *testing.T) {
+	probe := &fakeServiceProbe{result: harness.ServiceProbeResult{Reachable: true, Healthy: true}}
+	rt, store := observeRuntime(t, probe)
+
+	d := observableDeployment(t, store, "dep-overdue")
+	d.ExpiresAt = time.Now().Add(-time.Minute)
+	require.NoError(t, store.Put(d))
+
+	require.NoError(t, runObserve(t, rt, &strings.Builder{}))
+	assert.Equal(t, 1, probe.calls, "still running is still worth recording")
+}
+
+func TestObserveWithNoDeploymentsSucceeds(t *testing.T) {
+	probe := &fakeServiceProbe{}
+	rt, _ := observeRuntime(t, probe)
+
+	assert.NoError(t, runObserve(t, rt, &strings.Builder{}))
+	assert.Zero(t, probe.calls)
+}
+
+// The ring is what stops a permanently broken deployment turning its
+// record into an append-only log that grows until the disk does.
+func TestObservationsAreCappedOldestFirst(t *testing.T) {
+	var d livestore.Deployment
+	for i := 0; i < livestore.MaxObservations+10; i++ {
+		d.RecordObservation(livestore.Observation{
+			At:     time.Unix(int64(i), 0),
+			Status: livestore.ObservationHealthy,
+		})
+	}
+
+	require.Len(t, d.Observations, livestore.MaxObservations)
+	assert.Equal(t, int64(10), d.Observations[0].At.Unix(), "the oldest go first")
+	assert.Equal(t, int64(livestore.MaxObservations+9), d.Observations[len(d.Observations)-1].At.Unix())
+}
+
+// Observations survive the round trip, or the reproduction gate S156
+// builds on them counts nothing.
+func TestObservationsPersistAcrossAReload(t *testing.T) {
+	probe := &fakeServiceProbe{result: harness.ServiceProbeResult{Reachable: true, Healthy: true}}
+	rt, store := observeRuntime(t, probe)
+	d := observableDeployment(t, store, "dep-twice")
+
+	require.NoError(t, runObserve(t, rt, &strings.Builder{}))
+	require.NoError(t, runObserve(t, rt, &strings.Builder{}))
+
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	assert.Len(t, got.Observations, 2, "each pass appends rather than replacing")
+}
+
+// An observation nobody can see is not a signal. Without this column the
+// only way to learn a live service is failing is to read the JSON by
+// hand, which nobody does until they already know.
+func TestLiveListShowsTheLastObservation(t *testing.T) {
+	probe := &fakeServiceProbe{result: harness.ServiceProbeResult{
+		Reachable: true, Status: 503, Detail: "returned HTTP 503",
+	}}
+	rt, store := observeRuntime(t, probe)
+	observableDeployment(t, store, "dep-visible")
+
+	var out strings.Builder
+	require.NoError(t, renderLiveTable(&out, []livestore.Deployment{
+		{ID: "never-probed", State: livestore.StateLive, ExpiresAt: time.Now().Add(time.Hour)},
+	}, nil, time.Now()))
+	assert.Contains(t, out.String(), "HEALTH")
+	assert.Contains(t, out.String(), "unobserved", "a record with no probes says so rather than looking fine")
+
+	require.Error(t, runObserve(t, rt, &strings.Builder{}))
+
+	observed, _, err := store.List()
+	require.NoError(t, err)
+	var table strings.Builder
+	require.NoError(t, renderLiveTable(&table, observed, nil, time.Now()))
+	assert.Contains(t, table.String(), string(livestore.ObservationUnhealthy))
+}
+
+// `live observe` spans every deployment, so it belongs to no one
+// scenario. A blank "Scenario:" line reads as a value that failed to
+// render rather than one that does not apply.
+func TestHumanSummaryOmitsTheScenarioLineWhenThereIsNoScenario(t *testing.T) {
+	withScenario := RenderHumanSummary(OutputResult{
+		Command: "test", Scenario: "block-paris", Status: CommandStatusSuccess,
+	})
+	assert.Contains(t, withScenario, "Scenario: block-paris")
+
+	spanning := RenderHumanSummary(OutputResult{
+		Command: "live observe", Status: CommandStatusSuccess,
+	})
+	assert.NotContains(t, spanning, "Scenario:")
+	assert.Contains(t, spanning, "Command: live observe")
+}

--- a/internal/cli/live_observe_test.go
+++ b/internal/cli/live_observe_test.go
@@ -150,8 +150,9 @@ func TestObserveRecordsNothingWhenTheProbeItselfFailed(t *testing.T) {
 }
 
 // Probing a released deployment's old address would attribute whatever
-// answers there now to a service that no longer exists.
-func TestObserveSkipsReleasedAndUnprobeableRecords(t *testing.T) {
+// answers there now to a service that no longer exists. That one is a
+// genuine skip: there is nothing left to observe.
+func TestObserveSkipsAReleasedDeployment(t *testing.T) {
 	probe := &fakeServiceProbe{result: harness.ServiceProbeResult{Reachable: true, Healthy: true}}
 	rt, store := observeRuntime(t, probe)
 
@@ -159,16 +160,47 @@ func TestObserveSkipsReleasedAndUnprobeableRecords(t *testing.T) {
 	released.State = livestore.StateReleased
 	require.NoError(t, store.Put(released))
 
-	// A record from before S154 carries no port.
-	legacy := observableDeployment(t, store, "dep-legacy")
-	legacy.Port = 0
-	require.NoError(t, store.Put(legacy))
-
 	var out strings.Builder
-	require.NoError(t, runObserve(t, rt, &out), "skipping is not failing")
+	require.NoError(t, runObserve(t, rt, &out), "skipping a released record is not failing")
 	assert.Zero(t, probe.calls)
 	assert.Contains(t, out.String(), "released")
-	assert.Contains(t, out.String(), "nothing to probe")
+}
+
+// A LIVE deployment that cannot be probed is a failure, not a skip. The
+// record says something is running and the command has just admitted it
+// cannot tell -- exiting zero there is the false green this project
+// refuses everywhere else.
+//
+// Both halves reach it from the CURRENT deploy path, not only from old
+// records: registerDeployment captures the address best-effort, so an
+// apply that never produced a load balancer address leaves a live
+// deployment nobody can monitor.
+func TestObserveFailsOnALiveDeploymentItCannotProbe(t *testing.T) {
+	cases := map[string]func(*livestore.Deployment){
+		"no address": func(d *livestore.Deployment) { d.Address = "" },
+		"no port":    func(d *livestore.Deployment) { d.Port = 0 },
+		"neither":    func(d *livestore.Deployment) { d.Address, d.Port = "", 0 },
+	}
+
+	for name, break_ := range cases {
+		t.Run(name, func(t *testing.T) {
+			probe := &fakeServiceProbe{}
+			rt, store := observeRuntime(t, probe)
+			d := observableDeployment(t, store, "dep-unmonitorable")
+			break_(&d)
+			require.NoError(t, store.Put(d))
+
+			var out strings.Builder
+			err := runObserve(t, rt, &out)
+
+			require.Error(t, err, "an unmonitorable live deployment must not exit zero")
+			assert.Zero(t, probe.calls)
+			assert.Contains(t, out.String(), "cannot be observed")
+			// The operator gets the project id and a way out, not just a verdict.
+			assert.Contains(t, out.String(), d.ProjectID)
+			assert.Contains(t, out.String(), "live teardown")
+		})
+	}
 }
 
 // An expired deployment that is still answering means the reaper has not

--- a/internal/cli/output_contract.go
+++ b/internal/cli/output_contract.go
@@ -121,7 +121,12 @@ func RenderHumanSummary(result OutputResult) string {
 
 	var b strings.Builder
 	_, _ = fmt.Fprintf(&b, "Command: %s\n", normalized.Command)
-	_, _ = fmt.Fprintf(&b, "Scenario: %s\n", normalized.Scenario)
+	// Omitted rather than printed empty: `live observe` and `live reap`
+	// span every deployment, so they belong to no one scenario, and a
+	// blank "Scenario:" reads as a value that failed to render.
+	if normalized.Scenario != "" {
+		_, _ = fmt.Fprintf(&b, "Scenario: %s\n", normalized.Scenario)
+	}
 	_, _ = fmt.Fprintf(&b, "Status: %s\n", normalized.Status)
 
 	if len(normalized.Stages) > 0 {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -54,6 +54,13 @@ type RunProjectManager interface {
 	Delete(ctx context.Context, secretKey, projectID string) error
 }
 
+// ServiceProbeRunner checks a live deployment's health path. Separate
+// from RealProbeHarnessRunner because it runs out-of-band, against an
+// address recorded earlier, with no run in progress (S154).
+type ServiceProbeRunner interface {
+	Probe(ctx context.Context, address string, port int, healthPath string) (harness.ServiceProbeResult, error)
+}
+
 // OrphanSweepRunner verifies, against the real API, that a Layer 3 run
 // left nothing billable behind. For Layer 3 this -- not mockway state --
 // is what satisfies a `destruction: no_orphans` criterion.
@@ -91,6 +98,7 @@ type RuntimeDependencies struct {
 	AutoCreated    AutoCreatedPurgeRunner
 	OrphanSweep    OrphanSweepRunner
 	RunProject     RunProjectManager
+	ServiceProbe   ServiceProbeRunner
 	RealProbe      RealProbeHarnessRunner
 	MockState      harness.MockStateClient
 	MockStart      MockStarter
@@ -411,6 +419,10 @@ func buildRuntime(cmd *cobra.Command, opts runtimeOptions) (*CommandRuntime, err
 	}
 	if deps.RunProject == nil {
 		deps.RunProject = harness.NewScalewayRunProject(runProjectTimeout)
+	}
+	if deps.ServiceProbe == nil {
+		deps.ServiceProbe = harness.NewServiceProbe(
+			time.Duration(cfg.Validation.RealProbes.TimeoutSeconds) * time.Second)
 	}
 	if deps.OrphanSweep == nil {
 		deps.OrphanSweep = harness.NewScalewayOrphanSweep(

--- a/internal/harness/service_probe.go
+++ b/internal/harness/service_probe.go
@@ -1,0 +1,154 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ServiceProbeResult is what one probe of a live service's health path
+// concluded.
+//
+// Reachable and Healthy are separate because the difference matters
+// downstream: "we could not reach it" and "it answered and said it is
+// broken" are different facts about the world, and a learning loop that
+// collapses them learns the wrong lesson (S154).
+type ServiceProbeResult struct {
+	Reachable bool
+	Healthy   bool
+	// Status is the HTTP status when the service answered, zero when it
+	// did not.
+	Status int
+	// Detail is the reason, phrased for the pitfall extractors that
+	// eventually consume it. Empty when healthy.
+	Detail string
+}
+
+// ServiceProbe checks a live deployment's health path.
+//
+// Separate from RealProbeHarness on purpose. That one runs inside a run,
+// against the plan it just applied, with retries tuned to an apply that
+// has only just finished. This one runs out-of-band against an address
+// recorded minutes or hours ago, and a retry here would smear over
+// exactly the flapping it exists to notice: one probe, one observation.
+type ServiceProbe struct {
+	doer    func(*http.Request) (*http.Response, error)
+	timeout time.Duration
+}
+
+// NewServiceProbe builds a probe with its own client, so a hung service
+// cannot outlive the probe that found it.
+func NewServiceProbe(timeout time.Duration) *ServiceProbe {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	client := &http.Client{
+		Timeout: timeout,
+		// A health path that redirects has not answered the question
+		// asked, and following the redirect could leave the account's
+		// own network entirely. Report the 3xx as-is.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	return &ServiceProbe{doer: client.Do, timeout: timeout}
+}
+
+// NewServiceProbeWithDoer is the test seam.
+func NewServiceProbeWithDoer(doer func(*http.Request) (*http.Response, error)) *ServiceProbe {
+	return &ServiceProbe{doer: doer, timeout: 10 * time.Second}
+}
+
+// Probe requests healthPath on address:port once.
+//
+// Any 2xx is healthy. Everything else the service says is unhealthy, and
+// anything that stops the request reaching it is unreachable.
+func (p *ServiceProbe) Probe(ctx context.Context, address string, port int, healthPath string) (ServiceProbeResult, error) {
+	target, err := serviceProbeURL(address, port, healthPath)
+	if err != nil {
+		return ServiceProbeResult{}, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return ServiceProbeResult{}, fmt.Errorf("build health request for %s: %w", target, err)
+	}
+
+	resp, err := p.doer(req)
+	if err != nil {
+		// Not an error return: "unreachable" is a successful
+		// observation, not a failure to observe. Returning an error
+		// here would make the caller unable to tell a service that is
+		// down from a probe that never ran.
+		return ServiceProbeResult{
+			Detail: fmt.Sprintf("health path %s is unreachable: %v", target, err),
+		}, nil
+	}
+	defer func() {
+		// Drained so the connection can be reused, and bounded so a
+		// service answering with a firehose cannot exhaust memory here.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		_ = resp.Body.Close()
+	}()
+
+	result := ServiceProbeResult{Reachable: true, Status: resp.StatusCode}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		result.Healthy = true
+		return result, nil
+	}
+
+	result.Detail = fmt.Sprintf("health path %s returned HTTP %d", target, resp.StatusCode)
+	return result, nil
+}
+
+// serviceProbeURL refuses anything it cannot turn into a plain http URL
+// rather than guessing, because the address comes off a stored record and
+// a malformed one must not be probed as if it were something else.
+func serviceProbeURL(address string, port int, healthPath string) (string, error) {
+	host := strings.TrimSpace(address)
+	if host == "" {
+		return "", fmt.Errorf("no address recorded, so there is nothing to probe")
+	}
+	if port < 1 || port > 65535 {
+		return "", fmt.Errorf("port %d is not a valid service port", port)
+	}
+
+	raw := strings.TrimSpace(healthPath)
+	if raw == "" {
+		raw = "/"
+	}
+
+	// Parsed BEFORE the leading slash is added, not after. Normalising
+	// first turns "http://elsewhere.example/health" into the harmless-
+	// looking path "/http:/elsewhere.example/health", which passes a
+	// scheme-and-host check that never sees a scheme or a host -- so the
+	// probe would quietly request something nobody asked for.
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("health path %q is not a valid path: %w", healthPath, err)
+	}
+	if parsed.Scheme != "" || parsed.Host != "" || parsed.Opaque != "" {
+		return "", fmt.Errorf("health path %q must be a path, not a URL", healthPath)
+	}
+
+	path := parsed.Path
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	return (&url.URL{
+		Scheme:   "http",
+		Host:     net.JoinHostPort(host, strconv.Itoa(port)),
+		Path:     path,
+		RawQuery: parsed.RawQuery,
+	}).String(), nil
+}

--- a/internal/harness/service_probe_test.go
+++ b/internal/harness/service_probe_test.go
@@ -1,0 +1,118 @@
+package harness
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceProbeURLBuildsFromTheRecord(t *testing.T) {
+	cases := map[string]struct{ address, path, want string }{
+		"plain":         {"1.2.3.4", "/healthz", "http://1.2.3.4:80/healthz"},
+		"empty path":    {"1.2.3.4", "", "http://1.2.3.4:80/"},
+		"missing slash": {"1.2.3.4", "healthz", "http://1.2.3.4:80/healthz"},
+		"query kept":    {"1.2.3.4", "/healthz?deep=1", "http://1.2.3.4:80/healthz?deep=1"},
+		"ipv6":          {"2001:db8::1", "/", "http://[2001:db8::1]:80/"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := serviceProbeURL(tc.address, 80, tc.path)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// The address and path come off a stored record, so a malformed one must
+// be refused rather than probed as if it were something else.
+func TestServiceProbeURLRefusesWhatItCannotBuild(t *testing.T) {
+	_, err := serviceProbeURL("", 80, "/")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nothing to probe")
+
+	for _, port := range []int{0, -1, 70000} {
+		_, err := serviceProbeURL("1.2.3.4", port, "/")
+		require.Error(t, err, "port %d", port)
+	}
+
+	// A health path carrying its own host would send the probe somewhere
+	// else entirely and record the answer against this deployment.
+	_, err = serviceProbeURL("1.2.3.4", 80, "http://elsewhere.example/health")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a path")
+}
+
+func TestProbeTreatsAny2xxAsHealthy(t *testing.T) {
+	for _, status := range []int{http.StatusOK, http.StatusNoContent, 299} {
+		probe := NewServiceProbeWithDoer(func(*http.Request) (*http.Response, error) {
+			return jsonResponse(status, `{}`), nil
+		})
+
+		result, err := probe.Probe(context.Background(), "1.2.3.4", 80, "/")
+
+		require.NoError(t, err)
+		assert.True(t, result.Healthy, "status %d", status)
+		assert.True(t, result.Reachable)
+		assert.Empty(t, result.Detail, "a healthy probe has nothing to say")
+	}
+}
+
+// Answering wrongly and not answering at all are different facts about
+// the world, and a learning loop that collapses them learns the wrong
+// lesson.
+func TestProbeSeparatesUnhealthyFromUnreachable(t *testing.T) {
+	unhealthy := NewServiceProbeWithDoer(func(*http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusServiceUnavailable, `{}`), nil
+	})
+	result, err := unhealthy.Probe(context.Background(), "1.2.3.4", 80, "/")
+	require.NoError(t, err)
+	assert.True(t, result.Reachable, "the service answered")
+	assert.False(t, result.Healthy)
+	assert.Equal(t, http.StatusServiceUnavailable, result.Status)
+	assert.Contains(t, result.Detail, "HTTP 503")
+
+	unreachable := NewServiceProbeWithDoer(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("dial tcp: connection refused")
+	})
+	result, err = unreachable.Probe(context.Background(), "1.2.3.4", 80, "/")
+	// Not an error: "unreachable" is a successful observation, not a
+	// failure to observe. An error return would make the caller unable to
+	// tell a service that is down from a probe that never ran.
+	require.NoError(t, err)
+	assert.False(t, result.Reachable)
+	assert.False(t, result.Healthy)
+	assert.Contains(t, result.Detail, "unreachable")
+	assert.Contains(t, result.Detail, "connection refused")
+}
+
+// A URL it cannot build is a failure to observe, and must be
+// distinguishable from a service that is down.
+func TestProbeErrorsRatherThanReportingAnUnbuildableTargetAsDown(t *testing.T) {
+	probe := NewServiceProbeWithDoer(func(*http.Request) (*http.Response, error) {
+		t.Fatal("must not reach the network with an unbuildable target")
+		return nil, nil
+	})
+
+	_, err := probe.Probe(context.Background(), "", 80, "/")
+
+	require.Error(t, err)
+}
+
+// A health path that redirects has not answered the question asked, and
+// following it could leave the account's network entirely.
+func TestProbeDoesNotFollowRedirects(t *testing.T) {
+	probe := NewServiceProbeWithDoer(func(*http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusFound, `{}`), nil
+	})
+
+	result, err := probe.Probe(context.Background(), "1.2.3.4", 80, "/")
+
+	require.NoError(t, err)
+	assert.False(t, result.Healthy, "a 302 is not a service that is serving")
+	assert.Equal(t, http.StatusFound, result.Status)
+}

--- a/internal/livestore/livestore.go
+++ b/internal/livestore/livestore.go
@@ -75,12 +75,76 @@ type Deployment struct {
 	// strays would be recomputed from.
 	SweepVerificationFailed bool `json:"sweep_verification_failed,omitempty"`
 
+	// Port and HealthPath are the service's own, snapshotted at deploy
+	// time rather than re-read from the scenario when a probe runs. The
+	// scenario is a file that changes; this record describes one
+	// deployment that already happened, and an observation attributed to
+	// a health path the deployment never had is worse than no
+	// observation (S154).
+	Port       int    `json:"port,omitempty"`
+	HealthPath string `json:"health_path,omitempty"`
+
+	// Observations are what `live observe` saw, oldest first, capped at
+	// MaxObservations. A live service can fail every probe forever, so
+	// the record cannot grow with it -- the corpus this eventually feeds
+	// has never faced a firehose, and the cap is where that starts.
+	Observations []Observation `json:"observations,omitempty"`
+
 	// Undecodable marks a record the store could not parse. It is never
 	// persisted: it exists so an unreadable file still reaches the
 	// reaper as a deployment rather than only as a log line. ADR-0024
 	// rule 3 says unreadable means expired, and a record that never
 	// entered the reapable set did not honour that.
 	Undecodable bool `json:"-"`
+}
+
+// ObservationStatus is what one probe of a live service concluded.
+type ObservationStatus string
+
+const (
+	// ObservationHealthy means the health path answered as expected.
+	ObservationHealthy ObservationStatus = "healthy"
+	// ObservationUnhealthy means the service answered, and answered
+	// wrongly -- a 503, say. The service is up and not working.
+	ObservationUnhealthy ObservationStatus = "unhealthy"
+	// ObservationUnreachable means the probe got no answer at all.
+	// Deliberately distinct from unhealthy: "we could not reach it" and
+	// "it told us it is broken" are different facts, and collapsing them
+	// would teach the wrong lesson downstream.
+	ObservationUnreachable ObservationStatus = "unreachable"
+)
+
+// MaxObservations bounds the ring kept on a record.
+//
+// A failing deployment emits one of these per probe for as long as it
+// lives, so this is the difference between a record and an append-only
+// log that grows until the disk does. Fifty is comfortably more than the
+// reproduction window S156 needs and small enough that a record stays
+// readable by a human.
+const MaxObservations = 50
+
+// Observation is one probe of one deployment's health path.
+type Observation struct {
+	At     time.Time         `json:"at"`
+	Status ObservationStatus `json:"status"`
+	// Detail is the reason, in the shape the pitfall extractors already
+	// take. Empty on a healthy probe: there is nothing to say.
+	Detail string `json:"detail,omitempty"`
+}
+
+// Healthy is the only status that means the service is working. Written
+// as an allow-list rather than `!= unhealthy` so a status added later is
+// not silently treated as fine.
+func (o Observation) Healthy() bool {
+	return o.Status == ObservationHealthy
+}
+
+// RecordObservation appends to the ring, dropping the oldest when full.
+func (d *Deployment) RecordObservation(o Observation) {
+	d.Observations = append(d.Observations, o)
+	if len(d.Observations) > MaxObservations {
+		d.Observations = d.Observations[len(d.Observations)-MaxObservations:]
+	}
 }
 
 // Expired reports whether the deployment's TTL has run out. A zero


### PR DESCRIPTION
> **Draft on purpose.** This is the content of #178, which was merged by accident before review and then reverted in #179. It stays a draft until it has passed the same bar the cutover did: **two consecutive codex passes with nothing substantive flagged.** Codex has been rate-limited all afternoon; two attempts died mid-run.

Rebased onto the merged cutover, so the diff is now only this slice's own three commits.

Closes S154 of `docs/plans/live-learning-loop-plan.md`.

## What it does

`infrafactory live observe` probes every live deployment's health path once and records what it saw on that deployment's record.

**No learning, deliberately.** An observation is not a lesson until it is reproduced, and that gate is S156's. What this slice owes the loop is an honest, bounded record of what the service actually did.

Four decisions, each a place a later slice could quietly get it wrong — all recorded in ADR-0024:

- **`unhealthy` and `unreachable` are distinct statuses.** "It answered and said it is broken" and "we got no answer" are different facts about the world. S156's promotion gate groups by normalized detail, so collapsing them would put two different failures in one bucket and teach the wrong lesson from both.
- **A probe that could not run records nothing.** A malformed address is a failure to *observe*, not an observation of failure, and the reproduction gate must never count it.
- **Port and health path are snapshotted at deploy time.** The scenario file changes; this record describes one deployment that already happened, and an observation attributed to a health path that deployment never had is worse than none.
- **Observations are a bounded ring** (`MaxObservations = 50`). A permanently broken deployment emits one per probe for as long as it lives — the plan's unbounded-signal risk, one slice earlier than it expected.

One probe per invocation, no retries: `RealProbeHarness` retries because it runs seconds after an apply; this runs out-of-band, and a retry would smear over exactly the flapping it exists to notice. Scheduling stays a cron, like `live reap`'s.

`live ls` grew a `HEALTH` column — an observation nobody can see is not a signal.

## Also here: the gate's reap step read the wrong signal

`df218b5`. The `layer3-gate` workflow keyed cleanup off `terraform-live.tfstate` and, when there wasn't one, told the operator *"nothing records them, so reap cannot run — check the account by hand"*. Post-cutover a run can own a real project and never write state, and the marker exists **iff** a project does. It checks the marker first now.

Same defect class the cutover's loop found seven times in Go. It survived all fourteen passes **because it lives in YAML.**

## Verified against real Scaleway

~€0.01, and it closed a gap the cutover canary named: `deploy` and `live teardown` had **never** touched real Scaleway.

deploy (36s) → **HTTP 200** at the recorded address → `live observe` healthy → observe again, appended → `live ls` shows `HEALTH` → `live teardown` (39s) → account clean: 3 pre-existing projects, 1 server, 0 LBs.

**Only the healthy path ran for real.** `unhealthy` and `unreachable` are unit-covered and were not reproduced against a live service.

### The falsehood the plan predicted, now demonstrated

The record says `nginx:1.27`. What is actually serving is `python3 -m http.server` printing that string — `ubuntu_jammy` has no docker. `deploy` records the **declared** image without checking what runs. A loop that blamed `nginx:1.27` here would be learning something false, which makes verifying the running version a hard prerequisite for S155.

## One bug found by self-review

`7097ee1`. `observe` is the command most likely to be on a cron, so it is the one most likely to be mid-probe when an operator runs `live teardown` — a read-modify-write spanning a slow probe would put `state: live` back over a record just released. It re-reads before writing now. **This narrows the window rather than closing it**; the store has no compare-and-swap, and neither the comment nor the ADR claims otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD