### PR TITLE
Retest the NIC blocker: it moved from Layer 1/3 to Layer 2

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,27 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- 🔬 **The NIC blocker retested — it moved, and narrowed (2026-08-31)** — the
+  claim that `scaleway_instance_private_nic` is refused by the API with a 403 was
+  written before `PrivateNetworksFullAccess` and before the cutover, and **nothing
+  had ever applied one**: the arc's only instance-bearing scenario,
+  `lb-serving-paris`, declares no NIC. So it was folklore. Measured instead:
+
+  - **Real Scaleway applies it.** `state: available`, attached, in the run's own
+    project. The contradiction ADR-0025 was written to end is genuinely gone.
+  - **The mock does not.** `501 Not Implemented: POST
+    /instance/v2alpha1/zones/{zone}/private-network-interfaces` — and Layer 3 runs
+    only `if deployErr == nil`, so a failed mock apply stops it. Every compute
+    scenario is now blocked at **Layer 2**, not Layer 1 or 3.
+
+  Two readings corrected along the way, both from inferring rather than running:
+  "mockway has no private networks" (it has full CRUD on `/vpc/v1` and `/vpc/v2`;
+  my HCL was missing an explicit `scaleway_vpc`), and the 403 claim itself.
+
+  Next slice is small and named: `POST`/`GET`/`DELETE` for
+  `private-network-interfaces` in mockway. Detail:
+  [docs/layer3-coverage.md](layer3-coverage.md).
+
 - 🌱 **S154 SHIPPED — `live observe`, the first post-apply signal (2026-08-31)** —
   probes every live deployment's health path once and records what it saw on that
   deployment's record. **No learning yet, deliberately**: an observation is not a

--- a/docs/layer3-coverage.md
+++ b/docs/layer3-coverage.md
@@ -19,12 +19,15 @@
 > instance server and Layer 3 could not apply one. The gates contradicted each
 > other.
 >
-> **RESOLVED 2026-08-31 by the S166+S167 cutover (ADR-0025).** The run's project
-> is created through the Account API before the apply and handed to the provider
-> as the default, so the NIC lands in the same project as its server. Verified
-> against real Scaleway: [docs/status/s168-cutover-canary.md](status/s168-cutover-canary.md).
-> The "waits on IPAM" lines below are stale in their *reason*; whether each
-> scenario is runnable is a costing question again, not a blocked one.
+> **RESOLVED 2026-08-31 by the S166+S167 cutover (ADR-0025)**, and *measured*
+> rather than assumed — see "The NIC blocker, retested" below. A private NIC now
+> applies against real Scaleway and reaches `state: available`.
+>
+> **A different, narrower blocker took its place**, and every "waits on IPAM"
+> line below is stale in its reason: `mockway` returns **501** for
+> `POST /instance/v2alpha1/zones/{zone}/private-network-interfaces`, and Layer 3
+> only runs when the mock apply succeeded. So the constraint is now a mock gap
+> with a known endpoint, not a contradiction between gates.
 
 
 Audit date: 2026-08-24. **Refreshed** after `scaleway_instance_ip` and
@@ -56,17 +59,49 @@ A scenario reaches the real API only if **both** allow it:
    `BlockStorageFullAccess`, `LoadBalancersFullAccess`, `VPCFullAccess`,
    `InstancesFullAccess`. Nothing else (ADR-0023, credential amendments).
 
-They do not agree, deliberately. Four allowlisted entries —
-`scaleway_iam*`, `scaleway_registry_namespace`, `scaleway_domain*` and
-`scaleway_instance_private_nic` — pass the local check and are then refused
-by the API with a 403. That looks like a bug if you do not know it; it is
-the credential doing its job.
+They do not agree, deliberately. Three allowlisted entries —
+`scaleway_iam*`, `scaleway_registry_namespace` and `scaleway_domain*` —
+pass the local check and are then refused by the API with a 403. That looks
+like a bug if you do not know it; it is the credential doing its job, and
+all three are least-privilege choices.
 
-The first three are least-privilege choices. The fourth is not: private
-NICs are allowlisted only because `policies/scaleway/vpc_required.rego`
-denies any instance server without one, so omitting them would leave
-static policy demanding a resource the allowlist forbids — unsatisfiable
-by any generated HCL. It waits on private networking becoming applicable at all (see the retraction at the top), not on `IPAMFullAccess`.
+`scaleway_instance_private_nic` **used to be a fourth** and is not any more.
+It was allowlisted only because `policies/scaleway/vpc_required.rego` denies
+any instance server without one, so omitting it would have left static
+policy demanding a resource the allowlist forbade. It now applies for real
+(below), so the allowlist entry earns its place.
+
+## The NIC blocker, retested (2026-08-31)
+
+The claim above — that a private NIC is refused with a 403 — was written
+before `PrivateNetworksFullAccess` was granted and before the cutover, and
+**nothing had ever actually applied one.** The one scenario with an instance
+(`lb-serving-paris`) declares no NIC at all, so no canary in this arc
+exercised it. Retested directly, because a claim about the API that nobody
+has asked the API is folklore.
+
+| question | answer |
+|---|---|
+| Does a private NIC apply against real Scaleway? | **Yes.** `state: available`, attached to the server, inside the run's own project |
+| Does it apply against the mock? | **No** — `501 Not Implemented: POST /instance/v2alpha1/zones/{zone}/private-network-interfaces` |
+| Can a NIC-bearing scenario reach Layer 3 via `test`? | **No.** Layer 3 runs only `if deployErr == nil && sandboxEnabled` — a failed mock apply stops it |
+| Via `deploy`? | **Yes** — `deploy` skips Layer 2 entirely, which is how the above was measured |
+
+Two corrections to earlier readings, both from inferring instead of running:
+
+- A first attempt failed with `resource with ID  is not found` on the
+  private network, and the obvious reading — "mockway has no private
+  network support" — was **wrong**. It implements the full CRUD on
+  `/vpc/v1` and `/vpc/v2`; the HCL was simply missing an explicit
+  `scaleway_vpc` for the network to sit in.
+- mockway also already answers `ListPrivateNetworkInterfacesV2`. What it
+  lacks is exactly one verb on one path: **create**.
+
+So the next slice on this path is small and well defined: implement
+`POST` (and `GET`/`DELETE`) for
+`/instance/v2alpha1/zones/{zone}/private-network-interfaces` in mockway.
+Until then, every Scaleway compute scenario is blocked at **Layer 2**, not
+at Layer 1 or Layer 3, and `deploy` is the only route to a real NIC.
 
 ## Coverage
 


### PR DESCRIPTION
Docs only. No code changes.

`docs/layer3-coverage.md` claimed `scaleway_instance_private_nic` passes the allowlist and is then refused by the API with a **403**. That was written before `PrivateNetworksFullAccess` was granted and before the cutover — and **nothing had ever applied one.** `lb-serving-paris`, this arc's only instance-bearing scenario, declares no NIC, so no canary ever exercised it.

A claim about the API that nobody has asked the API is folklore. So it was measured.

| question | answer |
|---|---|
| Does a private NIC apply against real Scaleway? | **Yes** — `state: available`, attached to the server, inside the run's own project |
| Against the mock? | **No** — `501 Not Implemented: POST /instance/v2alpha1/zones/{zone}/private-network-interfaces` |
| Can a NIC-bearing scenario reach Layer 3 via `test`? | **No** — Layer 3 runs only `if deployErr == nil && sandboxEnabled` |
| Via `deploy`? | **Yes** — it skips Layer 2, which is how the above was measured |

## What this changes

**The contradiction ADR-0025 was written to end is genuinely gone**, now with evidence rather than inference. A different and much narrower blocker took its place: every Scaleway compute scenario is stopped at **Layer 2**, not at Layer 1 or Layer 3.

That makes the next slice small and named: `POST`/`GET`/`DELETE` for `private-network-interfaces` in mockway. It already answers `ListPrivateNetworkInterfacesV2`; what it lacks is exactly one verb on one path.

## Two readings corrected on the way, both from inferring instead of running

- A first attempt failed with `resource with ID  is not found` on the private network, and the obvious reading — *"mockway has no private network support"* — was **wrong**. It implements full CRUD on `/vpc/v1` and `/vpc/v2`; my HCL was missing an explicit `scaleway_vpc` for the network to sit in.
- The 403 claim itself, which had survived in the coverage doc since 2026-08-24.

Both are written into the doc rather than quietly fixed, because the pattern is the point: this arc has now produced four wrong diagnoses from reading configuration instead of running something.

## Cost and cleanliness

~€0.01. Account verified directly afterwards: 3 projects (all pre-existing), 1 server, 0 load balancers — `openclaw-prod` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD