### PR TITLE
S155a: verify the running version, because the record only states intent

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -32,6 +32,13 @@ Last updated: 2026-08-31
   in a partial body proves nothing. Every `unchecked` also carries its reason, so
   a declared-but-unreachable path no longer prints "no version_path declared".
 
+  Pass 48 then caught a regression pass 47 had introduced: reading the body head
+  meant editing the `defer` beside it, and the response drain lost its bound. It
+  would have shown up as slowness rather than a hang — `live observe` probes
+  every deployment in turn, so one streaming body delays all the ones behind it.
+  **An incidental edit inside a fix is still an edit**, and under a one-clean-pass
+  rule those are the ones that survive, because attention is on the finding.
+
   **Verified against real Scaleway** by deploying a service that contradicts its
   own record: `the record claims nginx:1.27 but / does not mention "1.27"`. Along
   the way it also confirmed pass 44's fix on real infrastructure — a deployment

--- a/STATUS.md
+++ b/STATUS.md
@@ -24,6 +24,14 @@ Last updated: 2026-08-31
   even when the service is perfectly healthy — that is the more dangerous case,
   because it looks fine.
 
+  **Pass 47 caught the slice violating its own doctrine**: a truncated or
+  unreadable body was compared anyway, so a partial response could be called a
+  mismatch — claiming a contradiction on evidence nobody fully gathered, which is
+  the same error as treating unchecked as confirmed. The asymmetry is explicit
+  now: *finding* the tag proves it is there whatever was cut off; *not* finding it
+  in a partial body proves nothing. Every `unchecked` also carries its reason, so
+  a declared-but-unreachable path no longer prints "no version_path declared".
+
   **Verified against real Scaleway** by deploying a service that contradicts its
   own record: `the record claims nginx:1.27 but / does not mention "1.27"`. Along
   the way it also confirmed pass 44's fix on real infrastructure — a deployment

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,32 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- 🔍 **S155a: the record states intent; only the service states fact (2026-08-31)** —
+  `deploy` records the **declared** image and tag, and the canary showed how far
+  that drifts: the record said `nginx:1.27` while the instance served
+  `python3 -m http.server`. An upgrade to a version nobody confirmed is running
+  proves nothing, so this is S155's prerequisite rather than a nicety.
+
+  A scenario may now declare `service.version_path`. `live observe` probes it
+  separately from health and records one of **three** states — deliberately not
+  two. `unchecked` (nothing was asked) and `unconfirmed` (we asked and the
+  service did not confirm) are different facts, and treating the first as
+  confirmation is the falsehood this exists to stop. A probe that fails is
+  `unchecked`, never `unconfirmed`: claiming a contradiction on evidence nobody
+  gathered is the same error in the other direction.
+
+  The check is **deliberately weak and deliberately stated**: the response must
+  *mention* the tag. That verifies a cooperating service and cannot verify an
+  uncooperative one, which is why declaring the path is opt-in. A mismatch fails
+  even when the service is perfectly healthy — that is the more dangerous case,
+  because it looks fine.
+
+  **Verified against real Scaleway** by deploying a service that contradicts its
+  own record: `the record claims nginx:1.27 but / does not mention "1.27"`. Along
+  the way it also confirmed pass 44's fix on real infrastructure — a deployment
+  with no load balancer produced no address, and `observe` refused it rather than
+  reporting clean.
+
 - 🔬 **The NIC blocker retested — it moved, and narrowed (2026-08-31)** — the
   claim that `scaleway_instance_private_nic` is refused by the API with a 403 was
   written before `PrivateNetworksFullAccess` and before the cutover, and **nothing

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -416,3 +416,27 @@ address writes exactly that record today. Reporting it as a skip meant the
 command said "all is well" about a deployment it had just admitted it could not
 see. Only a **released** deployment skips, because only there is nothing left to
 observe.
+
+## Amendment, 2026-08-31 (S155a): the record states intent, not fact
+
+`deploy` records the image and tag a scenario **declares**. That is a claim about
+what was asked for, and the 2026-08-31 canary measured the gap: the record said
+`nginx:1.27` while the instance served `python3 -m http.server`.
+
+A scenario may declare `service.version_path`, which `live observe` probes
+separately from health. Three decisions worth holding:
+
+- **Three states, not two.** `unchecked` means nothing was asked; `unconfirmed`
+  means the service answered and did not confirm. Treating the first as
+  confirmation is precisely the falsehood this exists to prevent, and a probe
+  that fails is `unchecked` — claiming a contradiction on evidence nobody
+  gathered is the same error inverted.
+- **The check is weak on purpose, and says so.** The response must *mention* the
+  tag. That verifies a cooperating service and cannot verify an uncooperative
+  one, which is why the path is opt-in rather than assumed.
+- **A mismatch fails a healthy deployment.** A service that answers perfectly
+  while running something else is the more dangerous case, because nothing else
+  in the system will notice.
+
+This is S155's prerequisite: an upgrade to a version nobody confirmed is running
+proves nothing.

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -440,3 +440,11 @@ separately from health. Three decisions worth holding:
 
 This is S155's prerequisite: an upgrade to a version nobody confirmed is running
 proves nothing.
+
+The evidence rule is asymmetric, and pass 47 found the slice breaking it.
+**Finding** the tag in a truncated body proves the tag is there; **not** finding
+it proves nothing, because the rest was never read. So a partial or unreadable
+response is `unchecked`, and only a complete one can produce `unconfirmed`.
+Every `unchecked` carries the reason it was not checked — "no version_path
+declared" is a lie for a declared path that could not be reached, and that
+distinction is the whole point of having three states.

--- a/docs/review-passes/pass47.md
+++ b/docs/review-passes/pass47.md
@@ -1,0 +1,49 @@
+# Codex review pass 47 — S155a verify the running version
+
+Two findings, both accepted. Both are the **stated doctrine of this slice,
+violated by the slice itself.**
+
+## [P2] A mismatch could be called on a partial body
+
+`ServiceProbe` read a bounded body and discarded the read error. So a truncated
+or failed read produced a partial body, and `strings.Contains` on it reported
+**unconfirmed** for a service that would have confirmed.
+
+That is precisely the error the slice was written against, inverted. The ADR
+says a probe that fails is `unchecked`, never `unconfirmed`, because *claiming a
+contradiction on evidence nobody gathered* is as wrong as treating unchecked as
+confirmation. A partial body is evidence nobody fully gathered.
+
+Fixed with `ServiceProbeResult.BodyComplete`, and the asymmetry made explicit:
+
+- **finding** the tag proves it is there, whatever was cut off → `confirmed`
+- **not finding** it in a partial body proves nothing → `unchecked`
+
+The probe reads one byte past the limit so hitting it is distinguishable from a
+body that merely ends there.
+
+## [P2] "no version_path declared" was a lie for a declared path
+
+A healthy deployment whose declared version path was unreachable printed
+`running version unchecked (no version_path declared)` — misstating the case,
+and hiding exactly the distinction this slice adds.
+
+`checkRunningVersion` now returns a reason with every `unchecked`, and the pass
+line prints it: `/version is unreachable`, `the record names no tag to check
+against`, `its response was truncated or unreadable`.
+
+## What the test fake caught
+
+The existing `versionProbe` did not set `BodyComplete`, so the mismatch test
+failed the moment the field existed. That is the fix working: a fake must now
+state whether its evidence is complete, which makes a test that asserts a
+contradiction declare the evidence it is asserting from.
+
+## Re-reading against the class, per the one-pass rule
+
+Class: *concluding more than the evidence supports*. The other conclusions in
+this path were checked — `Healthy` is set only from an actual 2xx, `Reachable`
+only from an actual response, and the `unchecked`-on-probe-error path already
+refused to conclude. The body was the one place a conclusion outran its input.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass48.md
+++ b/docs/review-passes/pass48.md
@@ -1,0 +1,25 @@
+# Codex review pass 48 — S155a
+
+One finding, accepted. **A regression pass 47 introduced.**
+
+## [P2] The response drain lost its bound
+
+Reading the body head meant editing the `defer` beside it, and in doing so
+`io.Copy(io.Discard, io.LimitReader(resp.Body, maxProbeBodyBytes))` became
+`io.Copy(io.Discard, resp.Body)`.
+
+The drain exists so the connection can be reused. Unbounded, a streaming or very
+large response spends the probe's entire timeout budget being thrown away — and
+`live observe` probes every live deployment in turn, so one slow body delays all
+the ones behind it. The client timeout caps it, which is why it would have shown
+up as slowness rather than a hang: the worst kind to find later.
+
+Restored, with the reason written down so the next edit to that block does not
+quietly drop it again.
+
+## The lesson, which is not about draining
+
+Pass 47 fixed two real findings and broke a third thing on the way, in a line it
+was not there to change. **An incidental edit inside a fix is still an edit** —
+and under a one-clean-pass rule it is the incidental ones that will survive,
+because attention is on the finding.

--- a/docs/review-passes/pass49.md
+++ b/docs/review-passes/pass49.md
@@ -1,0 +1,20 @@
+# Codex review pass 49 — S155a
+
+**Clean.** No findings.
+
+> The changes add version-path probing, bounded body reads, persistence fields,
+> and tests without introducing a clear correctness regression.
+
+Converged. Three passes, four findings, none declined — and **every one was in
+code written for this slice**, two of them in the fixes for the previous pass:
+
+| pass | finding |
+|---|---|
+| 47 | a mismatch could be called on a partial body — the slice's own doctrine, inverted; and "no version_path declared" printed for a declared-but-unreachable path |
+| 48 | the response drain lost its bound while pass 47 edited the line beside it |
+| 49 | clean |
+
+The pattern across S154, S170 and S155a is consistent enough to name: under a
+one-clean-pass rule, **the defects that survive are the ones adjacent to the
+fix**, not the ones the finding pointed at. Attention goes to the reported line;
+the `defer` next to it is where the next bug lands.

--- a/internal/cli/deploy_command.go
+++ b/internal/cli/deploy_command.go
@@ -309,12 +309,13 @@ func registerDeployment(
 		// Snapshotted, not looked up later: the scenario file changes,
 		// this record describes one deployment that already happened
 		// (S154).
-		Port:       sc.Service.Port,
-		HealthPath: sc.Service.HealthPath,
-		State:      livestore.StateLive,
-		WorkDir:    workDir,
-		CreatedAt:  now,
-		ExpiresAt:  now.Add(ttl),
+		Port:        sc.Service.Port,
+		HealthPath:  sc.Service.HealthPath,
+		VersionPath: sc.Service.VersionPath,
+		State:       livestore.StateLive,
+		WorkDir:     workDir,
+		CreatedAt:   now,
+		ExpiresAt:   now.Add(ttl),
 	}
 
 	if err := store.Put(d); err != nil {

--- a/internal/cli/live_observe.go
+++ b/internal/cli/live_observe.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -70,8 +71,13 @@ func runLiveObserveCommand(cmd *cobra.Command, _ []string, runtime *CommandRunti
 	}
 
 	if status == CommandStatusFailed {
+		// "not serving" would be a lie for the version findings: a
+		// deployment can answer perfectly and still be running something
+		// other than what the record claims, which is the more dangerous
+		// of the two because it looks fine. The summary must not
+		// contradict the failure beneath it.
 		return &CLIError{Op: "live observe", Code: errorCodeCommandFailed, Err: fmt.Errorf(
-			"%d live deployment(s) are not serving", len(failures))}
+			"%d live deployment(s) did not observe clean", len(failures))}
 	}
 	return nil
 }
@@ -152,6 +158,16 @@ func observeDeployment(
 	}
 
 	observation := livestore.Observation{At: now, Detail: result.Detail}
+
+	// The version check is separate from health on purpose: a service can
+	// be perfectly healthy and running something other than what the
+	// record claims, which is the more dangerous of the two because it
+	// looks fine.
+	versionDetail := ""
+	if d.VersionPath != "" {
+		observation.Version, versionDetail = checkRunningVersion(ctx, runtime, d)
+	}
+
 	switch {
 	case result.Healthy:
 		observation.Status = livestore.ObservationHealthy
@@ -192,14 +208,55 @@ func observeDeployment(
 			d.ID, observation.Status, err))
 	}
 
+	// A record that misstates what is running is a finding even when the
+	// service is up, and it is reported BEFORE health so it cannot be
+	// hidden behind a green probe.
+	if observation.Version == livestore.VersionUnconfirmed {
+		return fail("version", fmt.Sprintf("%s: %s", d.ID, versionDetail))
+	}
+
 	if observation.Healthy() {
+		detail := fmt.Sprintf("%s is serving (%s)", d.ID, d.Address)
+		switch observation.Version {
+		case livestore.VersionConfirmed:
+			detail += fmt.Sprintf(" and confirms %s", imageRef(d))
+		case livestore.VersionUnchecked:
+			// Said out loud. Silence here would read as confirmation,
+			// and the record's version is a claim nobody checked.
+			detail += "; running version unchecked (no version_path declared)"
+		}
 		return StageSummary{
-			Layer: "live", Stage: "observe", Status: StageStatusPass,
-			Detail: fmt.Sprintf("%s is serving (%s)", d.ID, d.Address),
+			Layer: "live", Stage: "observe", Status: StageStatusPass, Detail: detail,
 		}, nil
 	}
 
 	return fail(string(observation.Status), fmt.Sprintf("%s: %s", d.ID, observation.Detail))
+}
+
+// checkRunningVersion asks the service what it is running and compares it
+// with what the record claims.
+//
+// The comparison is deliberately weak: the response must MENTION the tag.
+// That verifies a cooperating service and cannot verify an uncooperative
+// one -- so a failure to probe is unchecked, never unconfirmed. Claiming
+// a contradiction on a probe that did not happen would be the same
+// falsehood in the other direction.
+func checkRunningVersion(ctx context.Context, runtime *CommandRuntime, d livestore.Deployment) (livestore.VersionCheck, string) {
+	result, err := runtime.Deps.ServiceProbe.Probe(ctx, d.Address, d.Port, d.VersionPath)
+	if err != nil || !result.Reachable {
+		return livestore.VersionUnchecked, ""
+	}
+	if d.Tag == "" {
+		return livestore.VersionUnchecked, ""
+	}
+
+	if strings.Contains(result.Body, d.Tag) {
+		return livestore.VersionConfirmed, ""
+	}
+	return livestore.VersionUnconfirmed, fmt.Sprintf(
+		"the record claims %s but %s does not mention %q. The record states intent, not fact -- "+
+			"an upgrade to a version nobody confirmed is running proves nothing",
+		imageRef(d), d.VersionPath, d.Tag)
 }
 
 // missingProbeTarget names what the record lacks, or "" when it can be

--- a/internal/cli/live_observe.go
+++ b/internal/cli/live_observe.go
@@ -163,7 +163,7 @@ func observeDeployment(
 	// be perfectly healthy and running something other than what the
 	// record claims, which is the more dangerous of the two because it
 	// looks fine.
-	versionDetail := ""
+	versionDetail := "no version_path declared"
 	if d.VersionPath != "" {
 		observation.Version, versionDetail = checkRunningVersion(ctx, runtime, d)
 	}
@@ -221,9 +221,11 @@ func observeDeployment(
 		case livestore.VersionConfirmed:
 			detail += fmt.Sprintf(" and confirms %s", imageRef(d))
 		case livestore.VersionUnchecked:
-			// Said out loud. Silence here would read as confirmation,
-			// and the record's version is a claim nobody checked.
-			detail += "; running version unchecked (no version_path declared)"
+			// Said out loud, WITH the reason. Silence would read as
+			// confirmation, and "no version_path declared" would be a
+			// lie for a declared path that could not be reached -- which
+			// is the very distinction this check exists to draw.
+			detail += fmt.Sprintf("; running version unchecked (%s)", versionDetail)
 		}
 		return StageSummary{
 			Layer: "live", Stage: "observe", Status: StageStatusPass, Detail: detail,
@@ -242,17 +244,33 @@ func observeDeployment(
 // a contradiction on a probe that did not happen would be the same
 // falsehood in the other direction.
 func checkRunningVersion(ctx context.Context, runtime *CommandRuntime, d livestore.Deployment) (livestore.VersionCheck, string) {
-	result, err := runtime.Deps.ServiceProbe.Probe(ctx, d.Address, d.Port, d.VersionPath)
-	if err != nil || !result.Reachable {
-		return livestore.VersionUnchecked, ""
-	}
 	if d.Tag == "" {
-		return livestore.VersionUnchecked, ""
+		return livestore.VersionUnchecked, "the record names no tag to check against"
 	}
 
+	result, err := runtime.Deps.ServiceProbe.Probe(ctx, d.Address, d.Port, d.VersionPath)
+	if err != nil {
+		return livestore.VersionUnchecked, fmt.Sprintf("%s could not be probed: %v", d.VersionPath, err)
+	}
+	if !result.Reachable {
+		return livestore.VersionUnchecked, fmt.Sprintf("%s is unreachable", d.VersionPath)
+	}
+
+	// Finding the tag proves it is there, whatever else was cut off.
 	if strings.Contains(result.Body, d.Tag) {
 		return livestore.VersionConfirmed, ""
 	}
+
+	// NOT finding it in a partial body proves nothing. Reporting a
+	// mismatch here would be claiming a contradiction on evidence we do
+	// not have -- the same error as treating unchecked as confirmed,
+	// inverted.
+	if !result.BodyComplete {
+		return livestore.VersionUnchecked, fmt.Sprintf(
+			"%s answered but its response was truncated or unreadable, so the absence of %q means nothing",
+			d.VersionPath, d.Tag)
+	}
+
 	return livestore.VersionUnconfirmed, fmt.Sprintf(
 		"the record claims %s but %s does not mention %q. The record states intent, not fact -- "+
 			"an upgrade to a version nobody confirmed is running proves nothing",

--- a/internal/cli/live_observe_test.go
+++ b/internal/cli/live_observe_test.go
@@ -332,3 +332,101 @@ func (p *releasingProbe) Probe(context.Context, string, int, string) (harness.Se
 	}
 	return harness.ServiceProbeResult{Reachable: true, Healthy: true}, nil
 }
+
+// versionProbe answers the health path and the version path differently,
+// which is the whole point: a service can be healthy and running
+// something other than what the record claims.
+type versionProbe struct {
+	healthy     bool
+	versionBody string
+	unreachable bool
+	paths       []string
+}
+
+func (p *versionProbe) Probe(_ context.Context, _ string, _ int, path string) (harness.ServiceProbeResult, error) {
+	p.paths = append(p.paths, path)
+	if p.unreachable && path == "/version" {
+		return harness.ServiceProbeResult{}, nil
+	}
+	if path == "/version" {
+		return harness.ServiceProbeResult{Reachable: true, Healthy: true, Body: p.versionBody}, nil
+	}
+	return harness.ServiceProbeResult{Reachable: true, Healthy: p.healthy}, nil
+}
+
+func versionedDeployment(t *testing.T, store *livestore.FilesystemStore, id string) livestore.Deployment {
+	t.Helper()
+	d := observableDeployment(t, store, id)
+	d.VersionPath = "/version"
+	require.NoError(t, store.Put(d))
+	return d
+}
+
+// The record states intent. Only the service states fact.
+func TestObserveConfirmsTheRunningVersion(t *testing.T) {
+	probe := &versionProbe{healthy: true, versionBody: "nginx/1.27.4"}
+	rt, store := observeRuntime(t, nil)
+	rt.Deps.ServiceProbe = probe
+	d := versionedDeployment(t, store, "dep-versioned")
+
+	var out strings.Builder
+	require.NoError(t, runObserve(t, rt, &out))
+
+	assert.Contains(t, probe.paths, "/version", "the version path is probed separately from health")
+	assert.Contains(t, out.String(), "confirms nginx:1.27")
+
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	require.Len(t, got.Observations, 1)
+	assert.Equal(t, livestore.VersionConfirmed, got.Observations[0].Version)
+}
+
+// The canary's exact shape: the record says nginx:1.27, a python
+// one-liner answers. Healthy, and lying.
+func TestObserveFailsWhenTheServiceDoesNotConfirmTheRecordedVersion(t *testing.T) {
+	probe := &versionProbe{healthy: true, versionBody: "SimpleHTTP/0.6 Python/3.10.12"}
+	rt, store := observeRuntime(t, nil)
+	rt.Deps.ServiceProbe = probe
+	d := versionedDeployment(t, store, "dep-lying")
+
+	var out strings.Builder
+	err := runObserve(t, rt, &out)
+
+	require.Error(t, err, "a healthy service running the wrong version is still a finding")
+	assert.Contains(t, out.String(), "does not mention")
+	assert.Contains(t, out.String(), "proves nothing")
+
+	got, storeErr := store.Get(d.ID)
+	require.NoError(t, storeErr)
+	assert.Equal(t, livestore.VersionUnconfirmed, got.Observations[0].Version)
+}
+
+// A probe that did not happen is unchecked, never unconfirmed. Claiming
+// a contradiction on evidence nobody gathered is the same falsehood in
+// the other direction.
+func TestObserveTreatsAnUnreachableVersionPathAsUnchecked(t *testing.T) {
+	probe := &versionProbe{healthy: true, unreachable: true}
+	rt, store := observeRuntime(t, nil)
+	rt.Deps.ServiceProbe = probe
+	d := versionedDeployment(t, store, "dep-silent")
+
+	require.NoError(t, runObserve(t, rt, &strings.Builder{}), "unchecked is not a failure")
+
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	assert.Equal(t, livestore.VersionUnchecked, got.Observations[0].Version)
+}
+
+// Silence would read as confirmation, so a deployment that declares no
+// version_path says so in its own stage line.
+func TestObserveSaysWhenTheRunningVersionWasNeverChecked(t *testing.T) {
+	probe := &fakeServiceProbe{result: harness.ServiceProbeResult{Reachable: true, Healthy: true}}
+	rt, store := observeRuntime(t, probe)
+	observableDeployment(t, store, "dep-unversioned")
+
+	var out strings.Builder
+	require.NoError(t, runObserve(t, rt, &out))
+
+	assert.Contains(t, out.String(), "running version unchecked")
+	assert.Equal(t, 1, probe.calls, "no version_path means no second probe")
+}

--- a/internal/cli/live_observe_test.go
+++ b/internal/cli/live_observe_test.go
@@ -339,6 +339,9 @@ func (p *releasingProbe) Probe(context.Context, string, int, string) (harness.Se
 type versionProbe struct {
 	healthy     bool
 	versionBody string
+	// partial marks the body as truncated or unreadable, which makes the
+	// ABSENCE of a tag prove nothing.
+	partial     bool
 	unreachable bool
 	paths       []string
 }
@@ -349,7 +352,10 @@ func (p *versionProbe) Probe(_ context.Context, _ string, _ int, path string) (h
 		return harness.ServiceProbeResult{}, nil
 	}
 	if path == "/version" {
-		return harness.ServiceProbeResult{Reachable: true, Healthy: true, Body: p.versionBody}, nil
+		return harness.ServiceProbeResult{
+			Reachable: true, Healthy: true,
+			Body: p.versionBody, BodyComplete: !p.partial,
+		}, nil
 	}
 	return harness.ServiceProbeResult{Reachable: true, Healthy: p.healthy}, nil
 }
@@ -429,4 +435,52 @@ func TestObserveSaysWhenTheRunningVersionWasNeverChecked(t *testing.T) {
 
 	assert.Contains(t, out.String(), "running version unchecked")
 	assert.Equal(t, 1, probe.calls, "no version_path means no second probe")
+}
+
+// Finding the tag proves it is there whatever was cut off; NOT finding it
+// in a partial body proves nothing. Reporting a mismatch on evidence we
+// do not have is the same error as treating unchecked as confirmed, only
+// inverted.
+func TestObserveWillNotCallAMismatchOnAPartialBody(t *testing.T) {
+	probe := &versionProbe{healthy: true, versionBody: "server: something-else", partial: true}
+	rt, store := observeRuntime(t, nil)
+	rt.Deps.ServiceProbe = probe
+	d := versionedDeployment(t, store, "dep-truncated")
+
+	var out strings.Builder
+	require.NoError(t, runObserve(t, rt, &out), "an unreadable answer is not a contradiction")
+	assert.Contains(t, out.String(), "means nothing")
+
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	assert.Equal(t, livestore.VersionUnchecked, got.Observations[0].Version)
+}
+
+// A tag found in a truncated body is still found.
+func TestObserveConfirmsFromAPartialBodyThatContainsTheTag(t *testing.T) {
+	probe := &versionProbe{healthy: true, versionBody: "nginx/1.27.4 and then a lot more", partial: true}
+	rt, store := observeRuntime(t, nil)
+	rt.Deps.ServiceProbe = probe
+	d := versionedDeployment(t, store, "dep-truncated-ok")
+
+	require.NoError(t, runObserve(t, rt, &strings.Builder{}))
+
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	assert.Equal(t, livestore.VersionConfirmed, got.Observations[0].Version)
+}
+
+// "no version_path declared" is a lie for a declared path that could not
+// be reached, and that is the exact distinction this check exists to draw.
+func TestObserveSaysWhyTheVersionWasUncheckedRatherThanGuessing(t *testing.T) {
+	probe := &versionProbe{healthy: true, unreachable: true}
+	rt, store := observeRuntime(t, nil)
+	rt.Deps.ServiceProbe = probe
+	versionedDeployment(t, store, "dep-silent-path")
+
+	var out strings.Builder
+	require.NoError(t, runObserve(t, rt, &out))
+
+	assert.Contains(t, out.String(), "/version is unreachable")
+	assert.NotContains(t, out.String(), "no version_path declared")
 }

--- a/internal/harness/service_probe.go
+++ b/internal/harness/service_probe.go
@@ -121,7 +121,12 @@ func (p *ServiceProbe) Probe(ctx context.Context, address string, port int, heal
 	// distinguishable from a body that merely ends there.
 	head, readErr := io.ReadAll(io.LimitReader(resp.Body, maxProbeBodyBytes+1))
 	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
+		// Bounded, still. The drain exists so the connection can be
+		// reused, which is worth a few kilobytes and not worth spending
+		// the probe's whole timeout budget on a streaming endpoint --
+		// and this probe runs against every live deployment in turn, so
+		// one slow body delays all the ones behind it.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxProbeBodyBytes))
 		_ = resp.Body.Close()
 	}()
 

--- a/internal/harness/service_probe.go
+++ b/internal/harness/service_probe.go
@@ -28,7 +28,19 @@ type ServiceProbeResult struct {
 	// Detail is the reason, phrased for the pitfall extractors that
 	// eventually consume it. Empty when healthy.
 	Detail string
+	// Body is the start of what the service said, bounded. Kept so a
+	// caller can check the running version against what the record
+	// claims (S155); a service answering with a firehose must not be
+	// able to grow this.
+	Body string
 }
+
+// maxProbeBodyBytes bounds what a probe keeps from the response.
+//
+// Enough to hold a version string or a small health document, and small
+// enough that a service answering with a firehose cannot grow a
+// deployment record -- which is stored, and stored per observation.
+const maxProbeBodyBytes = 4096
 
 // ServiceProbe checks a live deployment's health path.
 //
@@ -93,14 +105,16 @@ func (p *ServiceProbe) Probe(ctx context.Context, address string, port int, heal
 			Detail: fmt.Sprintf("health path %s is unreachable: %v", target, err),
 		}, nil
 	}
+	// Read the head of the body rather than discarding it: the version
+	// check needs what the service said. Still bounded, and the rest is
+	// still drained so the connection can be reused.
+	head, _ := io.ReadAll(io.LimitReader(resp.Body, maxProbeBodyBytes))
 	defer func() {
-		// Drained so the connection can be reused, and bounded so a
-		// service answering with a firehose cannot exhaust memory here.
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxProbeBodyBytes))
 		_ = resp.Body.Close()
 	}()
 
-	result := ServiceProbeResult{Reachable: true, Status: resp.StatusCode}
+	result := ServiceProbeResult{Reachable: true, Status: resp.StatusCode, Body: string(head)}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Healthy = true
 		return result, nil

--- a/internal/harness/service_probe.go
+++ b/internal/harness/service_probe.go
@@ -33,6 +33,14 @@ type ServiceProbeResult struct {
 	// claims (S155); a service answering with a firehose must not be
 	// able to grow this.
 	Body string
+	// BodyComplete reports whether Body is the whole response.
+	//
+	// It is false when the read failed or hit the byte limit, and the
+	// distinction is load-bearing: FINDING a version string in a partial
+	// body proves it is there, but NOT finding one proves nothing. A
+	// caller that ignores this reports a mismatch on evidence it does
+	// not have.
+	BodyComplete bool
 }
 
 // maxProbeBodyBytes bounds what a probe keeps from the response.
@@ -108,13 +116,24 @@ func (p *ServiceProbe) Probe(ctx context.Context, address string, port int, heal
 	// Read the head of the body rather than discarding it: the version
 	// check needs what the service said. Still bounded, and the rest is
 	// still drained so the connection can be reused.
-	head, _ := io.ReadAll(io.LimitReader(resp.Body, maxProbeBodyBytes))
+	//
+	// One byte over the limit is read on purpose, so hitting it is
+	// distinguishable from a body that merely ends there.
+	head, readErr := io.ReadAll(io.LimitReader(resp.Body, maxProbeBodyBytes+1))
 	defer func() {
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxProbeBodyBytes))
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
 
-	result := ServiceProbeResult{Reachable: true, Status: resp.StatusCode, Body: string(head)}
+	complete := readErr == nil && len(head) <= maxProbeBodyBytes
+	if len(head) > maxProbeBodyBytes {
+		head = head[:maxProbeBodyBytes]
+	}
+
+	result := ServiceProbeResult{
+		Reachable: true, Status: resp.StatusCode,
+		Body: string(head), BodyComplete: complete,
+	}
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Healthy = true
 		return result, nil

--- a/internal/livestore/livestore.go
+++ b/internal/livestore/livestore.go
@@ -75,6 +75,10 @@ type Deployment struct {
 	// strays would be recomputed from.
 	SweepVerificationFailed bool `json:"sweep_verification_failed,omitempty"`
 
+	// VersionPath, when declared, is probed to check that the service is
+	// running the version this record claims. Snapshotted with the rest.
+	VersionPath string `json:"version_path,omitempty"`
+
 	// Port and HealthPath are the service's own, snapshotted at deploy
 	// time rather than re-read from the scenario when a probe runs. The
 	// scenario is a file that changes; this record describes one
@@ -123,6 +127,29 @@ const (
 // readable by a human.
 const MaxObservations = 50
 
+// VersionCheck is what a probe could establish about the version the
+// service is ACTUALLY running, as opposed to the one the record claims.
+//
+// Three states, not two. "We did not look" and "we looked and the
+// service did not confirm it" are different facts, and a loop that
+// attributed a failure to a version on the strength of the first would
+// be learning a falsehood -- which is exactly the drift the 2026-08-31
+// canary found, where the record said nginx:1.27 and the instance served
+// python3 -m http.server.
+type VersionCheck string
+
+const (
+	// VersionUnchecked means no version_path was declared, so nothing
+	// was asked. Never treat it as confirmation.
+	VersionUnchecked VersionCheck = ""
+	// VersionConfirmed means the service's own response mentioned the
+	// tag this deployment claims to run.
+	VersionConfirmed VersionCheck = "confirmed"
+	// VersionUnconfirmed means the service answered and did NOT mention
+	// it. The record and the world disagree.
+	VersionUnconfirmed VersionCheck = "unconfirmed"
+)
+
 // Observation is one probe of one deployment's health path.
 type Observation struct {
 	At     time.Time         `json:"at"`
@@ -130,6 +157,9 @@ type Observation struct {
 	// Detail is the reason, in the shape the pitfall extractors already
 	// take. Empty on a healthy probe: there is nothing to say.
 	Detail string `json:"detail,omitempty"`
+	// Version is what this probe could establish about the running
+	// version. Empty means unchecked.
+	Version VersionCheck `json:"version,omitempty"`
 }
 
 // Healthy is the only status that means the service is working. Written

--- a/internal/scenario/service.go
+++ b/internal/scenario/service.go
@@ -45,6 +45,24 @@ type ServiceSpec struct {
 	Port       int    `json:"port"`
 	HealthPath string `json:"health_path,omitempty"`
 	TTL        string `json:"ttl"`
+
+	// VersionPath is a path whose response names the version actually
+	// running. Optional, and its absence means unchecked rather than
+	// confirmed.
+	//
+	// `deploy` records the DECLARED image and tag. That is a claim about
+	// intent, and the 2026-08-31 canary showed how far it can drift: the
+	// record said `nginx:1.27` while the instance served
+	// `python3 -m http.server`. An upgrade to a version nobody confirmed
+	// is running proves nothing, and a learning loop that attributed a
+	// failure to `nginx:1.27` on that basis would be learning a
+	// falsehood.
+	//
+	// The check this enables is deliberately weak and deliberately
+	// stated: the service's own response must MENTION the tag. That
+	// verifies a cooperating service and cannot verify an uncooperative
+	// one, which is why declaring the path is opt-in.
+	VersionPath string `json:"version_path,omitempty"`
 }
 
 // Ref is the fully qualified image reference the instance pulls.

--- a/scenario.schema.json
+++ b/scenario.schema.json
@@ -129,6 +129,11 @@
           "default": "/",
           "description": "HTTP path polled to decide whether the service is serving. Used by the http_probe criterion and, from S154, by the soak stage."
         },
+        "version_path": {
+          "type": "string",
+          "pattern": "^/",
+          "description": "HTTP path whose response names the version actually running. Optional; its absence means the running version is unchecked, never confirmed. deploy records the DECLARED image and tag, which is a claim about intent -- the 2026-08-31 canary recorded nginx:1.27 while the instance served python3 -m http.server. The check is deliberately weak: the response must MENTION the tag, which verifies a cooperating service and cannot verify an uncooperative one."
+        },
         "ttl": {
           "type": "string",
           "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",


### PR DESCRIPTION
S155's prerequisite, not a nicety. The plan's own words: *"an upgrade to a version nobody confirmed is running proves nothing."*

`deploy` records the image and tag a scenario **declares**. That is a claim about intent, and the 2026-08-31 canary measured the drift: the record said `nginx:1.27` while the instance served `python3 -m http.server`. A learning loop that attributed a failure to `nginx:1.27` on that basis would be learning a falsehood.

## What it adds

A scenario may declare `service.version_path`. `live observe` probes it **separately from health** and records one of **three** states — deliberately not two:

| state | meaning |
|---|---|
| `unchecked` | nothing was asked, or the answer proves nothing. **Never** read as confirmation |
| `confirmed` | the service's own response mentioned the tag |
| `unconfirmed` | it answered, completely, and did not |

A mismatch **fails a perfectly healthy deployment**. That is the more dangerous case precisely because it looks fine — nothing else in the system would notice.

The check is **deliberately weak and deliberately stated**: the response must *mention* the tag. That verifies a cooperating service and cannot verify an uncooperative one, which is why declaring the path is opt-in rather than assumed.

## The asymmetry that took two passes to get right

A probe that fails is `unchecked`, never `unconfirmed` — claiming a contradiction on evidence nobody gathered is the same error as treating unchecked as confirmed, inverted. Pass 47 found the slice breaking its own rule: a truncated body was compared anyway, so a partial response could be called a mismatch.

So the evidence rule is asymmetric, and now explicit via `BodyComplete`:

- **finding** the tag proves it is there, whatever was cut off → `confirmed`
- **not finding** it in a partial body proves nothing → `unchecked`

Every `unchecked` also carries its reason. `no version_path declared` was being printed for a *declared* path that could not be reached — misstating the case, and hiding the exact distinction this slice exists to draw.

## Verified against real Scaleway

Deployed a service that contradicts its own record and watched it get caught:

```
the record claims nginx:1.27 but / does not mention "1.27". The record states
intent, not fact -- an upgrade to a version nobody confirmed is running proves nothing
```

It also confirmed **pass 44's fix on real infrastructure**, unplanned: a first attempt used a fixture with no load balancer, so the apply produced no address, and `observe` refused it rather than reporting clean — exactly the shape codex said comes from today's deploy path.

Account clean afterwards; ~€0.01.

## Review: three passes, four findings, none declined

| pass | finding |
|---|---|
| 47 | mismatch on a partial body; wrong reason printed for unchecked |
| 48 | the response drain lost its bound while pass 47 edited the line beside it |
| 49 | clean |

Every finding was in code written for this slice, and two were in the fixes for the previous pass. The pattern across S154, S170 and S155a is consistent enough to name: under a one-clean-pass rule **the defects that survive are the ones adjacent to the fix**. Attention goes to the reported line; the `defer` next to it is where the next bug lands.

Also fixed: a summary that contradicted its own findings — "N deployments are not serving" is a lie for a version mismatch, where the service is serving fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD