### PR TITLE
S155b: live upgrade — an apply is not an upgrade

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,25 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- ✅ **S155b canary: the thesis, demonstrated on real infrastructure (2026-09-01)** —
+  deployed v1, confirmed the service was serving `nginx:1.27`, upgraded to 1.28,
+  and **`sandbox_deploy/apply` passed while `upgrade_verify` failed.** Confirmed
+  by hand: `curl` returned `nginx/1.27.0` while the workdir held the 1.28 config.
+
+  The mechanism is mundane, which is the point — changing `user_data` on a running
+  Scaleway instance does not re-run cloud-init. Terraform updated the resource,
+  reported success, and the machine kept serving what it already served.
+
+  **That upgrade was green everywhere else**: the apply passed, the sweep would
+  have reported the account clean because it was, a cost check would have found
+  nothing because there was nothing. Only the check that asked *the service*
+  disagreed. Same shape as D6, same lesson.
+
+  It also produced, by accident, exactly what S156 wants: a **failed upgrade with
+  both configurations preserved** — the before/after pair `ExtractFixPitfall`
+  needs, from a real failure rather than a constructed one. Full record:
+  [docs/status/s155b-upgrade-canary.md](status/s155b-upgrade-canary.md).
+
 - 🚀 **S155b: `live upgrade` — an apply is not an upgrade (2026-08-31)** —
   rolls a live deployment onto new configuration **in place**: same project, same
   workdir, so the load balancer and its address survive.

--- a/STATUS.md
+++ b/STATUS.md
@@ -82,7 +82,14 @@ Last updated: 2026-08-31
   because an upgrade holds its record across a real apply — minutes, not the
   microseconds a probe takes.
 
-  **The shape of this slice**: seven passes, thirteen findings, and ten of them are
+  Pass 57: the pass-56 re-read was used for the released check and then
+  **discarded**, writing back the stale copy — so observations `live observe`
+  appended during a minutes-long apply were silently dropped. Those are the input
+  S156's promotion gate counts, so it weakens the learning signal rather than
+  breaking anything visibly. Now an allow-list merge of the three fields an
+  upgrade owns onto the fresh record.
+
+  **The shape of this slice**: eight passes, fourteen findings, and ten of them are
   one incomplete answer rather than eleven mistakes — "did anything reach the
   cloud?" answered four times, "which project do we trust?" three, and three
   separate fixes that **already existed elsewhere in the codebase** and were not

--- a/STATUS.md
+++ b/STATUS.md
@@ -60,6 +60,18 @@ Last updated: 2026-08-31
   trivially passed, reporting a transition that was never attempted — a green
   built from checking that nothing changed.
 
+  Pass 54 finished it: the marker was *preferred*, not required, so an unreadable
+  one fell back to the editable record — a guard that degrades to the thing it was
+  guarding against. Required now, and the contrast with `live teardown` (which
+  does fall back, deliberately) is written down: refusing there strands real
+  pre-cutover resources and destroy is bounded by its own state; neither holds
+  when applying.
+
+  **The shape of this slice**: five passes, ten findings, and the through-line is
+  one fix applied incompletely rather than ten separate mistakes — "did anything
+  reach the cloud?" answered four times, "which project do we trust?" answered
+  twice. Both only converged once the answer became a single mechanism.
+
   - **The previous HCL is kept** in `.infrafactory-previous/`. That pair either
     side of one change is the diff `ExtractFixPitfall` needs and cannot
     reconstruct — it is what lets S156 produce prescriptive rules rather than the

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,35 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- 🚀 **S155b: `live upgrade` — an apply is not an upgrade (2026-08-31)** —
+  rolls a live deployment onto new configuration **in place**: same project, same
+  workdir, so the load balancer and its address survive.
+
+  **infrafactory does not invent the new HCL.** It owns the part that is hard to
+  get right — applying it into the project the deployment already owns, under the
+  same deny-by-default checks a first deploy runs, and proving afterwards that the
+  version actually changed. That composes with however the HCL was produced.
+
+  **Deliberately not parameterised through `TF_VAR`.** `SandboxStripEnv` removes
+  `TF_VAR_*` because the cost bounds read a variable's *default* to decide blast
+  radius, so an injected variable would make those checks vouch for a number that
+  never reaches the API. Handing over whole HCL keeps every existing check
+  applying to the configuration that is actually applied.
+
+  Three properties worth naming:
+
+  - **A successful apply is not an upgrade.** Terraform reaching its desired state
+    does not mean the service is running the new version — the instance may not
+    have restarted, the image may not have been pulled, the user data may never
+    have run. `upgrade_verify` fails on exactly that, and it is the whole point.
+  - **It refuses to start from a version the service contradicts**, because that
+    would record a v1→v2 transition that never happened. Unchecked is allowed and
+    said out loud; contradicted is not.
+  - **The previous HCL is kept** in `.infrafactory-previous/`. That pair either
+    side of one change is the diff `ExtractFixPitfall` needs and cannot
+    reconstruct — it is what lets S156 produce prescriptive rules rather than the
+    weakest class of lesson.
+
 - 🔍 **S155a: the record states intent; only the service states fact (2026-08-31)** —
   `deploy` records the **declared** image and tag, and the canary showed how far
   that drifts: the record said `nginx:1.27` while the instance served

--- a/STATUS.md
+++ b/STATUS.md
@@ -28,6 +28,14 @@ Last updated: 2026-08-31
   - **It refuses to start from a version the service contradicts**, because that
     would record a v1→v2 transition that never happened. Unchecked is allowed and
     said out loud; contradicted is not.
+  Pass 50 corrected two of them. The tag advanced even when the apply never ran —
+  right for a failure *during* apply, wrong at init or plan where nothing reached
+  the cloud, and there it made the record claim a version that was never deployed.
+  And the address could go stale: replacement HCL can recreate the load balancer,
+  so verification would probe infrastructure the deployment no longer owns. It is
+  re-read after the apply now, reported when it moves, and when it cannot be
+  re-read the old one is kept **and said out loud**.
+
   - **The previous HCL is kept** in `.infrafactory-previous/`. That pair either
     side of one change is the diff `ExtractFixPitfall` needs and cannot
     reconstruct — it is what lets S156 produce prescriptive rules rather than the

--- a/STATUS.md
+++ b/STATUS.md
@@ -36,6 +36,14 @@ Last updated: 2026-08-31
   re-read after the apply now, reported when it moves, and when it cannot be
   re-read the old one is kept **and said out loud**.
 
+  Pass 51 found two more, both data-safety: `--from` naming the deployment's own
+  workdir **emptied it** (the superseded files are removed before the new ones are
+  read), and a rejected configuration was left in place after an init or plan
+  failure, so every later operation would plan against something never applied.
+  Both now hang off the same `applyRan` predicate as the tag — *did anything reach
+  the cloud?* — which is the real fix: one question answered consistently rather
+  than three patches.
+
   - **The previous HCL is kept** in `.infrafactory-previous/`. That pair either
     side of one change is the diff `ExtractFixPitfall` needs and cannot
     reconstruct — it is what lets S156 produce prescriptive rules rather than the

--- a/STATUS.md
+++ b/STATUS.md
@@ -44,6 +44,14 @@ Last updated: 2026-08-31
   the cloud?* — which is the real fix: one question answered consistently rather
   than three patches.
 
+  Pass 52 closed it: `upgrade` never checked the `sandbox_deploy.enabled` opt-in,
+  so Layer 3 could be off and an upgrade would still apply to the real project —
+  a gate on one entry point and not the other guards nothing. And an environment
+  failure could still leave unapplied configuration behind, which was **fixed by
+  reordering rather than another rollback**: everything that can fail without
+  touching the workdir now happens before the part that does. Ordering beats
+  compensating — one rollback path instead of one per early return.
+
   - **The previous HCL is kept** in `.infrafactory-previous/`. That pair either
     side of one change is the diff `ExtractFixPitfall` needs and cannot
     reconstruct — it is what lets S156 produce prescriptive rules rather than the

--- a/STATUS.md
+++ b/STATUS.md
@@ -67,10 +67,19 @@ Last updated: 2026-08-31
   pre-cutover resources and destroy is bounded by its own state; neither holds
   when applying.
 
-  **The shape of this slice**: five passes, ten findings, and the through-line is
-  one fix applied incompletely rather than ten separate mistakes — "did anything
-  reach the cloud?" answered four times, "which project do we trust?" answered
-  twice. Both only converged once the answer became a single mechanism.
+  Pass 55 finished the second thread: the marker and the record are **both local
+  files**, so trusting either only proves two local files agree. ADR-0025 never
+  said "use the marker" — it said *two checks that must both pass*, the marker for
+  identity and **API provenance** for class, because the second cannot be forged
+  locally. Editing two files was enough to point a real apply at a production
+  project. The API is asked now, and deliberately not through the deletion guard,
+  which treats "gone" as success.
+
+  **The shape of this slice**: six passes, eleven findings, and ten of them are
+  one incomplete answer rather than eleven mistakes — "did anything reach the
+  cloud?" answered four times, "which project do we trust?" three. **The rule
+  already existed and was written down.** Reading ADR-0025's own words before
+  writing the guard would have collapsed three passes into one.
 
   - **The previous HCL is kept** in `.infrafactory-previous/`. That pair either
     side of one change is the diff `ExtractFixPitfall` needs and cannot

--- a/STATUS.md
+++ b/STATUS.md
@@ -52,6 +52,14 @@ Last updated: 2026-08-31
   touching the workdir now happens before the part that does. Ordering beats
   compensating — one rollback path instead of one per early return.
 
+  Pass 53: the project id came from the **record** rather than the marker — the
+  half a stale file can change — on a call that applies real infrastructure.
+  `live teardown` learned that in pass 37 and I did not carry it into new code;
+  a disagreement is refused now. **Applying deserves at least the care destroying
+  gets.** Also, with no `--tag` the verification compared the *old* tag and
+  trivially passed, reporting a transition that was never attempted — a green
+  built from checking that nothing changed.
+
   - **The previous HCL is kept** in `.infrafactory-previous/`. That pair either
     side of one change is the diff `ExtractFixPitfall` needs and cannot
     reconstruct — it is what lets S156 produce prescriptive rules rather than the

--- a/STATUS.md
+++ b/STATUS.md
@@ -75,11 +75,20 @@ Last updated: 2026-08-31
   project. The API is asked now, and deliberately not through the deletion guard,
   which treats "gone" as success.
 
-  **The shape of this slice**: six passes, eleven findings, and ten of them are
+  Pass 56: a prefix match confirmed tag `1.2` against a service reporting
+  `nginx/1.27.4` — a **false confirmation**, the exact drift S155a exists to
+  catch. `mentionsVersion` requires version boundaries now. And the upgrade could
+  overwrite a concurrent teardown: the same race fixed in `observe`, worse here
+  because an upgrade holds its record across a real apply — minutes, not the
+  microseconds a probe takes.
+
+  **The shape of this slice**: seven passes, thirteen findings, and ten of them are
   one incomplete answer rather than eleven mistakes — "did anything reach the
-  cloud?" answered four times, "which project do we trust?" three. **The rule
-  already existed and was written down.** Reading ADR-0025's own words before
-  writing the guard would have collapsed three passes into one.
+  cloud?" answered four times, "which project do we trust?" three, and three
+  separate fixes that **already existed elsewhere in the codebase** and were not
+  carried to a new path. The lesson is not "review harder": new code touching an
+  existing mechanism should start by reading how that mechanism is already used,
+  rather than reimplementing the parts of it that seem needed.
 
   - **The previous HCL is kept** in `.infrafactory-previous/`. That pair either
     side of one change is the diff `ExtractFixPitfall` needs and cannot

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -489,3 +489,14 @@ version that was never deployed. And the address is re-read from state after the
 apply, because replacement HCL can recreate the load balancer — verifying against
 the address captured at first deploy would probe infrastructure the deployment no
 longer owns, and leave every later observation pointed there too.
+
+Pass 51 added two more consequences of the same question. `--from` may not name
+the deployment's own workdir or anything inside it: the superseded configuration
+is removed before the new one is read, so that would leave the workdir empty while
+the infrastructure kept running. And when nothing reached the cloud, the rejected
+configuration is reverted from `.infrafactory-previous/` — otherwise the workdir
+describes something that was never applied.
+
+The tag, the address and the workdir contents all hang off one predicate: **did
+anything reach the cloud?** Three separate answers to that question is how the
+first version got two of them wrong.

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -521,3 +521,10 @@ Verification distinguishes an upgrade from a no-op. Without a new tag the record
 still names the old version, so confirming it shows the service is unchanged
 rather than upgraded; reporting otherwise would be a green built from checking
 that nothing changed.
+
+The marker is **required** for an upgrade, not merely preferred: falling back to
+the record when it cannot be read leaves the editable half deciding where real
+infrastructure is applied. `live teardown` does fall back, deliberately — refusing
+there strands a pre-cutover record whose resources are real, and destroy is bounded
+by the state in its own workdir. Neither argument holds when applying, and an
+operator who cannot upgrade can still tear down and deploy again.

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -500,3 +500,13 @@ describes something that was never applied.
 The tag, the address and the workdir contents all hang off one predicate: **did
 anything reach the cloud?** Three separate answers to that question is how the
 first version got two of them wrong.
+
+`live upgrade` requires `validation.layers.sandbox_deploy.enabled`, as `deploy`
+does. A gate on one entry point into real infrastructure and not the other guards
+nothing.
+
+And the ordering is load-bearing: every fallible step that does not touch the
+workdir runs **before** the destructive swap. Three review passes each found a
+different early return leaving unapplied configuration behind; the fix is not a
+fourth rollback path but removing the opportunity for one. **Ordering beats
+compensating.**

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -448,3 +448,36 @@ response is `unchecked`, and only a complete one can produce `unconfirmed`.
 Every `unchecked` carries the reason it was not checked — "no version_path
 declared" is a lie for a declared path that could not be reached, and that
 distinction is the whole point of having three states.
+
+## Amendment, 2026-08-31 (S155b): an apply is not an upgrade
+
+`live upgrade` rolls a deployment onto new configuration in place — same project,
+same workdir, so the address survives.
+
+**infrafactory does not produce the new HCL.** It owns applying it safely: into
+the project the deployment already owns, under the same deny-by-default checks a
+first deploy runs, and with proof afterwards that the version changed. This
+composes with however the configuration was produced, and keeps the generator out
+of the live path.
+
+Not parameterised through `TF_VAR`, deliberately. `SandboxStripEnv` removes
+`TF_VAR_*` because the cost bounds read a variable's **default** to decide blast
+radius; an injected variable would make those checks vouch for a number that never
+reaches the API. Handing over whole HCL keeps every check applying to the
+configuration actually applied.
+
+Three rules:
+
+- **A successful apply is not an upgrade.** Terraform reaching its desired state
+  says nothing about whether the service restarted, pulled the image, or ran its
+  user data. Reporting an upgrade on the strength of the apply is the same error
+  as trusting the record over the service, one step later.
+- **An upgrade refuses to start from a contradicted version.** Rolling forward
+  from a version the service denies would record a transition that never happened.
+  Unchecked is permitted and stated; contradicted is not.
+- **The superseded configuration is kept** in `.infrafactory-previous/`, one
+  generation deep. `ExtractFixPitfall` produces prescriptive rules by diffing a
+  failing configuration against a passing one, and a live failure has no "next
+  iteration that fixed it" — but an upgrade has a before and an after, which is
+  the same shape. Discarding it would leave live signals at the weakest class of
+  lesson.

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -543,3 +543,11 @@ the deployment resurrected. A record released mid-apply produces a loud failure
 naming the project, because whatever the apply created is not tracked by a
 released record. The window is narrowed, not closed: the store has no
 compare-and-swap.
+
+Re-reading a record before writing is only half the rule: the write must go onto
+the **fresh** copy, not the one loaded earlier. `live upgrade` holds its record
+across an apply that takes minutes, and `live observe` on a cron appends
+observations in exactly that window. Writing back the stale copy discarded them —
+which does not corrupt the record, it quietly weakens the learning signal S156's
+promotion gate counts. An upgrade merges only the three fields it owns (`Tag`,
+`UpgradedAt`, `Address`); anything else belongs to whoever wrote it last.

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -528,3 +528,18 @@ infrastructure is applied. `live teardown` does fall back, deliberately — refu
 there strands a pre-cutover record whose resources are real, and destroy is bounded
 by the state in its own workdir. Neither argument holds when applying, and an
 operator who cannot upgrade can still tear down and deploy again.
+
+The version comparison respects version boundaries. A plain substring match
+confirms tag `1.2` against a service reporting `nginx/1.27.4` — a service running
+something other than what the record claims, reported as confirmation, which is
+the precise drift this check exists to catch. A match may not be flanked by digits
+and may not directly follow a dot: `1.27` is confirmed by `1.27.4`, `1.2` is not,
+and `11.27` does not confirm `1.27`.
+
+`live upgrade` also re-reads its record before writing, as `observe` does. It
+holds that record across a real apply — minutes, not the microseconds a probe
+takes — so a teardown finishing in that window would otherwise be overwritten and
+the deployment resurrected. A record released mid-apply produces a loud failure
+naming the project, because whatever the apply created is not tracked by a
+released record. The window is narrowed, not closed: the store has no
+compare-and-swap.

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -481,3 +481,11 @@ Three rules:
   iteration that fixed it" — but an upgrade has a before and an after, which is
   the same shape. Discarding it would leave live signals at the weakest class of
   lesson.
+
+Two corrections from pass 50. The record advances onto the new tag only when the
+apply **ran**: a failure during apply may have changed a great deal, but a failure
+at init or plan changed nothing, and advancing there would make the record claim a
+version that was never deployed. And the address is re-read from state after the
+apply, because replacement HCL can recreate the load balancer — verifying against
+the address captured at first deploy would probe infrastructure the deployment no
+longer owns, and leave every later observation pointed there too.

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -510,3 +510,14 @@ workdir runs **before** the destructive swap. Three review passes each found a
 different early return leaving unapplied configuration behind; the fix is not a
 fourth rollback path but removing the opportunity for one. **Ordering beats
 compensating.**
+
+The project an upgrade applies into comes from the **marker**, not the deployment
+record, and a disagreement between them is refused. The record is the half a stale
+or edited file can change, and this call applies real infrastructure into whatever
+it names — applying deserves at least the care destroying gets (pass 37 for
+teardown, pass 53 for upgrade).
+
+Verification distinguishes an upgrade from a no-op. Without a new tag the record
+still names the old version, so confirming it shows the service is unchanged
+rather than upgraded; reporting otherwise would be a green built from checking
+that nothing changed.

--- a/docs/decisions/0025-run-project-created-before-the-apply.md
+++ b/docs/decisions/0025-run-project-created-before-the-apply.md
@@ -434,3 +434,23 @@ delete already used, and it lives inside `ensureRunProject` so `test`'s path get
 it without being told.
 
 **Losing the id is worse than the extra second: the id is the handle.**
+
+### Follow-up, S155b: the rule applies to applying, not only to destroying
+
+This ADR's guard was written for teardown, and `live upgrade` needed the same two
+checks for the opposite operation. It took three review passes to get there —
+first the marker, then the marker *required*, then finally the API — because each
+step looked complete on its own.
+
+It should not have. **The marker and the deployment record are both local files**,
+so choosing between them only ever proves that two local files agree. This ADR
+already said the marker gives identity and API provenance gives class, and that
+neither alone is sufficient *because provenance is the half that cannot be forged
+locally*. Editing two files was enough to point a real apply at somebody's
+production project.
+
+One asymmetry, deliberate: the deletion guard treats a project the API reports
+**gone** as fine, because gone is the outcome it wants. Applying is the opposite —
+a project that does not exist, or exists without the stamp, is one to refuse. So
+`live upgrade` uses its own check rather than reusing `AssertRunProjectDeletable`,
+whose message also describes the wrong operation.

--- a/docs/review-passes/pass50.md
+++ b/docs/review-passes/pass50.md
@@ -1,0 +1,36 @@
+# Codex review pass 50 — S155b `live upgrade`
+
+Two findings, both accepted.
+
+## [P1] The tag advanced even when the apply never ran
+
+I moved the record onto the new tag on every path, reasoning that a half-finished
+apply is running *something* and a record naming the old version would send the
+next observation looking for the wrong thing. That reasoning is right for a
+failure **during** apply and wrong for a failure at init or plan, where nothing
+reached the cloud at all — and advancing there makes the record claim a version
+that was never deployed, which is the exact falsehood S155a exists to prevent.
+
+Split on `applyRan(err)`, which reads the `SandboxDeployError.Stage`. Anything
+unrecognised counts as "it ran": assuming nothing happened is the answer that
+loses infrastructure.
+
+## [P2] The address could go stale across an upgrade
+
+Replacement HCL can recreate the load balancer. `d.Address` was captured at first
+deploy and never refreshed, so `upgrade_verify` would probe infrastructure this
+deployment no longer owns — and every later `live observe` would keep probing it.
+
+Now re-read from state after the apply, reported when it moves. When it cannot be
+re-read the old one is kept **and said out loud**, because everything after that
+point probes an address nothing just confirmed.
+
+## What the test fake taught
+
+`TestUpgradeRefreshesTheAddressWhenTheEndpointMoves` failed at first because
+`fakeSandboxDeployHarness.Run` writes its own minimal state, and my `onRun` hook
+fired *before* it — so the fake overwrote the fixture the test had just staged.
+The hook now runs last. Worth noting because the failure looked like the
+production code ignoring the new address, and was not.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass51.md
+++ b/docs/review-passes/pass51.md
@@ -1,0 +1,35 @@
+# Codex review pass 51 — S155b `live upgrade`
+
+Two findings, both accepted, both **P1 and both data-safety**.
+
+## [P1] `--from` pointing at the deployment's own workdir emptied it
+
+`replaceDeployedHCL` removes the superseded `.tf` files before copying the new
+ones in. So a `--from` naming the deployment's own workdir deleted the files it
+was about to read, and the workdir ended up holding **no configuration at all**
+— for infrastructure that is still running.
+
+Refused now, for the workdir itself and for any path inside it, with symlinks
+resolved before comparing: a symlinked path deletes the files just as
+effectively as a literal one.
+
+## [P1] A rejected configuration was left in the workdir
+
+An init or plan failure never reaches the cloud, so the deployment is still
+running the **old** configuration — while the workdir now held the new, rejected
+one. Every later operation would plan against something that was never applied.
+
+Restored from `.infrafactory-previous/` on exactly the predicate pass 50
+introduced for the tag, `applyRan(err)`. The two decisions are the same decision:
+*did anything reach the cloud?* A failure **during** apply keeps the new
+configuration, because something may be running from it and reverting would hide
+that.
+
+## The shape of this slice's findings
+
+Passes 50 and 51 both landed on the same question and I had answered it in only
+one of the places it applies. `applyRan` now governs the tag, the address and the
+workdir contents together, which is the fix the second pass really made — not two
+patches, one predicate applied consistently.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass52.md
+++ b/docs/review-passes/pass52.md
@@ -1,0 +1,37 @@
+# Codex review pass 52 — S155b `live upgrade`
+
+Two findings, both accepted, both P1.
+
+## [P1] The real-deploy opt-in was not required
+
+`deploy` refuses unless `validation.layers.sandbox_deploy.enabled`. `upgrade`
+did not check it at all — so an operator with credentials and an allowlist but
+Layer 3 deliberately **off** could still apply to the deployment's real project.
+
+A gate that guards one entry point into real infrastructure and not the other
+guards nothing. Added, and checked before anything touches the workdir.
+
+## [P1] An environment failure left unapplied configuration in the workdir
+
+`sandboxCommandEnvForProject` ran *after* the destructive swap, so an env problem
+returned early with the new HCL in place and nothing applied — the same shape
+pass 51 fixed for init/plan failures, on a path pass 51 did not cover.
+
+**Fixed by reordering rather than by another rollback.** Every fallible step that
+does not touch the workdir now happens first, which removes the failure mode
+instead of compensating for it. The swap itself also restores on partial failure,
+because that one genuinely cannot be ordered away.
+
+## Three passes, one question
+
+Passes 50, 51 and 52 all found the same thing in different places: *what happens
+when nothing reached the cloud?* The tag, the address, the workdir contents, and
+now the ordering of setup. Each was individually right and collectively
+inconsistent.
+
+The durable fix is not the fourth patch — it is that `applyRan` is now the single
+predicate, and that everything which can fail without touching the workdir runs
+before the part that does. **Ordering beats compensating**: one rollback path
+instead of one per early return.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass53.md
+++ b/docs/review-passes/pass53.md
@@ -1,0 +1,31 @@
+# Codex review pass 53 — S155b `live upgrade`
+
+Two findings, both accepted.
+
+## [P1] The project came from the record, not the marker
+
+`sandboxCommandEnvForProject(runtime, d.ProjectID)` took the project from the
+deployment record — the half a stale or hand-edited file can change. This call
+**applies real infrastructure** into whatever it names.
+
+`live teardown` learned this in pass 37 and prefers the marker; I did not carry
+the lesson into new code. A disagreement is now refused outright rather than
+resolved in the record's favour, because applying into a project this workdir
+does not own could change infrastructure belonging to another deployment.
+
+**Applying deserves at least the care destroying gets.** That it took a review to
+notice, in a slice written days after the guard that established the rule, is the
+finding worth remembering.
+
+## [P2] Verification could pass by checking that nothing changed
+
+With no `--tag`, the record still names the **old** version, so `upgrade_verify`
+compared the old tag against the service — which trivially confirms, and reported
+`now confirms nginx:1.27` as though a transition had been proven. A green built
+from checking that nothing changed.
+
+Now `tagChanged` gates the wording: without a new tag the stage says the service
+is *unchanged rather than upgraded*, which is what the evidence actually supports.
+Setting `--tag` to the value already recorded counts as unchanged too.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass54.md
+++ b/docs/review-passes/pass54.md
@@ -1,0 +1,38 @@
+# Codex review pass 54 — S155b `live upgrade`
+
+One finding, accepted. **The incomplete half of pass 53's fix.**
+
+## [P1] The marker was preferred, not required
+
+Pass 53 made the upgrade take its project from the marker — but fell back to the
+deployment record when the marker could not be read. That leaves the **editable**
+half deciding where real infrastructure gets applied, which is the hole the marker
+exists to close. A guard that degrades to the thing it was guarding against is not
+a guard.
+
+Required now. The distinction from `live teardown`, which *does* fall back, is
+deliberate and written down:
+
+| | teardown | upgrade |
+|---|---|---|
+| refusing strands something | yes — a pre-cutover record whose resources are real | no — tear down and deploy again |
+| bounded by existing state | yes, destroy acts on its own workdir's state | no, an apply creates |
+
+Neither argument for falling back holds when applying.
+
+## The pattern in this slice
+
+Five passes, ten findings, and the through-line is not carelessness in ten places
+— it is **one fix applied incompletely, repeatedly**:
+
+- passes 50–52: "did anything reach the cloud?" answered for the tag, then the
+  address, then the workdir, then the ordering
+- passes 53–54: "which project do we trust?" answered by preferring the marker,
+  then by requiring it
+
+Both converged only when the answer became a single mechanism rather than a
+series of correct-looking local patches. Worth remembering: under a one-clean-pass
+rule the second pass is not a formality, it is where a half-applied fix gets
+caught.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass55.md
+++ b/docs/review-passes/pass55.md
@@ -1,0 +1,42 @@
+# Codex review pass 55 — S155b `live upgrade`
+
+One finding, accepted. **ADR-0025's rule, half-implemented for the third time.**
+
+## [P1] Local files decided where a real apply landed
+
+Pass 53 took the project from the marker. Pass 54 made the marker required. Both
+were about *which local file to trust* — and the marker and the record are **both
+local files**, so together they prove only that two local files agree.
+
+ADR-0025 never said "use the marker". It said **two checks that must both pass**:
+the marker for identity, and API provenance for class, *because the second is the
+one that cannot be forged locally*. Editing two files was enough to point a real
+apply at somebody's production project.
+
+`assertRunProjectOurs` now asks the API before applying. It is deliberately not
+the deletion guard: `AssertRunProjectDeletable` treats a project the API reports
+**gone** as fine, because gone is the outcome it wants. Applying is the opposite —
+a project that does not exist, or exists without the stamp, is one this command
+must not touch.
+
+## A wording bug found while fixing it
+
+The first version wrapped `ErrProtectedProject`, which renders as *"refusing to
+delete a project this run did not create"* — on a path that applies. A guard whose
+message describes the wrong operation sends the reader looking in the wrong place.
+Dropped, with the reason recorded so it is not reintroduced for the sentinel's
+convenience.
+
+## Six passes, and the same shape every time
+
+| passes | the question | how it went wrong |
+|---|---|---|
+| 50–52 | did anything reach the cloud? | answered for the tag, then the address, then the workdir, then the ordering |
+| 53–55 | which project do we trust? | the marker, then *required*, then finally the API too |
+
+Ten of eleven findings in this slice are one incomplete answer, not eleven
+mistakes. **The rule already existed and was written down**; each pass applied a
+bit more of it. Reading ADR-0025's own words before writing the guard would have
+collapsed three passes into one.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass56.md
+++ b/docs/review-passes/pass56.md
@@ -1,0 +1,39 @@
+# Codex review pass 56 — S155b `live upgrade`
+
+Two findings, both accepted. Neither is a nit: one is a **false confirmation**,
+which is the exact failure this slice exists to detect.
+
+## [P2] A prefix match confirmed the wrong version
+
+`strings.Contains(body, tag)` confirms tag `1.2` against a service reporting
+`nginx/1.27.4`. That is a service running something other than what the record
+claims — the precise drift S155a was built to catch — reported as confirmation.
+
+`mentionsVersion` requires version boundaries: a match may not be flanked by
+digits, and may not directly follow a dot. So `1.27` is confirmed by `1.27.4` (a
+patch of the same version), `1.2` is not, and `1.27` is not confirmed by `11.27`.
+
+## [P2] The upgrade could overwrite a concurrent teardown
+
+The same lost-update race fixed in `live observe` earlier, on a path I did not
+carry it to — and worse here, because an upgrade holds its record across a **real
+apply**: minutes, not the microseconds a probe takes. A `live teardown` finishing
+in that window would be overwritten and the deployment resurrected.
+
+Re-read before writing, and a record released mid-apply now produces a loud
+failure naming the project, because whatever the apply created is **not** tracked
+by a released record. The window is narrowed, not closed — the store has no
+compare-and-swap, and the comment says so rather than implying otherwise.
+
+## Seven passes
+
+This is the third time in this slice that a fix already written elsewhere was not
+carried to a new path: the marker guard (pass 53), the `applyRan` predicate
+(passes 50–52), and now the re-read-before-write race. Each was solved correctly
+somewhere in the codebase before this slice began.
+
+The lesson is not "review harder". It is that **new code touching an existing
+mechanism should start by reading how that mechanism is already used**, not by
+reimplementing the parts of it that seem needed.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass57.md
+++ b/docs/review-passes/pass57.md
@@ -1,0 +1,37 @@
+# Codex review pass 57 — S155b `live upgrade`
+
+One finding, accepted. **The incomplete half of pass 56's own fix.**
+
+## [P2] The re-read was checked and then discarded
+
+Pass 56 re-read the record before writing, to avoid overwriting a concurrent
+teardown. It used the fresh copy **only** for the released check, then wrote back
+the stale `d` loaded before the apply — discarding anything another writer had
+added in between.
+
+An apply takes minutes. `live observe` on a cron appends observations during
+exactly that window, and those observations are the input S156's promotion gate
+counts. Losing them does not corrupt the record; it **quietly weakens the learning
+signal**, which is harder to notice than a broken one.
+
+Fixed by merging the three fields an upgrade owns — `Tag`, `UpgradedAt`,
+`Address` — onto the fresh record. An allow-list, not a blanket copy: anything an
+upgrade does not own belongs to whoever wrote it last.
+
+`live observe` already did this correctly (it mutates the fresh copy). The pattern
+existed; the new path reimplemented half of it. Again.
+
+## Eight passes, and what they are actually saying
+
+| passes | question | outcome |
+|---|---|---|
+| 50–52 | did anything reach the cloud? | four places |
+| 53–55 | which project do we trust? | three passes to reach the ADR's stated answer |
+| 56–57 | how do you write a record you read a while ago? | fixed, then fixed properly |
+
+Fourteen findings, eleven of them one incomplete answer. **This is the strongest
+evidence yet for the S156 split**: the problem is not review depth, it is that a
+command with six interacting invariants gives every fix five other places to be
+wrong. S154, S170 and S155a — one question each — converged in three passes.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass58.md
+++ b/docs/review-passes/pass58.md
@@ -1,0 +1,14 @@
+# Codex review pass 58 — S155b
+
+**Clean.** No findings.
+
+> I did not identify any discrete correctness, safety, or maintainability issues
+> introduced by the changes. The new live upgrade/version-observation paths are
+> covered by focused tests, and the inspected logic preserves the intended safety
+> gates.
+
+**Converged**, after eight passes and fourteen findings — by far the hardest
+slice of this arc, and the reason S156 was cut into five before being built.
+
+Still owed before this leaves draft: a real-cloud upgrade run. Every guarantee
+here is unit-tested and none has touched Scaleway.

--- a/docs/status/s155b-upgrade-canary.md
+++ b/docs/status/s155b-upgrade-canary.md
@@ -1,0 +1,77 @@
+# S155b canary: an apply is not an upgrade, demonstrated
+
+Run 2026-09-01 against real Scaleway, `fr-par-1`, ~€0.01.
+
+The slice's whole claim is that **Terraform reaching its desired state does not
+mean the service is running the new version**. That claim was unit-tested and
+unproven. This run proved it — and not with a contrived fixture, but with an
+ordinary property of the cloud.
+
+## The run
+
+| step | result |
+|---|---|
+| `deploy` v1 (`--tag 1.27`) | pass — LB serving at `212.47.241.224` |
+| `live observe` | **pass** — *"is serving and confirms nginx:1.27"* |
+| `live upgrade --from <v1.28> --tag 1.28` | **upgrade_verify: FAIL** |
+| `live teardown` | pass — project deleted, sweep clean |
+| account afterwards | 3 projects (all pre-existing), 1 server, 0 LBs |
+
+## What actually happened
+
+```
+- live/upgrade_preflight: pass (confirms nginx:1.27 before the upgrade)
+- sandbox_deploy/apply:   pass
+- live/upgrade_verify:    fail
+```
+
+Confirmed by hand rather than taken from the verdict:
+
+```
+$ curl http://212.47.241.224/
+nginx/1.27.0                       <- the service, still on the OLD version
+
+$ grep nginx <workdir>/main.tf
+echo "nginx/1.28.0" > ...          <- what tofu applied
+
+$ grep nginx <workdir>/.infrafactory-previous/main.tf
+echo "nginx/1.27.0" > ...          <- what it replaced
+```
+
+**The mechanism is mundane and that is the point.** Changing `user_data` on a
+running Scaleway instance does not re-run cloud-init. Terraform updated the
+resource, reported success, and the machine kept serving what it was already
+serving. Nothing was wrong with the apply.
+
+## What this says about every layer below it
+
+That upgrade was **green everywhere else**:
+
+- `sandbox_deploy/apply: pass`
+- the orphan sweep would have reported the account clean, because it was
+- a cost check would have reported nothing unusual, because nothing was
+- the deployment record would have said `nginx:1.28`, because that is what was asked for
+
+Only `upgrade_verify` disagreed, and only because it asked the service instead of
+the record. This is the same shape as **D6** — a failure that every green signal
+in the system agreed was fine — and the same lesson: *a check that asks the thing
+itself is worth more than any number of checks that ask about it.*
+
+## And the diff S156 wanted, produced by accident
+
+The workdir now holds a **failed upgrade with both configurations preserved**:
+the one that was running and the one that did not take effect. That is precisely
+the before/after pair `ExtractFixPitfall` needs, and it arrived from a real
+failure rather than a constructed one.
+
+The lesson available here is genuinely prescriptive — *a user_data change alone
+does not restart a Scaleway instance, so an upgrade expressed that way applies
+cleanly and changes nothing* — which is the class of rule S156e has to produce to
+call the loop closed.
+
+## Cost of the slice, stated
+
+Eight codex passes, fourteen findings, one real-cloud run. The findings are
+catalogued in `docs/review-passes/pass50.md` through `pass58.md`; eleven of the
+fourteen were one incomplete answer spread across six interacting invariants,
+which is why S156 was cut into five slices before being built.

--- a/internal/cli/live_command.go
+++ b/internal/cli/live_command.go
@@ -54,6 +54,16 @@ func newLiveCmd(cfg *rootConfig) *cobra.Command {
 		RunE:  cfg.withRuntime("live observe", runLiveObserveCommand),
 	})
 
+	upgrade := &cobra.Command{
+		Use:   "upgrade <deployment-id>",
+		Short: "Roll a live deployment onto new configuration in place, and prove the version changed",
+		Args:  cobra.ExactArgs(1),
+		RunE:  cfg.withRuntime("live upgrade", runLiveUpgradeCommand),
+	}
+	upgrade.Flags().String("from", "", "Directory holding the new HCL to apply (required)")
+	upgrade.Flags().String("tag", "", "Tag the deployment now claims to run; recorded and verified against the service")
+	cmd.AddCommand(upgrade)
+
 	reap := &cobra.Command{
 		Use:   "reap",
 		Short: "Destroy every live deployment whose TTL has run out",

--- a/internal/cli/live_observe.go
+++ b/internal/cli/live_observe.go
@@ -257,7 +257,7 @@ func checkRunningVersion(ctx context.Context, runtime *CommandRuntime, d livesto
 	}
 
 	// Finding the tag proves it is there, whatever else was cut off.
-	if strings.Contains(result.Body, d.Tag) {
+	if mentionsVersion(result.Body, d.Tag) {
 		return livestore.VersionConfirmed, ""
 	}
 
@@ -292,3 +292,36 @@ func missingProbeTarget(d livestore.Deployment) string {
 	}
 	return ""
 }
+
+// mentionsVersion reports whether body names this exact version.
+//
+// Not strings.Contains: a plain substring match confirms tag "1.2"
+// against a service reporting "nginx/1.27.4", which is a service running
+// something other than what the record claims -- the precise drift this
+// check exists to catch, passed off as confirmation.
+//
+// A match must not be flanked by digits, and must not directly follow a
+// dot. So "1.27" is confirmed by "1.27.4" (a patch of the same version)
+// and "1.2" is not, and "1.27" is not confirmed by "11.27".
+func mentionsVersion(body, tag string) bool {
+	if tag == "" {
+		return false
+	}
+	for offset := 0; ; {
+		idx := strings.Index(body[offset:], tag)
+		if idx < 0 {
+			return false
+		}
+		start := offset + idx
+		end := start + len(tag)
+
+		leftOK := start == 0 || (!isVersionDigit(body[start-1]) && body[start-1] != '.')
+		rightOK := end == len(body) || !isVersionDigit(body[end])
+		if leftOK && rightOK {
+			return true
+		}
+		offset = start + 1
+	}
+}
+
+func isVersionDigit(b byte) bool { return b >= '0' && b <= '9' }

--- a/internal/cli/live_observe_test.go
+++ b/internal/cli/live_observe_test.go
@@ -484,3 +484,29 @@ func TestObserveSaysWhyTheVersionWasUncheckedRatherThanGuessing(t *testing.T) {
 	assert.Contains(t, out.String(), "/version is unreachable")
 	assert.NotContains(t, out.String(), "no version_path declared")
 }
+
+// A plain substring match confirms tag "1.2" against a service reporting
+// "nginx/1.27.4" -- a service running something other than what the
+// record claims, passed off as confirmation. That is the precise drift
+// this check exists to catch.
+func TestVersionMatchingRespectsVersionBoundaries(t *testing.T) {
+	cases := []struct {
+		body, tag string
+		want      bool
+		why       string
+	}{
+		{"nginx/1.27.4", "1.27", true, "a patch of the same version confirms it"},
+		{"nginx/1.27.4", "1.2", false, "1.2 is not 1.27, however the substring falls"},
+		{"nginx/11.27", "1.27", false, "and 11.27 is not 1.27"},
+		{"nginx/1.27", "1.27", true, "exact"},
+		{"running 1.27 now", "1.27", true, "surrounded by spaces"},
+		{"v1.27", "1.27", true, "a leading v is not a digit"},
+		{"1.270", "1.27", false, "nor is 1.270"},
+		{"anything", "", false, "an empty tag confirms nothing"},
+	}
+
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, mentionsVersion(tc.body, tc.tag),
+			"%q vs %q: %s", tc.body, tc.tag, tc.why)
+	}
+}

--- a/internal/cli/live_upgrade.go
+++ b/internal/cli/live_upgrade.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -107,14 +108,44 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 	})
 	stages, failures = appendSandboxDeployResult(stages, failures, applyResult, applyErr)
 
-	// The record moves to the new tag whether or not the apply worked.
-	// A half-finished upgrade is running something, and a record still
+	// The record moves to the new tag only if the apply actually RAN.
+	//
+	// A half-finished apply is running something, and a record still
 	// claiming the old version would send the next observation looking
-	// for the wrong thing.
-	if strings.TrimSpace(newTag) != "" {
-		d.Tag = strings.TrimSpace(newTag)
+	// for the wrong thing -- so a failure during apply still advances it.
+	// But a failure at init or plan changed nothing at all, and advancing
+	// the tag there would make the record claim a version that was never
+	// deployed, which is the exact falsehood S155a exists to prevent.
+	if applyRan(applyErr) {
+		if strings.TrimSpace(newTag) != "" {
+			d.Tag = strings.TrimSpace(newTag)
+		}
+		d.UpgradedAt = time.Now()
+
+		// The address can move: replacement HCL may recreate the load
+		// balancer. Verifying against the address captured at first
+		// deploy would probe infrastructure this deployment no longer
+		// owns, and leave every later observation pointed there too.
+		if address, addrErr := harness.LiveEndpoint(d.WorkDir, "load_balancer"); addrErr == nil && address != "" {
+			if address != d.Address {
+				stages = append(stages, StageSummary{
+					Layer: "live", Stage: "upgrade_address", Status: StageStatusPass,
+					Detail: fmt.Sprintf("%s moved from %s to %s", d.ID, d.Address, address),
+				})
+			}
+			d.Address = address
+		} else if d.Address != "" {
+			// Said out loud rather than assumed unchanged: everything
+			// after this probes an address nothing just confirmed.
+			stages = append(stages, StageSummary{
+				Layer: "live", Stage: "upgrade_address", Status: StageStatusSkip,
+				Detail: fmt.Sprintf(
+					"could not re-read the endpoint after the apply, so %s is still assumed to serve at %s",
+					d.ID, d.Address),
+			})
+		}
 	}
-	d.UpgradedAt = time.Now()
+
 	if err := store.Put(d); err != nil {
 		failures = append(failures, FailureSummary{
 			Layer: "live", Stage: "upgrade", Check: "record",
@@ -308,4 +339,21 @@ func reportUpgrade(cmd *cobra.Command, d livestore.Deployment, stages []StageSum
 			"%s was not upgraded cleanly", d.ID)}
 	}
 	return nil
+}
+
+// applyRan reports whether the apply stage actually executed.
+//
+// A failure at init or plan changed nothing on the cloud, so the record
+// must not move; a failure during apply may have changed a great deal,
+// so it must. Anything unrecognised is treated as "it ran", because
+// assuming nothing happened is the answer that loses infrastructure.
+func applyRan(err error) bool {
+	if err == nil {
+		return true
+	}
+	var deployErr *harness.SandboxDeployError
+	if errors.As(err, &deployErr) {
+		return deployErr.Stage != "init" && deployErr.Stage != "plan"
+	}
+	return true
 }

--- a/internal/cli/live_upgrade.go
+++ b/internal/cli/live_upgrade.go
@@ -253,7 +253,29 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 		}
 	}
 
-	if err := store.Put(d); err != nil {
+	// Re-read before writing, as `live observe` does. An upgrade holds
+	// its record across a real apply -- minutes, not microseconds -- and
+	// a `live teardown` finishing in that window would be overwritten by
+	// this write, resurrecting a deployment that is already gone.
+	//
+	// The window is narrowed, not closed: the store has no
+	// compare-and-swap, and claiming more than narrowing would be wrong.
+	if fresh, readErr := store.Get(d.ID); readErr != nil {
+		failures = append(failures, FailureSummary{
+			Layer: "live", Stage: "upgrade", Check: "record",
+			Command: "live upgrade " + d.ID,
+			Detail: fmt.Sprintf(
+				"%s was applied but its record could not be re-read to save the result: %v", d.ID, readErr),
+		})
+	} else if fresh.State == livestore.StateReleased {
+		failures = append(failures, FailureSummary{
+			Layer: "live", Stage: "upgrade", Check: "record",
+			Command: "live upgrade " + d.ID,
+			Detail: fmt.Sprintf(
+				"%s was torn down while this upgrade was applying. Whatever the apply created is NOT tracked by "+
+					"that record -- check project %s by hand", d.ID, d.ProjectID),
+		})
+	} else if err := store.Put(d); err != nil {
 		failures = append(failures, FailureSummary{
 			Layer: "live", Stage: "upgrade", Check: "record",
 			Command: "live upgrade " + d.ID,

--- a/internal/cli/live_upgrade.go
+++ b/internal/cli/live_upgrade.go
@@ -123,17 +123,32 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 	// names -- so a disagreement is refused rather than resolved in the
 	// record's favour. `live teardown` learned this in pass 37; applying
 	// deserves at least the care destroying gets.
-	applyProjectID := d.ProjectID
-	if marker, markerErr := harness.ReadRunProjectMarker(d.WorkDir); markerErr == nil {
-		if marker.ProjectID != d.ProjectID {
-			return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: fmt.Errorf(
-				"refusing to upgrade %s: the record names project %s but %s names %s. "+
-					"Applying into a project this workdir does not own could change infrastructure "+
-					"belonging to another deployment",
-				d.ID, d.ProjectID, harness.RunProjectMarkerFilename, marker.ProjectID)}
-		}
-		applyProjectID = marker.ProjectID
+	// REQUIRED, not merely preferred. Falling back to the record when the
+	// marker cannot be read would leave the editable half deciding where
+	// real infrastructure gets applied, which is the hole the marker
+	// exists to close.
+	//
+	// `live teardown` does fall back, deliberately (pass 35): refusing
+	// there would strand a pre-cutover record whose resources are real,
+	// and destroy is bounded by the state in its own workdir anyway.
+	// Neither argument holds here. Applying is not bounded by anything
+	// already deployed, and an operator who cannot upgrade can still tear
+	// down and deploy again -- nothing is stranded by refusing.
+	marker, markerErr := harness.ReadRunProjectMarker(d.WorkDir)
+	if markerErr != nil {
+		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+			"refusing to upgrade %s: %v. Without it the only thing naming a project to apply into is the "+
+				"deployment record, which is editable -- tear down and deploy again rather than applying on that basis",
+			d.ID, markerErr)}
 	}
+	if marker.ProjectID != d.ProjectID {
+		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+			"refusing to upgrade %s: the record names project %s but %s names %s. "+
+				"Applying into a project this workdir does not own could change infrastructure "+
+				"belonging to another deployment",
+			d.ID, d.ProjectID, harness.RunProjectMarkerFilename, marker.ProjectID)}
+	}
+	applyProjectID := marker.ProjectID
 
 	sandboxEnv, err := sandboxCommandEnvForProject(runtime, applyProjectID)
 	if err != nil {

--- a/internal/cli/live_upgrade.go
+++ b/internal/cli/live_upgrade.go
@@ -73,6 +73,14 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 			"%s records no work_dir, so its existing state cannot be updated in place", d.ID)}
 	}
 
+	// The same opt-in `deploy` requires. An upgrade applies to real
+	// infrastructure exactly as a first deploy does, and a gate that
+	// guards one entry point and not the other guards nothing.
+	if !runtime.Config.Validation.Layers.SandboxDeploy.Enabled {
+		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: errors.New(
+			"live upgrade applies to real infrastructure and requires validation.layers.sandbox_deploy.enabled")}
+	}
+
 	if err := assertDeployableSource(source); err != nil {
 		return &CLIError{Op: "live upgrade", Code: errorCodeUsage, Err: err}
 	}
@@ -98,19 +106,34 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 		return &CLIError{Op: "live upgrade", Code: errorCodeUsage, Err: err}
 	}
 
+	// Every fallible step that does NOT touch the workdir happens first.
+	//
+	// The swap below is destructive, so anything that can fail after it
+	// leaves the workdir holding configuration that was never applied.
+	// Ordering removes that failure mode instead of compensating for it,
+	// which is the difference between one rollback path and one per
+	// early return.
+	//
+	// The deployment's OWN project, so the apply updates what is already
+	// there rather than building a second copy somewhere else.
+	sandboxEnv, err := sandboxCommandEnvForProject(runtime, d.ProjectID)
+	if err != nil {
+		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: err}
+	}
+
 	_, _ = fmt.Fprintf(progress, "Upgrading %s in project %s\n", d.ID, d.ProjectID)
 
 	if err := stashPreviousHCL(d.WorkDir); err != nil {
 		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: err}
 	}
 	if err := replaceDeployedHCL(source, d.WorkDir); err != nil {
-		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: err}
-	}
-
-	// The deployment's OWN project, so the apply updates what is already
-	// there rather than building a second copy somewhere else.
-	sandboxEnv, err := sandboxCommandEnvForProject(runtime, d.ProjectID)
-	if err != nil {
+		// The swap failed partway, so the workdir may hold a mixture.
+		// Put back what was running rather than leaving it ambiguous.
+		if restoreErr := restorePreviousHCL(d.WorkDir); restoreErr != nil {
+			return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+				"%w; and the previous configuration could not be restored: %v (it is in %s)",
+				err, restoreErr, PreviousHCLDirname)}
+		}
 		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: err}
 	}
 

--- a/internal/cli/live_upgrade.go
+++ b/internal/cli/live_upgrade.go
@@ -155,6 +155,19 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: err}
 	}
 
+	// The other half of ADR-0025's rule, and the half that is not
+	// forgeable locally. The marker gives identity -- this workdir owns
+	// that project -- but the marker is a file, and so is the record.
+	// Both together still only prove that two local files agree.
+	//
+	// Provenance asks the API whether the project is one of
+	// infrafactory's disposable ones. Without it, editing two files is
+	// enough to point a real apply at somebody's production project.
+	if err := assertRunProjectOurs(ctx, runtime, applyProjectID, sandboxEnv); err != nil {
+		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+			"refusing to upgrade %s: %w", d.ID, err)}
+	}
+
 	_, _ = fmt.Fprintf(progress, "Upgrading %s in project %s\n", d.ID, d.ProjectID)
 
 	if err := stashPreviousHCL(d.WorkDir); err != nil {
@@ -536,6 +549,44 @@ func restorePreviousHCL(workDir string) error {
 		if err := os.WriteFile(filepath.Join(workDir, entry.Name()), payload, 0o644); err != nil {
 			return fmt.Errorf("restore %s: %w", entry.Name(), err)
 		}
+	}
+	return nil
+}
+
+// assertRunProjectOurs asks the API whether a project is one of
+// infrafactory's disposable run projects, before real infrastructure is
+// applied into it.
+//
+// The deletion guard (AssertRunProjectDeletable) treats a project the API
+// reports GONE as fine, because gone is the outcome it wants. Applying is
+// the opposite: a project that does not exist, or exists without the
+// stamp, is one this command must not touch.
+//
+// An unreachable API refuses, for the same reason every other guard in
+// this arc does -- "we could not check" must never behave like "it is
+// fine".
+//
+// Deliberately NOT wrapping ErrProtectedProject: that sentinel renders as
+// "refusing to delete a project this run did not create", which is
+// actively wrong on a path that applies. A guard whose message describes
+// the wrong operation sends the reader looking in the wrong place.
+func assertRunProjectOurs(ctx context.Context, runtime *CommandRuntime, projectID string, sandboxEnv map[string]string) error {
+	if runtime.Deps.RunProject == nil {
+		return fmt.Errorf("no run-project client, so the project's provenance cannot be checked")
+	}
+
+	provenance, err := runtime.Deps.RunProject.Describe(ctx, sandboxEnv["SCW_SECRET_KEY"], projectID)
+	if err != nil {
+		return fmt.Errorf("could not verify project %s with the API: %v", projectID, err)
+	}
+	if !provenance.Exists {
+		return fmt.Errorf("project %s no longer exists, so there is nothing to upgrade in it", projectID)
+	}
+	if !provenance.IsInfrafactoryRunProject() {
+		return fmt.Errorf(
+			"%s does not carry infrafactory's stamp (name %q, description %q). Local files say this "+
+				"deployment owns it and the API disagrees -- refusing rather than applying into it",
+			projectID, provenance.Name, provenance.Description)
 	}
 	return nil
 }

--- a/internal/cli/live_upgrade.go
+++ b/internal/cli/live_upgrade.go
@@ -1,0 +1,311 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redscaresu/infrafactory/internal/harness"
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+// PreviousHCLDirname holds the configuration a deployment was running
+// before its most recent upgrade.
+//
+// Kept because it is the input S156 needs and cannot reconstruct.
+// `ExtractFixPitfall` is the extractor that produces prescriptive rules,
+// and it works by diffing a failing configuration against a passing one.
+// A live failure has no "next iteration that fixed it" -- but an upgrade
+// has a before and an after, which is the same shape. Discarding the
+// previous HCL would leave live signals stuck at the weakest class of
+// lesson.
+const PreviousHCLDirname = ".infrafactory-previous"
+
+// runLiveUpgradeCommand rolls a live deployment forward onto new
+// configuration, in place (S155).
+//
+// infrafactory does not invent the new HCL. It owns the part that is
+// hard to get right: applying it into the SAME project the deployment
+// already owns, under the same guards a first deploy runs, and proving
+// afterwards that the version actually changed.
+//
+// Deliberately not parameterised through TF_VAR. `SandboxStripEnv`
+// removes TF_VAR_* because the cost bounds read a variable's DEFAULT to
+// decide blast radius, so an injected variable would make those checks
+// vouch for a number that never reaches the API. Handing over whole HCL
+// keeps every existing check applying to the configuration that is
+// actually applied.
+func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRuntime) error {
+	ctx := cmd.Context()
+	progress := cmd.ErrOrStderr()
+
+	source, err := cmd.Flags().GetString("from")
+	if err != nil {
+		return &CLIError{Op: "live upgrade", Code: errorCodeUsage, Err: err}
+	}
+	if strings.TrimSpace(source) == "" {
+		return &CLIError{Op: "live upgrade", Code: errorCodeUsage, Err: fmt.Errorf(
+			"--from is required: an upgrade applies new configuration, and there is nowhere else for it to come from")}
+	}
+	newTag, err := cmd.Flags().GetString("tag")
+	if err != nil {
+		return &CLIError{Op: "live upgrade", Code: errorCodeUsage, Err: err}
+	}
+
+	store := livestore.NewFilesystemStore(runtime.LiveStoreRoot())
+	d, err := store.Get(args[0])
+	if err != nil {
+		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: err}
+	}
+	if d.State == livestore.StateReleased {
+		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+			"%s was already torn down, so there is nothing running to upgrade", d.ID)}
+	}
+	if d.WorkDir == "" {
+		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+			"%s records no work_dir, so its existing state cannot be updated in place", d.ID)}
+	}
+
+	if err := assertDeployableSource(source); err != nil {
+		return &CLIError{Op: "live upgrade", Code: errorCodeUsage, Err: err}
+	}
+	// The same deny-by-default the first deploy ran. New configuration is
+	// new configuration whether it arrives through `deploy` or here.
+	if err := layer3PreflightHCL(source, runtime.Config.Validation.Layers.SandboxDeploy.AllowResourceTypes); err != nil {
+		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: fmt.Errorf("layer 3 hcl validation: %w", err)}
+	}
+
+	stages, failures := upgradePreflight(ctx, runtime, d)
+	if len(failures) > 0 {
+		return reportUpgrade(cmd, d, stages, failures)
+	}
+
+	_, _ = fmt.Fprintf(progress, "Upgrading %s in project %s\n", d.ID, d.ProjectID)
+
+	if err := stashPreviousHCL(d.WorkDir); err != nil {
+		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: err}
+	}
+	if err := replaceDeployedHCL(source, d.WorkDir); err != nil {
+		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: err}
+	}
+
+	// The deployment's OWN project, so the apply updates what is already
+	// there rather than building a second copy somewhere else.
+	sandboxEnv, err := sandboxCommandEnvForProject(runtime, d.ProjectID)
+	if err != nil {
+		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: err}
+	}
+
+	applyResult, applyErr := runDeployApply(cmd, ctx, signal.NotifyContext, func(applyCtx context.Context) (*harness.SandboxDeployResult, error) {
+		return runtime.Deps.SandboxDeploy.Run(applyCtx, d.WorkDir, sandboxEnv)
+	})
+	stages, failures = appendSandboxDeployResult(stages, failures, applyResult, applyErr)
+
+	// The record moves to the new tag whether or not the apply worked.
+	// A half-finished upgrade is running something, and a record still
+	// claiming the old version would send the next observation looking
+	// for the wrong thing.
+	if strings.TrimSpace(newTag) != "" {
+		d.Tag = strings.TrimSpace(newTag)
+	}
+	d.UpgradedAt = time.Now()
+	if err := store.Put(d); err != nil {
+		failures = append(failures, FailureSummary{
+			Layer: "live", Stage: "upgrade", Check: "record",
+			Command: "live upgrade " + d.ID,
+			Detail:  fmt.Sprintf("%s was applied but the record still names the old version: %v", d.ID, err),
+		})
+	}
+
+	if applyErr == nil {
+		stages, failures = appendUpgradeVerification(ctx, runtime, d, stages, failures)
+	}
+
+	return reportUpgrade(cmd, d, stages, failures)
+}
+
+// upgradePreflight refuses an upgrade whose starting point is not known.
+//
+// An upgrade from a version nobody confirmed proves nothing, and one
+// from a version the service actively contradicts is worse: it would
+// record a v1→v2 transition that never happened. Unchecked is allowed
+// and said out loud; contradicted is not.
+func upgradePreflight(ctx context.Context, runtime *CommandRuntime, d livestore.Deployment) ([]StageSummary, []FailureSummary) {
+	if d.VersionPath == "" {
+		return []StageSummary{{
+			Layer: "live", Stage: "upgrade_preflight", Status: StageStatusSkip,
+			Detail: fmt.Sprintf(
+				"%s declares no version_path, so what it is running now is unverified and the upgrade cannot be proven to have changed anything",
+				d.ID),
+		}}, nil
+	}
+
+	before, detail := checkRunningVersion(ctx, runtime, d)
+	switch before {
+	case livestore.VersionUnconfirmed:
+		return []StageSummary{{Layer: "live", Stage: "upgrade_preflight", Status: StageStatusFail}},
+			[]FailureSummary{{
+				Layer: "live", Stage: "upgrade_preflight", Check: "version_before",
+				Command: "live upgrade " + d.ID,
+				Detail: fmt.Sprintf(
+					"refusing to upgrade %s: %s. Upgrading from a version the service contradicts would record a transition that never happened",
+					d.ID, detail),
+			}}
+	case livestore.VersionUnchecked:
+		return []StageSummary{{
+			Layer: "live", Stage: "upgrade_preflight", Status: StageStatusSkip,
+			Detail: fmt.Sprintf("%s: starting version unchecked (%s)", d.ID, detail),
+		}}, nil
+	}
+
+	return []StageSummary{{
+		Layer: "live", Stage: "upgrade_preflight", Status: StageStatusPass,
+		Detail: fmt.Sprintf("%s confirms %s before the upgrade", d.ID, imageRef(d)),
+	}}, nil
+}
+
+// appendUpgradeVerification is the point of the whole command.
+//
+// A successful apply says Terraform reached its desired state. It does
+// NOT say the service is running the new version -- the instance may not
+// have restarted, the image may not have been pulled, the user data may
+// never have run. Reporting an upgrade on the strength of the apply is
+// the same error as trusting the record over the service, one step
+// later.
+func appendUpgradeVerification(
+	ctx context.Context,
+	runtime *CommandRuntime,
+	d livestore.Deployment,
+	stages []StageSummary,
+	failures []FailureSummary,
+) ([]StageSummary, []FailureSummary) {
+	if d.VersionPath == "" {
+		return append(stages, StageSummary{
+			Layer: "live", Stage: "upgrade_verify", Status: StageStatusSkip,
+			Detail: "no version_path, so the apply is all there is to go on",
+		}), failures
+	}
+
+	after, detail := checkRunningVersion(ctx, runtime, d)
+	switch after {
+	case livestore.VersionConfirmed:
+		return append(stages, StageSummary{
+			Layer: "live", Stage: "upgrade_verify", Status: StageStatusPass,
+			Detail: fmt.Sprintf("%s now confirms %s", d.ID, imageRef(d)),
+		}), failures
+	case livestore.VersionUnconfirmed:
+		return append(stages, StageSummary{Layer: "live", Stage: "upgrade_verify", Status: StageStatusFail}),
+			append(failures, FailureSummary{
+				Layer: "live", Stage: "upgrade_verify", Check: "version_after",
+				Command: "live upgrade " + d.ID,
+				Detail: fmt.Sprintf(
+					"the apply succeeded but %s. An apply reaching its desired state is not the service running the new version",
+					detail),
+			})
+	}
+
+	return append(stages, StageSummary{
+		Layer: "live", Stage: "upgrade_verify", Status: StageStatusSkip,
+		Detail: fmt.Sprintf("%s: could not verify the new version (%s)", d.ID, detail),
+	}), failures
+}
+
+// stashPreviousHCL copies the configuration currently deployed into
+// PreviousHCLDirname before it is overwritten.
+//
+// One generation deep, deliberately: S156 needs the pair either side of
+// one change, and keeping every generation would turn a workdir into an
+// archive nobody prunes.
+func stashPreviousHCL(workDir string) error {
+	previous := filepath.Join(workDir, PreviousHCLDirname)
+	if err := os.RemoveAll(previous); err != nil {
+		return fmt.Errorf("clear previous hcl: %w", err)
+	}
+	if err := os.MkdirAll(previous, 0o755); err != nil {
+		return fmt.Errorf("create previous hcl dir: %w", err)
+	}
+
+	entries, err := os.ReadDir(workDir)
+	if err != nil {
+		return fmt.Errorf("read deployment workdir: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !hasDeployableExtension(entry.Name()) {
+			continue
+		}
+		payload, err := os.ReadFile(filepath.Join(workDir, entry.Name()))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", entry.Name(), err)
+		}
+		if err := os.WriteFile(filepath.Join(previous, entry.Name()), payload, 0o644); err != nil {
+			return fmt.Errorf("stash %s: %w", entry.Name(), err)
+		}
+	}
+	return nil
+}
+
+// replaceDeployedHCL swaps the workdir's configuration for the new one.
+//
+// Old .tf files are removed first. Copying over the top would leave a
+// resource behind that the new configuration no longer declares, and
+// tofu would keep managing it -- an upgrade that silently kept something
+// the operator had deleted.
+func replaceDeployedHCL(source, workDir string) error {
+	entries, err := os.ReadDir(workDir)
+	if err != nil {
+		return fmt.Errorf("read deployment workdir: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !hasDeployableExtension(entry.Name()) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(workDir, entry.Name())); err != nil {
+			return fmt.Errorf("remove superseded %s: %w", entry.Name(), err)
+		}
+	}
+
+	newEntries, err := os.ReadDir(source)
+	if err != nil {
+		return fmt.Errorf("read new hcl: %w", err)
+	}
+	for _, entry := range newEntries {
+		if entry.IsDir() || !hasDeployableExtension(entry.Name()) {
+			continue
+		}
+		payload, err := os.ReadFile(filepath.Join(source, entry.Name()))
+		if err != nil {
+			return fmt.Errorf("read %s: %w", entry.Name(), err)
+		}
+		if err := os.WriteFile(filepath.Join(workDir, entry.Name()), payload, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", entry.Name(), err)
+		}
+	}
+	return nil
+}
+
+func reportUpgrade(cmd *cobra.Command, d livestore.Deployment, stages []StageSummary, failures []FailureSummary) error {
+	status := CommandStatusSuccess
+	if len(failures) > 0 {
+		status = CommandStatusFailed
+	}
+	if err := writeCommandOutput(cmd, OutputResult{
+		Command:  "live upgrade",
+		Scenario: d.Scenario,
+		Status:   status,
+		Stages:   stages,
+		Failures: failures,
+	}); err != nil {
+		return err
+	}
+	if status == CommandStatusFailed {
+		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+			"%s was not upgraded cleanly", d.ID)}
+	}
+	return nil
+}

--- a/internal/cli/live_upgrade.go
+++ b/internal/cli/live_upgrade.go
@@ -87,6 +87,17 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 		return reportUpgrade(cmd, d, stages, failures)
 	}
 
+	// Refuse a source that IS the workdir, or lives inside it.
+	//
+	// replaceDeployedHCL removes the superseded .tf files before copying
+	// the new ones in, so pointing --from at the deployment's own workdir
+	// deletes the very files it is about to read: the workdir ends up
+	// holding no configuration at all, for infrastructure that is still
+	// running.
+	if err := assertUpgradeSourceIsSeparate(source, d.WorkDir); err != nil {
+		return &CLIError{Op: "live upgrade", Code: errorCodeUsage, Err: err}
+	}
+
 	_, _ = fmt.Fprintf(progress, "Upgrading %s in project %s\n", d.ID, d.ProjectID)
 
 	if err := stashPreviousHCL(d.WorkDir); err != nil {
@@ -107,6 +118,30 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 		return runtime.Deps.SandboxDeploy.Run(applyCtx, d.WorkDir, sandboxEnv)
 	})
 	stages, failures = appendSandboxDeployResult(stages, failures, applyResult, applyErr)
+
+	// An init or plan failure never reached the cloud, so the deployment
+	// is still running the OLD configuration -- and the workdir would be
+	// left holding the new, rejected one. Every later operation would
+	// then plan against configuration that was never applied. Put it
+	// back, and say so.
+	if !applyRan(applyErr) {
+		if restoreErr := restorePreviousHCL(d.WorkDir); restoreErr != nil {
+			failures = append(failures, FailureSummary{
+				Layer: "live", Stage: "upgrade_rollback", Check: "restore",
+				Command: "live upgrade " + d.ID,
+				Detail: fmt.Sprintf(
+					"%s was not applied, but its workdir still holds the rejected configuration and could not be reverted: %v. "+
+						"The previous configuration is in %s",
+					d.ID, restoreErr, PreviousHCLDirname),
+			})
+		} else {
+			stages = append(stages, StageSummary{
+				Layer: "live", Stage: "upgrade_rollback", Status: StageStatusPass,
+				Detail: fmt.Sprintf(
+					"nothing was applied, so %s keeps the configuration it was already running", d.ID),
+			})
+		}
+	}
 
 	// The record moves to the new tag only if the apply actually RAN.
 	//
@@ -356,4 +391,78 @@ func applyRan(err error) bool {
 		return deployErr.Stage != "init" && deployErr.Stage != "plan"
 	}
 	return true
+}
+
+// assertUpgradeSourceIsSeparate refuses a source that is, or is inside,
+// the deployment's own workdir.
+//
+// Symlinks are resolved before comparing, because the check protects
+// against deleting the files about to be read and a symlinked path
+// deletes them just as effectively as a literal one.
+func assertUpgradeSourceIsSeparate(source, workDir string) error {
+	resolve := func(path string) (string, error) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return "", err
+		}
+		if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+			return resolved, nil
+		}
+		return abs, nil
+	}
+
+	src, err := resolve(source)
+	if err != nil {
+		return fmt.Errorf("resolve --from %s: %w", source, err)
+	}
+	wd, err := resolve(workDir)
+	if err != nil {
+		return fmt.Errorf("resolve deployment workdir %s: %w", workDir, err)
+	}
+
+	if src == wd || strings.HasPrefix(src, wd+string(os.PathSeparator)) {
+		return fmt.Errorf(
+			"--from %s is the deployment's own workdir (%s): the superseded configuration is removed before "+
+				"the new one is copied in, so this would leave the workdir with no configuration at all while "+
+				"the infrastructure is still running",
+			source, workDir)
+	}
+	return nil
+}
+
+// restorePreviousHCL puts the stashed configuration back, for an upgrade
+// that never reached the cloud.
+func restorePreviousHCL(workDir string) error {
+	previous := filepath.Join(workDir, PreviousHCLDirname)
+	entries, err := os.ReadDir(previous)
+	if err != nil {
+		return fmt.Errorf("read stashed configuration: %w", err)
+	}
+
+	current, err := os.ReadDir(workDir)
+	if err != nil {
+		return fmt.Errorf("read deployment workdir: %w", err)
+	}
+	for _, entry := range current {
+		if entry.IsDir() || !hasDeployableExtension(entry.Name()) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(workDir, entry.Name())); err != nil {
+			return fmt.Errorf("remove rejected %s: %w", entry.Name(), err)
+		}
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !hasDeployableExtension(entry.Name()) {
+			continue
+		}
+		payload, err := os.ReadFile(filepath.Join(previous, entry.Name()))
+		if err != nil {
+			return fmt.Errorf("read stashed %s: %w", entry.Name(), err)
+		}
+		if err := os.WriteFile(filepath.Join(workDir, entry.Name()), payload, 0o644); err != nil {
+			return fmt.Errorf("restore %s: %w", entry.Name(), err)
+		}
+	}
+	return nil
 }

--- a/internal/cli/live_upgrade.go
+++ b/internal/cli/live_upgrade.go
@@ -275,7 +275,7 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 				"%s was torn down while this upgrade was applying. Whatever the apply created is NOT tracked by "+
 					"that record -- check project %s by hand", d.ID, d.ProjectID),
 		})
-	} else if err := store.Put(d); err != nil {
+	} else if err := store.Put(mergeUpgradeOntoFresh(fresh, d)); err != nil {
 		failures = append(failures, FailureSummary{
 			Layer: "live", Stage: "upgrade", Check: "record",
 			Command: "live upgrade " + d.ID,
@@ -611,4 +611,24 @@ func assertRunProjectOurs(ctx context.Context, runtime *CommandRuntime, projectI
 			projectID, provenance.Name, provenance.Description)
 	}
 	return nil
+}
+
+// mergeUpgradeOntoFresh applies the fields an upgrade owns onto the
+// record as it stands NOW, rather than writing back the copy this
+// command loaded before the apply.
+//
+// Re-reading only to check whether the record was released was half the
+// fix: `live observe` may have appended observations during an apply that
+// takes minutes, and overwriting with the stale copy silently discards
+// them. Those observations are the input S156's promotion gate counts, so
+// losing them does not corrupt the record -- it quietly weakens the
+// learning signal, which is harder to notice.
+//
+// An allow-list of three fields, not a blanket copy: anything an upgrade
+// does not own belongs to whoever wrote it last.
+func mergeUpgradeOntoFresh(fresh, upgraded livestore.Deployment) livestore.Deployment {
+	fresh.Tag = upgraded.Tag
+	fresh.UpgradedAt = upgraded.UpgradedAt
+	fresh.Address = upgraded.Address
+	return fresh
 }

--- a/internal/cli/live_upgrade.go
+++ b/internal/cli/live_upgrade.go
@@ -116,7 +116,26 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 	//
 	// The deployment's OWN project, so the apply updates what is already
 	// there rather than building a second copy somewhere else.
-	sandboxEnv, err := sandboxCommandEnvForProject(runtime, d.ProjectID)
+	//
+	// From the MARKER, as every destroy path does since ADR-0025. The
+	// record's project id is the half a stale or hand-edited file can
+	// change, and this call applies real infrastructure into whatever it
+	// names -- so a disagreement is refused rather than resolved in the
+	// record's favour. `live teardown` learned this in pass 37; applying
+	// deserves at least the care destroying gets.
+	applyProjectID := d.ProjectID
+	if marker, markerErr := harness.ReadRunProjectMarker(d.WorkDir); markerErr == nil {
+		if marker.ProjectID != d.ProjectID {
+			return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+				"refusing to upgrade %s: the record names project %s but %s names %s. "+
+					"Applying into a project this workdir does not own could change infrastructure "+
+					"belonging to another deployment",
+				d.ID, d.ProjectID, harness.RunProjectMarkerFilename, marker.ProjectID)}
+		}
+		applyProjectID = marker.ProjectID
+	}
+
+	sandboxEnv, err := sandboxCommandEnvForProject(runtime, applyProjectID)
 	if err != nil {
 		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: err}
 	}
@@ -174,9 +193,11 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 	// But a failure at init or plan changed nothing at all, and advancing
 	// the tag there would make the record claim a version that was never
 	// deployed, which is the exact falsehood S155a exists to prevent.
+	tagChanged := false
 	if applyRan(applyErr) {
-		if strings.TrimSpace(newTag) != "" {
-			d.Tag = strings.TrimSpace(newTag)
+		if trimmed := strings.TrimSpace(newTag); trimmed != "" && trimmed != d.Tag {
+			d.Tag = trimmed
+			tagChanged = true
 		}
 		d.UpgradedAt = time.Now()
 
@@ -213,7 +234,7 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 	}
 
 	if applyErr == nil {
-		stages, failures = appendUpgradeVerification(ctx, runtime, d, stages, failures)
+		stages, failures = appendUpgradeVerification(ctx, runtime, d, tagChanged, stages, failures)
 	}
 
 	return reportUpgrade(cmd, d, stages, failures)
@@ -271,6 +292,7 @@ func appendUpgradeVerification(
 	ctx context.Context,
 	runtime *CommandRuntime,
 	d livestore.Deployment,
+	tagChanged bool,
 	stages []StageSummary,
 	failures []FailureSummary,
 ) ([]StageSummary, []FailureSummary) {
@@ -284,6 +306,19 @@ func appendUpgradeVerification(
 	after, detail := checkRunningVersion(ctx, runtime, d)
 	switch after {
 	case livestore.VersionConfirmed:
+		// Without a new tag the record still names the OLD version, so
+		// confirming it proves the service is running what the record
+		// says -- and proves nothing about a transition. Reporting
+		// "upgraded" here would be a green built from checking that
+		// nothing changed.
+		if !tagChanged {
+			return append(stages, StageSummary{
+				Layer: "live", Stage: "upgrade_verify", Status: StageStatusPass,
+				Detail: fmt.Sprintf(
+					"%s still confirms %s: no --tag was given, so this shows the service is unchanged rather than upgraded",
+					d.ID, imageRef(d)),
+			}), failures
+		}
 		return append(stages, StageSummary{
 			Layer: "live", Stage: "upgrade_verify", Status: StageStatusPass,
 			Detail: fmt.Sprintf("%s now confirms %s", d.ID, imageRef(d)),

--- a/internal/cli/live_upgrade_test.go
+++ b/internal/cli/live_upgrade_test.go
@@ -580,3 +580,28 @@ func TestUpgradeRefusesAProjectThatNoLongerExists(t *testing.T) {
 	assert.Contains(t, err.Error(), "no longer exists")
 	assert.Zero(t, deploy.calls)
 }
+
+// An upgrade holds its record across a real apply -- minutes, not
+// microseconds -- so a teardown finishing in that window would be
+// overwritten by the upgrade's write, resurrecting a deployment that is
+// already gone.
+func TestUpgradeDoesNotResurrectARecordTornDownWhileApplying(t *testing.T) {
+	sandboxCredsForTest(t)
+	probe := &stagingVersionProbe{running: "nginx/1.27.4"}
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, probe, deploy)
+	d := upgradeableDeployment(t, store, "dep-racing-upgrade", "1.27")
+
+	// Teardown lands while the apply is running.
+	deploy.onRun = func() { require.NoError(t, store.MarkReleased(d.ID)) }
+
+	var out strings.Builder
+	require.Error(t, runUpgrade(t, rt, d.ID, &out, "--from", newHCLDir(t), "--tag", "1.28"))
+
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	assert.Equal(t, livestore.StateReleased, got.State, "the teardown stands")
+	assert.Equal(t, "1.27", got.Tag, "and the upgrade does not write over it")
+	assert.Contains(t, out.String(), "was torn down while this upgrade was applying")
+	assert.Contains(t, out.String(), "check project")
+}

--- a/internal/cli/live_upgrade_test.go
+++ b/internal/cli/live_upgrade_test.go
@@ -336,3 +336,74 @@ func writeUpgradeStateWithLBAddress(t *testing.T, workDir, address string) {
 	require.NoError(t, os.WriteFile(
 		filepath.Join(workDir, harness.LiveStateFilename), []byte(state), 0o600))
 }
+
+// replaceDeployedHCL removes the superseded .tf files before copying the
+// new ones in, so a --from pointing at the workdir deletes the files it
+// is about to read -- leaving no configuration at all for infrastructure
+// that is still running.
+func TestUpgradeRefusesASourceInsideTheDeploymentWorkdir(t *testing.T) {
+	sandboxCredsForTest(t)
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, &stagingVersionProbe{running: "nginx/1.27.4"}, deploy)
+	d := upgradeableDeployment(t, store, "dep-selfref", "1.27")
+
+	for name, source := range map[string]string{
+		"the workdir itself": d.WorkDir,
+		"a path inside it":   filepath.Join(d.WorkDir, PreviousHCLDirname),
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, os.MkdirAll(source, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(source, "providers.tf"), []byte(deployableProvidersTF), 0o644))
+
+			err := runUpgrade(t, rt, d.ID, &strings.Builder{}, "--from", source, "--tag", "1.28")
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "deployment's own workdir")
+			assert.Zero(t, deploy.calls)
+
+			// And the configuration it was running is untouched.
+			_, statErr := os.Stat(filepath.Join(d.WorkDir, "main.tf"))
+			assert.NoError(t, statErr, "the running configuration must survive a refused upgrade")
+		})
+	}
+}
+
+// An init or plan failure never reached the cloud, so the deployment is
+// still running the old configuration. Leaving the rejected one in the
+// workdir would make every later operation plan against something that
+// was never applied.
+func TestUpgradeRestoresTheOldHCLWhenNothingWasApplied(t *testing.T) {
+	sandboxCredsForTest(t)
+	deploy := &fakeSandboxDeployHarness{err: &harness.SandboxDeployError{
+		Stage: "plan", Err: errors.New("invalid configuration"),
+	}}
+	rt, store := upgradeRuntime(t, &stagingVersionProbe{running: "nginx/1.27.4"}, deploy)
+	d := upgradeableDeployment(t, store, "dep-reverted", "1.27")
+
+	var out strings.Builder
+	require.Error(t, runUpgrade(t, rt, d.ID, &out, "--from", newHCLDir(t), "--tag", "1.28"))
+
+	current, err := os.ReadFile(filepath.Join(d.WorkDir, "main.tf"))
+	require.NoError(t, err)
+	assert.Contains(t, string(current), "size_in_gb = 1",
+		"the workdir must hold what is actually running, not what was rejected")
+	assert.Contains(t, out.String(), "keeps the configuration it was already running")
+}
+
+// A failure DURING apply may have changed the cloud, so the new
+// configuration stays: it is the one that describes what is out there.
+func TestUpgradeKeepsTheNewHCLWhenTheApplyRan(t *testing.T) {
+	sandboxCredsForTest(t)
+	deploy := &fakeSandboxDeployHarness{err: &harness.SandboxDeployError{
+		Stage: "apply", Err: errors.New("timeout"),
+	}}
+	rt, store := upgradeRuntime(t, &stagingVersionProbe{running: "nginx/1.27.4"}, deploy)
+	d := upgradeableDeployment(t, store, "dep-kept", "1.27")
+
+	require.Error(t, runUpgrade(t, rt, d.ID, &strings.Builder{}, "--from", newHCLDir(t), "--tag", "1.28"))
+
+	current, err := os.ReadFile(filepath.Join(d.WorkDir, "main.tf"))
+	require.NoError(t, err)
+	assert.Contains(t, string(current), "size_in_gb = 2",
+		"something may be running from this configuration; reverting would hide it")
+}

--- a/internal/cli/live_upgrade_test.go
+++ b/internal/cli/live_upgrade_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -259,4 +260,79 @@ func TestUpgradeRequiresNewConfiguration(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--from is required")
+}
+
+// A failure at init or plan changed nothing on the cloud. Advancing the
+// tag there would make the record claim a version that was never
+// deployed -- the exact falsehood S155a exists to prevent.
+func TestUpgradeDoesNotAdvanceTheTagWhenTheApplyNeverRan(t *testing.T) {
+	sandboxCredsForTest(t)
+	probe := &stagingVersionProbe{running: "nginx/1.27.4"}
+	deploy := &fakeSandboxDeployHarness{err: &harness.SandboxDeployError{
+		Stage: "plan", Err: errors.New("invalid configuration"),
+	}}
+	rt, store := upgradeRuntime(t, probe, deploy)
+	d := upgradeableDeployment(t, store, "dep-planfail", "1.27")
+
+	require.Error(t, runUpgrade(t, rt, d.ID, &strings.Builder{},
+		"--from", newHCLDir(t), "--tag", "1.28"))
+
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "1.27", got.Tag, "nothing was applied, so the record must not claim 1.28")
+	assert.True(t, got.UpgradedAt.IsZero())
+}
+
+// A failure DURING apply may have changed a great deal, so the record
+// moves: an observation looking for the old version would look for the
+// wrong thing.
+func TestUpgradeAdvancesTheTagWhenTheApplyFailedPartway(t *testing.T) {
+	sandboxCredsForTest(t)
+	probe := &stagingVersionProbe{running: "nginx/1.27.4"}
+	deploy := &fakeSandboxDeployHarness{err: &harness.SandboxDeployError{
+		Stage: "apply", Err: errors.New("timeout waiting for instance"),
+	}}
+	rt, store := upgradeRuntime(t, probe, deploy)
+	d := upgradeableDeployment(t, store, "dep-partial", "1.27")
+
+	require.Error(t, runUpgrade(t, rt, d.ID, &strings.Builder{},
+		"--from", newHCLDir(t), "--tag", "1.28"))
+
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "1.28", got.Tag, "something may be running; the record must not hide it")
+}
+
+// Replacement HCL can recreate the load balancer. Verifying against the
+// address captured at first deploy would probe infrastructure this
+// deployment no longer owns, and point every later observation there too.
+func TestUpgradeRefreshesTheAddressWhenTheEndpointMoves(t *testing.T) {
+	sandboxCredsForTest(t)
+	probe := &stagingVersionProbe{running: "nginx/1.27.4"}
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, probe, deploy)
+	d := upgradeableDeployment(t, store, "dep-moved", "1.27")
+
+	deploy.onRun = func() {
+		probe.running = "nginx/1.28.0"
+		writeUpgradeStateWithLBAddress(t, d.WorkDir, "9.9.9.9")
+	}
+
+	var out strings.Builder
+	require.NoError(t, runUpgrade(t, rt, d.ID, &out, "--from", newHCLDir(t), "--tag", "1.28"))
+
+	assert.Contains(t, out.String(), "moved from 1.2.3.4 to 9.9.9.9")
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "9.9.9.9", got.Address)
+}
+
+// writeUpgradeStateWithLBAddress fakes what an apply leaves behind when
+// the load balancer's IP has changed.
+func writeUpgradeStateWithLBAddress(t *testing.T, workDir, address string) {
+	t.Helper()
+	state := `{"version":4,"outputs":{},"resources":[{"type":"scaleway_lb_ip","name":"front",
+	  "instances":[{"attributes":{"id":"ip-1","ip_address":"` + address + `"}}]}]}`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workDir, harness.LiveStateFilename), []byte(state), 0o600))
 }

--- a/internal/cli/live_upgrade_test.go
+++ b/internal/cli/live_upgrade_test.go
@@ -454,3 +454,45 @@ func TestUpgradeLeavesTheWorkdirAloneWhenTheEnvironmentIsUnusable(t *testing.T) 
 	require.NoError(t, storeErr)
 	assert.Equal(t, "1.27", got.Tag)
 }
+
+// The record's project id is the half a stale or edited file can change.
+// This call applies REAL infrastructure into whatever it names, so a
+// disagreement with the marker is refused rather than resolved in the
+// record's favour.
+func TestUpgradeRefusesWhenTheRecordAndMarkerDisagreeOnTheProject(t *testing.T) {
+	sandboxCredsForTest(t)
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, &stagingVersionProbe{running: "nginx/1.27.4"}, deploy)
+	d := upgradeableDeployment(t, store, "dep-mismatch", "1.27")
+	require.NoError(t, harness.WriteRunProjectMarker(d.WorkDir, harness.RunProject{
+		ID: "99999999-9999-9999-9999-999999999999", Name: harness.RunProjectNamePrefix + "other",
+	}))
+
+	err := runUpgrade(t, rt, d.ID, &strings.Builder{}, "--from", newHCLDir(t), "--tag", "1.28")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could change infrastructure belonging to another deployment")
+	assert.Zero(t, deploy.calls)
+
+	current, readErr := os.ReadFile(filepath.Join(d.WorkDir, "main.tf"))
+	require.NoError(t, readErr)
+	assert.Contains(t, string(current), "size_in_gb = 1", "refused before the swap")
+}
+
+// Without --tag the record still names the old version, so confirming it
+// proves the service is running what the record says and proves nothing
+// about a transition. Calling that "upgraded" would be a green built from
+// checking that nothing changed.
+func TestUpgradeWithoutANewTagDoesNotClaimAVersionChange(t *testing.T) {
+	sandboxCredsForTest(t)
+	probe := &stagingVersionProbe{running: "nginx/1.27.4"}
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, probe, deploy)
+	d := upgradeableDeployment(t, store, "dep-notag", "1.27")
+
+	var out strings.Builder
+	require.NoError(t, runUpgrade(t, rt, d.ID, &out, "--from", newHCLDir(t)))
+
+	assert.Contains(t, out.String(), "unchanged rather than upgraded")
+	assert.NotContains(t, out.String(), "now confirms")
+}

--- a/internal/cli/live_upgrade_test.go
+++ b/internal/cli/live_upgrade_test.go
@@ -1,0 +1,262 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redscaresu/infrafactory/internal/config"
+	"github.com/redscaresu/infrafactory/internal/harness"
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+// stagingVersionProbe answers with whatever version is "running" now, so
+// a test can change it between the before and after probes exactly as an
+// apply would.
+type stagingVersionProbe struct {
+	running     string
+	unreachable bool
+	probes      int
+}
+
+func (p *stagingVersionProbe) Probe(_ context.Context, _ string, _ int, _ string) (harness.ServiceProbeResult, error) {
+	p.probes++
+	if p.unreachable {
+		return harness.ServiceProbeResult{}, nil
+	}
+	return harness.ServiceProbeResult{
+		Reachable: true, Healthy: true, Body: p.running, BodyComplete: true,
+	}, nil
+}
+
+func upgradeRuntime(t *testing.T, probe ServiceProbeRunner, deploy *fakeSandboxDeployHarness) (*CommandRuntime, *livestore.FilesystemStore) {
+	t.Helper()
+	h := newCommandTestHarness(t)
+	cfg, err := config.Load(h.ConfigPath)
+	require.NoError(t, err)
+	cfg.Validation.Layers.SandboxDeploy.Enabled = true
+
+	rt := &CommandRuntime{
+		Config:        cfg,
+		livestoreRoot: h.LivestoreRoot(),
+		Deps:          RuntimeDependencies{ServiceProbe: probe, SandboxDeploy: deploy},
+	}
+	return rt, livestore.NewFilesystemStore(h.LivestoreRoot())
+}
+
+// upgradeableDeployment writes a record plus a workdir holding the HCL it
+// is currently running.
+func upgradeableDeployment(t *testing.T, store *livestore.FilesystemStore, id, tag string) livestore.Deployment {
+	t.Helper()
+	workDir := filepath.Join(t.TempDir(), "wd")
+	require.NoError(t, os.MkdirAll(workDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "providers.tf"), []byte(deployableProvidersTF), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.tf"),
+		[]byte("resource \"scaleway_block_volume\" \"v\" { size_in_gb = 1 }\n"), 0o644))
+
+	now := time.Now()
+	d := livestore.Deployment{
+		ID: id, Scenario: "web-live-paris",
+		ProjectID:   "7c98d82e-ad6d-4f4c-99ea-d1886b0f38e5",
+		Address:     "1.2.3.4",
+		Port:        80,
+		HealthPath:  "/",
+		VersionPath: "/version",
+		Image:       "nginx", Tag: tag,
+		State:     livestore.StateLive,
+		WorkDir:   workDir,
+		CreatedAt: now.Add(-time.Hour),
+		ExpiresAt: now.Add(time.Hour),
+	}
+	require.NoError(t, store.Put(d))
+	return d
+}
+
+// deployableProvidersTF is what the Layer 3 shape gate requires of any
+// configuration that reaches the real API: an exact provider pin, not a
+// range. Every fixture here carries it, because an upgrade runs the same
+// deny-by-default checks a first deploy runs.
+const deployableProvidersTF = `terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "2.81.0"
+    }
+  }
+}
+
+provider "scaleway" {
+  region = "fr-par"
+  zone   = "fr-par-1"
+}
+`
+
+// newHCLDir is where the upgrade's replacement configuration comes from.
+func newHCLDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "providers.tf"), []byte(deployableProvidersTF), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"),
+		[]byte("resource \"scaleway_block_volume\" \"v\" { size_in_gb = 2 }\n"), 0o644))
+	return dir
+}
+
+func runUpgrade(t *testing.T, rt *CommandRuntime, id string, out *strings.Builder, args ...string) error {
+	t.Helper()
+	cmd := &cobra.Command{Use: "upgrade"}
+	cmd.Flags().String("from", "", "")
+	cmd.Flags().String("tag", "", "")
+	cmd.Flags().String("output", string(OutputModeHuman), "")
+	require.NoError(t, cmd.ParseFlags(args))
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetContext(context.Background())
+	return runLiveUpgradeCommand(cmd, []string{id}, rt)
+}
+
+// The whole point: a successful apply is not the service running the new
+// version. The instance may not have restarted, the image may not have
+// been pulled, the user data may never have run.
+func TestUpgradeFailsWhenTheApplySucceedsButTheVersionDidNotChange(t *testing.T) {
+	sandboxCredsForTest(t)
+	probe := &stagingVersionProbe{running: "nginx/1.27.4"} // never moves to 1.28
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, probe, deploy)
+	d := upgradeableDeployment(t, store, "dep-stuck", "1.27")
+
+	var out strings.Builder
+	err := runUpgrade(t, rt, d.ID, &out, "--from", newHCLDir(t), "--tag", "1.28")
+
+	require.Error(t, err, "an apply that changed nothing is not an upgrade")
+	assert.Equal(t, 1, deploy.calls, "the apply did run")
+	assert.Contains(t, out.String(), "upgrade_verify")
+	assert.Contains(t, out.String(), "is not the service running the new version")
+
+	// The record moved to the new tag anyway: something was applied, and
+	// a record naming the old version would send the next observation
+	// looking for the wrong thing.
+	got, storeErr := store.Get(d.ID)
+	require.NoError(t, storeErr)
+	assert.Equal(t, "1.28", got.Tag)
+	assert.False(t, got.UpgradedAt.IsZero())
+}
+
+func TestUpgradeConfirmsTheNewVersionIsActuallyRunning(t *testing.T) {
+	sandboxCredsForTest(t)
+	probe := &stagingVersionProbe{running: "nginx/1.27.4"}
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, probe, deploy)
+	d := upgradeableDeployment(t, store, "dep-rolled", "1.27")
+
+	// The apply is what changes what is serving, so the fake moves the
+	// running version at that moment rather than before it.
+	deploy.onRun = func() { probe.running = "nginx/1.28.0" }
+
+	var out strings.Builder
+	require.NoError(t, runUpgrade(t, rt, d.ID, &out, "--from", newHCLDir(t), "--tag", "1.28"))
+
+	assert.Contains(t, out.String(), "confirms nginx:1.27 before the upgrade")
+	assert.Contains(t, out.String(), "now confirms nginx:1.28")
+}
+
+// Upgrading from a version the service contradicts would record a v1→v2
+// transition that never happened.
+func TestUpgradeRefusesWhenTheStartingVersionIsContradicted(t *testing.T) {
+	sandboxCredsForTest(t)
+	probe := &stagingVersionProbe{running: "SimpleHTTP/0.6 Python/3.10.12"}
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, probe, deploy)
+	d := upgradeableDeployment(t, store, "dep-lying", "1.27")
+
+	var out strings.Builder
+	err := runUpgrade(t, rt, d.ID, &out, "--from", newHCLDir(t), "--tag", "1.28")
+
+	require.Error(t, err)
+	assert.Zero(t, deploy.calls, "nothing is applied on top of a state nobody understands")
+	assert.Contains(t, out.String(), "would record a transition that never happened")
+
+	got, storeErr := store.Get(d.ID)
+	require.NoError(t, storeErr)
+	assert.Equal(t, "1.27", got.Tag, "a refused upgrade must not move the record")
+}
+
+// The pair either side of one change is the diff S156 needs and cannot
+// reconstruct.
+func TestUpgradeKeepsThePreviousConfiguration(t *testing.T) {
+	sandboxCredsForTest(t)
+	probe := &stagingVersionProbe{running: "nginx/1.27.4"}
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, probe, deploy)
+	d := upgradeableDeployment(t, store, "dep-diffable", "1.27")
+	deploy.onRun = func() { probe.running = "nginx/1.28.0" }
+
+	require.NoError(t, runUpgrade(t, rt, d.ID, &strings.Builder{},
+		"--from", newHCLDir(t), "--tag", "1.28"))
+
+	previous, err := os.ReadFile(filepath.Join(d.WorkDir, PreviousHCLDirname, "main.tf"))
+	require.NoError(t, err)
+	assert.Contains(t, string(previous), "size_in_gb = 1", "the configuration that was running")
+
+	current, err := os.ReadFile(filepath.Join(d.WorkDir, "main.tf"))
+	require.NoError(t, err)
+	assert.Contains(t, string(current), "size_in_gb = 2", "and the one that replaced it")
+}
+
+// Copying over the top would leave a resource behind that the new
+// configuration no longer declares, and tofu would keep managing it --
+// an upgrade that silently kept something the operator deleted.
+func TestUpgradeRemovesSupersededHCL(t *testing.T) {
+	sandboxCredsForTest(t)
+	probe := &stagingVersionProbe{running: "nginx/1.27.4"}
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, probe, deploy)
+	d := upgradeableDeployment(t, store, "dep-pruned", "1.27")
+	deploy.onRun = func() { probe.running = "nginx/1.28.0" }
+
+	// A second file the replacement does not carry.
+	require.NoError(t, os.WriteFile(filepath.Join(d.WorkDir, "extra.tf"),
+		[]byte("resource \"scaleway_block_volume\" \"gone\" { size_in_gb = 1 }\n"), 0o644))
+
+	require.NoError(t, runUpgrade(t, rt, d.ID, &strings.Builder{},
+		"--from", newHCLDir(t), "--tag", "1.28"))
+
+	_, err := os.Stat(filepath.Join(d.WorkDir, "extra.tf"))
+	assert.True(t, os.IsNotExist(err), "a resource the new configuration drops must not stay managed")
+	// But it is still recoverable for the diff.
+	_, err = os.Stat(filepath.Join(d.WorkDir, PreviousHCLDirname, "extra.tf"))
+	assert.NoError(t, err)
+}
+
+func TestUpgradeRefusesAReleasedDeployment(t *testing.T) {
+	sandboxCredsForTest(t)
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, &stagingVersionProbe{}, deploy)
+	d := upgradeableDeployment(t, store, "dep-gone", "1.27")
+	require.NoError(t, store.MarkReleased(d.ID))
+
+	err := runUpgrade(t, rt, d.ID, &strings.Builder{}, "--from", newHCLDir(t))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nothing running to upgrade")
+	assert.Zero(t, deploy.calls)
+}
+
+func TestUpgradeRequiresNewConfiguration(t *testing.T) {
+	sandboxCredsForTest(t)
+	rt, store := upgradeRuntime(t, &stagingVersionProbe{}, &fakeSandboxDeployHarness{})
+	d := upgradeableDeployment(t, store, "dep-nosource", "1.27")
+
+	err := runUpgrade(t, rt, d.ID, &strings.Builder{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--from is required")
+}

--- a/internal/cli/live_upgrade_test.go
+++ b/internal/cli/live_upgrade_test.go
@@ -47,7 +47,12 @@ func upgradeRuntime(t *testing.T, probe ServiceProbeRunner, deploy *fakeSandboxD
 	rt := &CommandRuntime{
 		Config:        cfg,
 		livestoreRoot: h.LivestoreRoot(),
-		Deps:          RuntimeDependencies{ServiceProbe: probe, SandboxDeploy: deploy},
+		Deps: RuntimeDependencies{
+			ServiceProbe: probe, SandboxDeploy: deploy,
+			// Provenance is the half local files cannot forge, so every
+			// upgrade asks the API before applying.
+			RunProject: &fakeRunProject{},
+		},
 	}
 	return rt, livestore.NewFilesystemStore(h.LivestoreRoot())
 }
@@ -520,5 +525,58 @@ func TestUpgradeRefusesWithoutAReadableMarker(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "which is editable")
+	assert.Zero(t, deploy.calls)
+}
+
+// The marker and the record are both local files, so together they prove
+// only that two local files agree. Provenance asks the API, which is the
+// half that cannot be forged from a text editor.
+func TestUpgradeRefusesAProjectTheAPIDoesNotVouchFor(t *testing.T) {
+	sandboxCredsForTest(t)
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, &stagingVersionProbe{running: "nginx/1.27.4"}, deploy)
+	d := upgradeableDeployment(t, store, "dep-unstamped", "1.27")
+
+	// A real project that is not one of ours: exactly what editing two
+	// local files would point an apply at.
+	rt.Deps.RunProject = &fakeRunProject{describeUnstamped: true}
+
+	err := runUpgrade(t, rt, d.ID, &strings.Builder{}, "--from", newHCLDir(t), "--tag", "1.28")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not carry infrafactory's stamp")
+	assert.NotContains(t, err.Error(), "refusing to delete",
+		"the message must describe the operation being refused")
+	assert.Zero(t, deploy.calls)
+}
+
+// "We could not check" must never behave like "it is fine".
+func TestUpgradeRefusesWhenProvenanceCannotBeChecked(t *testing.T) {
+	sandboxCredsForTest(t)
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, &stagingVersionProbe{running: "nginx/1.27.4"}, deploy)
+	d := upgradeableDeployment(t, store, "dep-unreachable-api", "1.27")
+	rt.Deps.RunProject = &fakeRunProject{describeErr: errors.New("dial tcp: connection refused")}
+
+	err := runUpgrade(t, rt, d.ID, &strings.Builder{}, "--from", newHCLDir(t), "--tag", "1.28")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not verify project")
+	assert.Zero(t, deploy.calls)
+}
+
+// Applying into a project that is already gone is not an upgrade. The
+// deletion guard treats gone as success; this is the opposite case.
+func TestUpgradeRefusesAProjectThatNoLongerExists(t *testing.T) {
+	sandboxCredsForTest(t)
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, &stagingVersionProbe{running: "nginx/1.27.4"}, deploy)
+	d := upgradeableDeployment(t, store, "dep-vanished", "1.27")
+	rt.Deps.RunProject = &fakeRunProject{describeGone: true}
+
+	err := runUpgrade(t, rt, d.ID, &strings.Builder{}, "--from", newHCLDir(t), "--tag", "1.28")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no longer exists")
 	assert.Zero(t, deploy.calls)
 }

--- a/internal/cli/live_upgrade_test.go
+++ b/internal/cli/live_upgrade_test.go
@@ -407,3 +407,50 @@ func TestUpgradeKeepsTheNewHCLWhenTheApplyRan(t *testing.T) {
 	assert.Contains(t, string(current), "size_in_gb = 2",
 		"something may be running from this configuration; reverting would hide it")
 }
+
+// An upgrade applies to real infrastructure exactly as a first deploy
+// does. A gate that guards one entry point and not the other guards
+// nothing.
+func TestUpgradeRequiresTheRealDeployOptIn(t *testing.T) {
+	sandboxCredsForTest(t)
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, &stagingVersionProbe{running: "nginx/1.27.4"}, deploy)
+	rt.Config.Validation.Layers.SandboxDeploy.Enabled = false
+	d := upgradeableDeployment(t, store, "dep-optout", "1.27")
+
+	err := runUpgrade(t, rt, d.ID, &strings.Builder{}, "--from", newHCLDir(t), "--tag", "1.28")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sandbox_deploy.enabled")
+	assert.Zero(t, deploy.calls, "Layer 3 is off, so nothing reaches the real project")
+
+	// And the workdir is untouched: the refusal came before the swap.
+	current, readErr := os.ReadFile(filepath.Join(d.WorkDir, "main.tf"))
+	require.NoError(t, readErr)
+	assert.Contains(t, string(current), "size_in_gb = 1")
+}
+
+// Everything that can fail without touching the workdir happens before
+// the destructive swap, so an environment problem cannot leave the
+// workdir holding configuration that was never applied.
+func TestUpgradeLeavesTheWorkdirAloneWhenTheEnvironmentIsUnusable(t *testing.T) {
+	sandboxCredsForTest(t)
+	// No organisation id: sandboxCommandEnvForProject refuses.
+	t.Setenv("SCW_DEFAULT_ORGANIZATION_ID", "")
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, &stagingVersionProbe{running: "nginx/1.27.4"}, deploy)
+	d := upgradeableDeployment(t, store, "dep-noenv", "1.27")
+
+	require.Error(t, runUpgrade(t, rt, d.ID, &strings.Builder{},
+		"--from", newHCLDir(t), "--tag", "1.28"))
+
+	assert.Zero(t, deploy.calls)
+	current, err := os.ReadFile(filepath.Join(d.WorkDir, "main.tf"))
+	require.NoError(t, err)
+	assert.Contains(t, string(current), "size_in_gb = 1",
+		"a failure before the apply must not leave unapplied configuration behind")
+
+	got, storeErr := store.Get(d.ID)
+	require.NoError(t, storeErr)
+	assert.Equal(t, "1.27", got.Tag)
+}

--- a/internal/cli/live_upgrade_test.go
+++ b/internal/cli/live_upgrade_test.go
@@ -59,6 +59,11 @@ func upgradeableDeployment(t *testing.T, store *livestore.FilesystemStore, id, t
 	workDir := filepath.Join(t.TempDir(), "wd")
 	require.NoError(t, os.MkdirAll(workDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(workDir, "providers.tf"), []byte(deployableProvidersTF), 0o644))
+	// Every post-cutover deployment has one: ensureRunProject writes it
+	// before the apply, and failing to is fatal there.
+	require.NoError(t, harness.WriteRunProjectMarker(workDir, harness.RunProject{
+		ID: "7c98d82e-ad6d-4f4c-99ea-d1886b0f38e5", Name: harness.RunProjectNamePrefix + "fixture",
+	}))
 	require.NoError(t, os.WriteFile(filepath.Join(workDir, "main.tf"),
 		[]byte("resource \"scaleway_block_volume\" \"v\" { size_in_gb = 1 }\n"), 0o644))
 
@@ -495,4 +500,25 @@ func TestUpgradeWithoutANewTagDoesNotClaimAVersionChange(t *testing.T) {
 
 	assert.Contains(t, out.String(), "unchanged rather than upgraded")
 	assert.NotContains(t, out.String(), "now confirms")
+}
+
+// Required, not merely preferred. Falling back to the record would leave
+// the editable half deciding where real infrastructure gets applied.
+//
+// `live teardown` does fall back, deliberately: refusing there strands a
+// pre-cutover record whose resources are real, and destroy is bounded by
+// its own state anyway. Neither argument holds for applying, and an
+// operator who cannot upgrade can still tear down and deploy again.
+func TestUpgradeRefusesWithoutAReadableMarker(t *testing.T) {
+	sandboxCredsForTest(t)
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, &stagingVersionProbe{running: "nginx/1.27.4"}, deploy)
+	d := upgradeableDeployment(t, store, "dep-unmarked", "1.27")
+	require.NoError(t, os.Remove(filepath.Join(d.WorkDir, harness.RunProjectMarkerFilename)))
+
+	err := runUpgrade(t, rt, d.ID, &strings.Builder{}, "--from", newHCLDir(t), "--tag", "1.28")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "which is editable")
+	assert.Zero(t, deploy.calls)
 }

--- a/internal/cli/live_upgrade_test.go
+++ b/internal/cli/live_upgrade_test.go
@@ -605,3 +605,35 @@ func TestUpgradeDoesNotResurrectARecordTornDownWhileApplying(t *testing.T) {
 	assert.Contains(t, out.String(), "was torn down while this upgrade was applying")
 	assert.Contains(t, out.String(), "check project")
 }
+
+// An apply takes minutes, and `live observe` may append observations
+// during it. Writing back the copy loaded before the apply discards them
+// -- which does not corrupt the record, it quietly weakens the learning
+// signal S156's promotion gate counts.
+func TestUpgradeKeepsObservationsRecordedWhileItWasApplying(t *testing.T) {
+	sandboxCredsForTest(t)
+	probe := &stagingVersionProbe{running: "nginx/1.27.4"}
+	deploy := &fakeSandboxDeployHarness{}
+	rt, store := upgradeRuntime(t, probe, deploy)
+	d := upgradeableDeployment(t, store, "dep-observed", "1.27")
+
+	// An observation lands mid-apply, exactly as a cron'd observe would.
+	deploy.onRun = func() {
+		probe.running = "nginx/1.28.0"
+		concurrent, err := store.Get(d.ID)
+		require.NoError(t, err)
+		concurrent.RecordObservation(livestore.Observation{
+			At: time.Now(), Status: livestore.ObservationHealthy,
+		})
+		require.NoError(t, store.Put(concurrent))
+	}
+
+	require.NoError(t, runUpgrade(t, rt, d.ID, &strings.Builder{},
+		"--from", newHCLDir(t), "--tag", "1.28"))
+
+	got, err := store.Get(d.ID)
+	require.NoError(t, err)
+	assert.Len(t, got.Observations, 1, "the concurrent observation survives the upgrade's write")
+	assert.Equal(t, "1.28", got.Tag, "and the upgrade's own fields still land")
+	assert.False(t, got.UpgradedAt.IsZero())
+}

--- a/internal/cli/run_project_lifecycle_test.go
+++ b/internal/cli/run_project_lifecycle_test.go
@@ -22,11 +22,14 @@ type fakeRunProject struct {
 	deleteErrs   []error
 	describeErr  error
 	describeGone bool
-	creates      int
-	deletes      int
-	lastOrg      string
-	lastScen     string
-	deletedID    string
+	// describeUnstamped returns a real project that is NOT one of
+	// infrafactory's -- what editing local files would point an apply at.
+	describeUnstamped bool
+	creates           int
+	deletes           int
+	lastOrg           string
+	lastScen          string
+	deletedID         string
 }
 
 func (f *fakeRunProject) Create(_ context.Context, _, organizationID, scenario, _ string) (harness.RunProject, error) {
@@ -44,6 +47,9 @@ func (f *fakeRunProject) Describe(_ context.Context, _, projectID string) (harne
 	}
 	if f.describeGone {
 		return harness.ProjectProvenance{Exists: false}, nil
+	}
+	if f.describeUnstamped {
+		return harness.ProjectProvenance{Exists: true, Name: "openclaw-prod", Description: "real infrastructure"}, nil
 	}
 	return harness.ProjectProvenance{
 		Exists: true, Name: harness.RunProjectNamePrefix + "x", Description: harness.RunProjectDescription,

--- a/internal/cli/test_command_test.go
+++ b/internal/cli/test_command_test.go
@@ -49,6 +49,10 @@ type fakeSandboxDeployHarness struct {
 	err     error
 	calls   int
 	lastCtx context.Context
+	// onRun fires during the apply, so a test can move the world at the
+	// moment a real apply would -- an upgrade's version changes because
+	// the apply changed it, not before.
+	onRun func()
 }
 
 // Run writes a minimal terraform-live.tfstate, because a real apply
@@ -57,6 +61,9 @@ type fakeSandboxDeployHarness struct {
 // fail at capture -- which is correct fail-closed behaviour, just not
 // what these tests are exercising.
 func (f *fakeSandboxDeployHarness) Run(ctx context.Context, workDir string, _ map[string]string) (*harness.SandboxDeployResult, error) {
+	if f.onRun != nil {
+		f.onRun()
+	}
 	f.calls++
 	f.lastCtx = ctx
 	if f.err == nil && workDir != "" {

--- a/internal/cli/test_command_test.go
+++ b/internal/cli/test_command_test.go
@@ -61,15 +61,17 @@ type fakeSandboxDeployHarness struct {
 // fail at capture -- which is correct fail-closed behaviour, just not
 // what these tests are exercising.
 func (f *fakeSandboxDeployHarness) Run(ctx context.Context, workDir string, _ map[string]string) (*harness.SandboxDeployResult, error) {
-	if f.onRun != nil {
-		f.onRun()
-	}
 	f.calls++
 	f.lastCtx = ctx
 	if f.err == nil && workDir != "" {
 		_ = os.MkdirAll(workDir, 0o755)
 		_ = os.WriteFile(filepath.Join(workDir, harness.LiveStateFilename), []byte(
 			`{"resources":[{"type":"scaleway_account_project","instances":[{"attributes":{"id":"test-run-project"}}]}]}`), 0o600)
+	}
+	// Last, so a hook that writes its own state is not overwritten by the
+	// default one above.
+	if f.onRun != nil {
+		f.onRun()
 	}
 	return f.result, f.err
 }

--- a/internal/livestore/livestore.go
+++ b/internal/livestore/livestore.go
@@ -75,6 +75,10 @@ type Deployment struct {
 	// strays would be recomputed from.
 	SweepVerificationFailed bool `json:"sweep_verification_failed,omitempty"`
 
+	// UpgradedAt is when this deployment was last rolled onto new
+	// configuration. Zero means never.
+	UpgradedAt time.Time `json:"upgraded_at,omitempty"`
+
 	// VersionPath, when declared, is probed to check that the service is
 	// running the version this record claims. Snapshotted with the rest.
 	VersionPath string `json:"version_path,omitempty"`


### PR DESCRIPTION
> **Draft.** Seven codex passes have run and each found something; the eighth has not, because codex hit its usage limit (resets 01:36). It comes out of draft on one clean pass.

Rolls a live deployment onto new configuration **in place** — same project, same workdir, so the load balancer and its address survive.

## The design decision

**infrafactory does not invent the new HCL.** It owns the part that is hard to get right: applying it into the project the deployment already owns, under the same deny-by-default checks a first deploy runs, and proving afterwards that the version actually changed. That composes with however the configuration was produced, and keeps the generator out of the live path.

**Deliberately not parameterised through `TF_VAR`.** `SandboxStripEnv` removes `TF_VAR_*` because the cost bounds read a variable's *default* to decide blast radius, so an injected variable would make those checks vouch for a number that never reaches the API. Handing over whole HCL keeps every existing check applying to the configuration that is actually applied.

## What it guarantees

- **A successful apply is not an upgrade.** Terraform reaching its desired state says nothing about whether the service restarted, pulled the image, or ran its user data. `upgrade_verify` fails on exactly that.
- **It refuses to start from a version the service contradicts** — that would record a v1→v2 transition that never happened.
- **It refuses without the marker *and* API provenance.** Both, because the marker and the record are both local files.
- **The previous HCL is kept** in `.infrafactory-previous/`. That pair either side of one change is the diff `ExtractFixPitfall` needs and cannot reconstruct — it is what lets S156 produce prescriptive rules instead of the weakest class of lesson.

## Review: seven passes, thirteen findings, none declined

This slice was harder than the ones before it, and the shape is worth stating plainly rather than burying:

| passes | question | how it went wrong |
|---|---|---|
| 50–52 | did anything reach the cloud? | answered for the tag, then the address, then the workdir, then the ordering |
| 53–55 | which project do we trust? | the marker, then *required*, then finally the API too |
| 56 | — | a prefix match confirmed `1.2` against `nginx/1.27.4`; and the upgrade could overwrite a concurrent teardown |

**Ten of thirteen findings are one incomplete answer, not thirteen mistakes.** And three of them were fixes that **already existed elsewhere in this codebase** — the marker guard, the `applyRan` predicate, the re-read-before-write race — which I reimplemented partially instead of reusing.

The honest lesson is not "review harder". It is that new code touching an existing mechanism should start by reading how that mechanism is already used. ADR-0025 already said the guard is *two checks that must both pass*; reading its own words before writing this one would have collapsed three passes into one.

## Not yet done

- **The final clean pass.** Seven ran, all found something.
- **No real-cloud run of `upgrade` yet.** Every guarantee above is unit-tested; none has been exercised against Scaleway. Given this slice's history that is the thing I would want proven before merging, not after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD