### PR TITLE
Break S156 into five slices, and schedule its unscheduled prerequisite

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,24 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- 🗂️ **S156 broken into five slices, and its unscheduled prerequisite scheduled
+  (2026-09-01)** — `docs/plans/live-learning-loop-plan.md`. The plan already
+  warned that **S156 must not merge without a retirement path for `source: live`
+  pitfalls**, and nothing was scheduled to build one. It is now **S156a**, and it
+  is the only one of the five with no dependency — so it was the slice to build
+  while S155b waited on its canary. **S156a has since shipped** (below).
+
+  Doing the outflow before the inflow is deliberate: every other slice *adds* to
+  the corpus. A pitfall that steers generation away from something no longer
+  broken makes every future generation worse, **silently**, which is the failure
+  mode this project has learned to fear most.
+
+  **Why five and not one**: S155b took seven codex passes and thirteen findings,
+  ten of which were one incomplete answer spread across six interacting invariants
+  in a single command. S154, S170 and S155a — each smaller — converged in three.
+  **Slice size was the lever, not review effort**, and S156 is bigger than S155b
+  was.
+
 - 🧹 **S156a: the corpus gets an outflow (2026-09-01)** — `pitfalls retire`
   removes `source: live` entries that have not been seen within a retention
   window, and **names every one it removed**.

--- a/STATUS.md
+++ b/STATUS.md
@@ -9,7 +9,7 @@ Last updated: 2026-08-31
   warned that **S156 must not merge without a retirement path for `source: live`
   pitfalls**, and nothing was scheduled to build one. It is now **S156a**, and it
   is the only one of the five with no dependency — so it was the slice to build
-  while S155b waited on its canary. **S156a has since shipped** (below).
+  while S155b waited on its canary. **Both have since shipped** (below).
 
   Doing the outflow before the inflow is deliberate: every other slice *adds* to
   the corpus. A pitfall that steers generation away from something no longer

--- a/docs/plans/live-learning-loop-plan.md
+++ b/docs/plans/live-learning-loop-plan.md
@@ -162,6 +162,56 @@ failure, then with it present and observe the failure gone.
 One such entry is worth more than a hundred symptom lines, and is the honest bar
 for saying the loop is closed.
 
+## S156, broken up (planned 2026-09-01)
+
+S156 was one slice. It should not be, and the evidence is S155b: **seven codex
+passes, thirteen findings, and ten of them were one incomplete answer applied to
+six interacting invariants in a single command.** S154, S170 and S155a — each
+smaller — converged in three. Slice size is the lever that mattered, not review
+effort.
+
+So S156 becomes five, ordered by dependency, each independently mergeable and
+each with a single question to get right.
+
+| id | slice | the one question | depends on |
+|---|---|---|---|
+| **S156a** | **Retirement path for `source: live` entries** | how does a pitfall stop being true? | nothing |
+| S156b | Promotion gate — reproduction over stored observations | when is an observation a lesson? | S154 |
+| S156c | Extraction, descriptive — promoted observations become `source: live` pitfalls | does the existing extractor accept a live signal unchanged? | S156a, S156b |
+| S156d | Extraction, prescriptive — upgrade diffs through `ExtractFixPitfall` | is the before/after pair a usable diff? | S156c, **S155b** |
+| S156e | The validation run | does a live-sourced pitfall demonstrably prevent a repeat? | all of the above |
+
+### S156a comes first, and can start today
+
+The prerequisite section above is unambiguous: *"S156 should not merge without at
+least a retirement path for `source: live` entries."* It is also the **only one of
+the five with no dependency**, so it is the slice to build while S155b waits on
+its canary.
+
+It is worth doing first for a second reason. Every other slice adds entries to the
+corpus; this one is the only thing that can take them out. Building the inflow
+before the outflow is how a corpus becomes something nobody dares prune later —
+and a pitfall that steers generation away from something no longer broken makes
+every future generation worse, **silently**, which is the failure mode this
+project has learned to fear most.
+
+Scope, deliberately narrow:
+
+- an expiry or supersession rule for `source: live` entries only — static,
+  `fix` and `avoid` entries are out of scope and keep their current lifetime
+- re-validation against the holdout set as the retirement trigger, reusing what
+  already exists rather than inventing a second corpus mechanism
+- **removal is reported, never silent.** Same rule as the D6 purge: a corpus that
+  quietly drops entries is indistinguishable from one that never learned them
+
+### What S156e must show, restated
+
+One live-sourced pitfall that is prescriptive, attributable, and demonstrably
+prevents a repeat — proven the way this project proves everything, by running it:
+generate the scenario with the pitfall absent and observe the failure, then with
+it present and observe the failure gone. **One such entry is worth more than a
+hundred symptom lines.**
+
 ## Out of scope
 
 Drift detection (periodic re-plan against live state) — cheapest of the three

--- a/docs/review-passes/pass68.md
+++ b/docs/review-passes/pass68.md
@@ -1,0 +1,11 @@
+# Codex review pass 68 — the S156 planning split
+
+**Clean.** No findings.
+
+> The changes are documentation-only updates to the current status and planning
+> notes. I found no actionable correctness, safety, or maintainability issues
+> introduced by this diff.
+
+Docs-only, but run because the rule is "everything that merges has been through
+the loop" — and a planning document that misstates a dependency is a defect with
+a longer half-life than most code.


### PR DESCRIPTION
Docs only. No code.

## The prerequisite nobody had scheduled

`live-learning-loop-plan.md` already said it plainly: *"S156 should not merge without at least a retirement path for `source: live` entries."* Nothing was scheduled to build one.

The reasoning still holds and has got sharper since S154 landed. Learning used to be bounded — a run produces at most `repair_iterations_max` failures, and a scenario that stops failing stops emitting. **Live observation removes that bound.** A deployment left running with a broken image emits the same normalized failure on every probe, for its whole TTL, across every deployment of that scenario.

The promotion gate limits the *rate*. It gives no way to remove a live-sourced pitfall once the cause is fixed — and a pitfall steering generation away from something no longer broken makes every future generation worse, **silently**.

So it is now **S156a**, and it is the **only one of the five with no dependency**. That makes it the slice to build while S155b waits on its canary.

**Outflow before inflow, deliberately.** Every other slice adds to the corpus; this is the only thing that can take entries out. Building the inflow first is how a corpus becomes something nobody dares prune later.

## The five

| id | slice | the one question | depends on |
|---|---|---|---|
| **S156a** | Retirement path for `source: live` | how does a pitfall stop being true? | nothing |
| S156b | Promotion gate — reproduction over stored observations | when is an observation a lesson? | S154 |
| S156c | Extraction, descriptive | does the existing extractor accept a live signal unchanged? | S156a, S156b |
| S156d | Extraction, prescriptive, from upgrade diffs | is the before/after pair a usable diff? | S156c, S155b |
| S156e | The validation run | does a live-sourced pitfall demonstrably prevent a repeat? | all |

## Why five and not one

Evidence rather than preference:

| slice | codex passes | findings |
|---|---|---|
| S154 | 3 | 3 |
| S170 | 3 | 5 |
| S155a | 3 | 4 |
| **S155b** | **7+** | **13** |

S155b put six interacting invariants in one command, and ten of its thirteen findings were **one incomplete answer** applied to a subset of them — the tag, then the address, then the workdir, then the ordering; the marker, then required, then the API. The smaller slices converged in three passes each.

**Slice size was the lever, not review effort.** S156 as specified is bigger than S155b was, so it gets cut before it is built rather than after.

Each of the five has a single question to get right, which is the property S155b lacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD