### PR TITLE
S156a: give the pitfall corpus an outflow

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -77,6 +77,16 @@ Last updated: 2026-08-31
   place that reads it**, and the reliable way to find those is to enumerate the
   readers before the first edit rather than after each review.
 
+  **Pass 64**: the sweep parses `kept_new` into `AVOID_EMISSIONS`, a ratchet on
+  whether the avoid extractor still works — so preserving live entries could have
+  made a sweep with **zero** avoid pitfalls report a healthy number. `pitfall-merge`
+  prints per-source counts now and the sweep ratchets on `kept_avoid`.
+
+  Five passes, five findings, all downstream of adding **one constant**. The
+  places that had to learn about `live`: two corpus ratchets, the sweep's
+  preservation list, the merge's freshness handling, the merge's source
+  semantics, the metric reading the merge, and the new command's path guard.
+
   `--dry-run` and the real thing share one rule by construction: a dry-run that
   can disagree with the real thing is worse than no dry-run. And `TouchLivePitfall`
   refreshes rather than appends, which is what makes retention mean *last

--- a/STATUS.md
+++ b/STATUS.md
@@ -48,6 +48,12 @@ Last updated: 2026-08-31
   `refreshed=N`. **Preserving a record is not the same as preserving what the
   record says.**
 
+  **Pass 61**: the command was wired through the full runtime, which builds the
+  Claude transport — so corpus maintenance would fail because the *agent* was
+  unconfigured, on exactly the machine doing housekeeping.
+  `withRuntimeNoGenerator` keeps the logging and substitutes a generator that
+  **refuses**, since this command must never generate.
+
   `--dry-run` and the real thing share one rule by construction: a dry-run that
   can disagree with the real thing is worse than no dry-run. And `TouchLivePitfall`
   refreshes rather than appends, which is what makes retention mean *last

--- a/STATUS.md
+++ b/STATUS.md
@@ -32,6 +32,14 @@ Last updated: 2026-08-31
     would otherwise empty the corpus in one command, and a dry-run that accepts
     what the real run rejects teaches the wrong thing about what is safe to type.
 
+  **Pass 59**: `live` was added as a persisted value while two ratchets still
+  fenced the corpus to `descriptive`/`fix`/`avoid`, so the first live entry would
+  have failed CI with the blame pointing at the entry rather than the ratchet.
+  Both updated. Sweeping for the same class then found what the finding did not:
+  `pitfall-merge` preserves `--keep avoid` across a sweep, so **a sweep would have
+  silently deleted every live entry** — the exact thing this slice exists to
+  prevent. Now `avoid,live`.
+
   `--dry-run` and the real thing share one rule by construction: a dry-run that
   can disagree with the real thing is worse than no dry-run. And `TouchLivePitfall`
   refreshes rather than appends, which is what makes retention mean *last

--- a/STATUS.md
+++ b/STATUS.md
@@ -87,6 +87,15 @@ Last updated: 2026-08-31
   preservation list, the merge's freshness handling, the merge's source
   semantics, the metric reading the merge, and the new command's path guard.
 
+  **Pass 65 was declined** — the first decline in the slice. The sweep omits
+  genesys from its pitfall handling, and so do all three ratchets, consistently
+  and since long before this arc; `LiveSource` neither created that gap nor widens
+  it. Bringing genesys in means deciding whether it joins the ratchets and what
+  `AVOID_EMISSIONS` means for a cloud with no avoid entries — its own scope, and
+  folding it in is how a small slice becomes S155b. Recorded in the plan as a
+  prerequisite for **S156c**, the first slice that will actually produce live
+  entries.
+
   `--dry-run` and the real thing share one rule by construction: a dry-run that
   can disagree with the real thing is worse than no dry-run. And `TouchLivePitfall`
   refreshes rather than appends, which is what makes retention mean *last

--- a/STATUS.md
+++ b/STATUS.md
@@ -66,6 +66,17 @@ Last updated: 2026-08-31
   mechanism is already enforced. Adding `LiveSource` was three lines; the work was
   the four places that had to learn about it.
 
+  **Pass 63**: the refresh crossed source boundaries. `entryKey` ignores `source`,
+  so a live timestamp could land on a `descriptive` entry — attaching a lifetime
+  to a source that has none, while the live record vanished as a duplicate. Now
+  like-with-like.
+
+  Passes 59, 60 and 63 all landed on the same **fifteen lines** of merge code,
+  each fix correct and each too narrow. What S156a actually teaches is not about
+  slice size, since this slice is small: **a change to a data model lands in every
+  place that reads it**, and the reliable way to find those is to enumerate the
+  readers before the first edit rather than after each review.
+
   `--dry-run` and the real thing share one rule by construction: a dry-run that
   can disagree with the real thing is worse than no dry-run. And `TouchLivePitfall`
   refreshes rather than appends, which is what makes retention mean *last

--- a/STATUS.md
+++ b/STATUS.md
@@ -87,6 +87,13 @@ Last updated: 2026-08-31
   preservation list, the merge's freshness handling, the merge's source
   semantics, the metric reading the merge, and the new command's path guard.
 
+  **Pass 66 reversed pass 63.** Skipping a source-mismatched duplicate preserved
+  the old dedup and silently dropped the *live* entry whenever an older
+  `descriptive` rule shared its `(resource, rule)` — losing the `last_seen` that
+  retirement runs on. `mergeKey` includes the source for `live` only: dropping a
+  duplicate `avoid` loses a rule the corpus already states in other words;
+  dropping a duplicate `live` loses information nothing can rebuild.
+
   **Pass 65 was declined** — the first decline in the slice. The sweep omits
   genesys from its pitfall handling, and so do all three ratchets, consistently
   and since long before this arc; `LiveSource` neither created that gap nor widens

--- a/STATUS.md
+++ b/STATUS.md
@@ -54,6 +54,18 @@ Last updated: 2026-08-31
   `withRuntimeNoGenerator` keeps the logging and substitutes a generator that
   **refuses**, since this command must never generate.
 
+  **Pass 62**: the `<cloud>` argument went into `filepath.Join` unvalidated, so
+  `retire ../../x` would have **rewritten** a file outside the corpus.
+  `livestore.validateID` already guards deployment ids against exactly that;
+  `assertCloudName` now does the same on all three entry points.
+
+  Across S156a's four passes, **three findings were mechanisms that already
+  existed in this repository** — the source ratchets, the sweep's preservation
+  rule, the path guard. Slice size is not the whole story: the other half is that
+  new code touching an existing mechanism should start by finding every place that
+  mechanism is already enforced. Adding `LiveSource` was three lines; the work was
+  the four places that had to learn about it.
+
   `--dry-run` and the real thing share one rule by construction: a dry-run that
   can disagree with the real thing is worse than no dry-run. And `TouchLivePitfall`
   refreshes rather than appends, which is what makes retention mean *last

--- a/STATUS.md
+++ b/STATUS.md
@@ -40,6 +40,14 @@ Last updated: 2026-08-31
   silently deleted every live entry** — the exact thing this slice exists to
   prevent. Now `avoid,live`.
 
+  **Pass 60** then caught the incomplete half of that: preserving live entries
+  through a sweep preserved the *entries* but not their *freshness*, so a rule
+  re-observed during a sweep kept the older timestamp — retention silently
+  reverting to *first observed* and retiring a rule that was still true.
+  `pitfall-merge` carries forward a newer `last_seen` now and reports
+  `refreshed=N`. **Preserving a record is not the same as preserving what the
+  record says.**
+
   `--dry-run` and the real thing share one rule by construction: a dry-run that
   can disagree with the real thing is worse than no dry-run. And `TouchLivePitfall`
   refreshes rather than appends, which is what makes retention mean *last

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,39 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- 🧹 **S156a: the corpus gets an outflow (2026-09-01)** — `pitfalls retire`
+  removes `source: live` entries that have not been seen within a retention
+  window, and **names every one it removed**.
+
+  Built before anything produces a live entry, deliberately. Every other S156
+  slice *adds* to the corpus; this is the only thing that can take entries out,
+  and building the inflow first is how a corpus becomes something nobody dares
+  prune. The plan flagged it as a hard prerequisite and nothing was scheduled for
+  it.
+
+  Why live entries decay and the others do not: learning used to be **bounded** —
+  a run emits at most `repair_iterations_max` failures, and a scenario that stops
+  failing stops emitting. Live observation removed that bound. And a stale pitfall
+  is not inert: it steers generation away from something no longer broken, making
+  every future generation worse **silently**.
+
+  Three refusals, each guarding against deleting learning on weak evidence:
+
+  - **No timestamp is never retired.** Absence means nobody recorded when the rule
+    was last true — not evidence that it stopped being true. An unparseable value
+    counts as absent too, because zero would make every malformed entry infinitely
+    stale.
+  - **Retirement is exclusive at the boundary**, so a 14-day threshold does not
+    delete something last seen 14 days ago to the second.
+  - **A non-positive window is refused on both entry points** — a mistyped flag
+    would otherwise empty the corpus in one command, and a dry-run that accepts
+    what the real run rejects teaches the wrong thing about what is safe to type.
+
+  `--dry-run` and the real thing share one rule by construction: a dry-run that
+  can disagree with the real thing is worse than no dry-run. And `TouchLivePitfall`
+  refreshes rather than appends, which is what makes retention mean *last
+  observed* instead of *first observed*.
+
 - ✅ **S155b canary: the thesis, demonstrated on real infrastructure (2026-09-01)** —
   deployed v1, confirmed the service was serving `nginx:1.27`, upgraded to 1.28,
   and **`sandbox_deploy/apply` passed while `upgrade_verify` failed.** Confirmed

--- a/cmd/pitfall-merge/main.go
+++ b/cmd/pitfall-merge/main.go
@@ -101,7 +101,17 @@ func merge(pre, post generator.PitfallsFile, keepSet map[string]bool) (generator
 			continue
 		}
 		if i, seen := preIdx[entryKey(p)]; seen {
-			if newerLastSeen(out.Pitfalls[i].LastSeen, p.LastSeen) {
+			// Only refresh LIKE with LIKE. entryKey is (resource, rule)
+			// and deliberately ignores source, so the same rule can
+			// exist as `descriptive` in pre and `live` in post --
+			// and copying the live timestamp onto the descriptive entry
+			// would attach a lifetime to something that has none, while
+			// the live record disappeared as a duplicate. Two errors from
+			// one line.
+			//
+			// A source mismatch keeps the pre-existing behaviour: skip it,
+			// exactly as this merge did before timestamps existed.
+			if out.Pitfalls[i].Source == p.Source && newerLastSeen(out.Pitfalls[i].LastSeen, p.LastSeen) {
 				out.Pitfalls[i].LastSeen = p.LastSeen
 				refreshed++
 			}

--- a/cmd/pitfall-merge/main.go
+++ b/cmd/pitfall-merge/main.go
@@ -36,7 +36,13 @@ func main() {
 	preFile := flag.String("pre", "", "pre-sweep pitfalls yaml path (required)")
 	postFile := flag.String("post", "", "post-sweep pitfalls yaml path (required)")
 	outFile := flag.String("out", "", "output merged yaml path (required)")
-	keepFlag := flag.String("keep", "avoid", "comma-separated source values to preserve from post")
+	// `live` joins `avoid` in the default: both are run-derived, and a
+	// sweep that discards live entries would delete learning SILENTLY --
+	// which is the one thing S156a's retirement path exists to prevent.
+	// Retirement names what it removes; a sweep dropping the same entries
+	// on the floor would make the corpus untrustworthy in exactly the way
+	// the reporting was meant to fix.
+	keepFlag := flag.String("keep", "avoid,live", "comma-separated source values to preserve from post")
 	flag.Parse()
 
 	if *preFile == "" || *postFile == "" || *outFile == "" {

--- a/cmd/pitfall-merge/main.go
+++ b/cmd/pitfall-merge/main.go
@@ -67,14 +67,20 @@ func main() {
 		die("read post: %v", err)
 	}
 
-	merged, added, refreshed := merge(pre, post, keepSet)
+	merged, added, refreshed, addedBySource := merge(pre, post, keepSet)
 
 	if err := savePitfalls(*outFile, merged); err != nil {
 		die("write out: %v", err)
 	}
 
-	fmt.Printf("pitfall-merge: pre=%d post=%d kept_new=%d refreshed=%d (sources: %s)\n",
-		len(pre.Pitfalls), len(post.Pitfalls), added, refreshed, strings.Join(sortedKeys(keepSet), ","))
+	// Per-source counts as well as the total. AVOID_EMISSIONS in
+	// scripts/sweep_39.sh is a ratchet on whether the avoid extractor
+	// still works, and a combined kept_new would let preserved `live`
+	// entries mask an avoid-learning regression -- a metric that reads
+	// healthy while the thing it measures is broken.
+	fmt.Printf("pitfall-merge: pre=%d post=%d kept_new=%d refreshed=%d %s(sources: %s)\n",
+		len(pre.Pitfalls), len(post.Pitfalls), added, refreshed,
+		perSourceCounts(addedBySource), strings.Join(sortedKeys(keepSet), ","))
 }
 
 // merge returns pre + any post entries whose source is in keepSet and
@@ -88,7 +94,7 @@ func main() {
 // "first observed" instead of "last observed", exactly what
 // TouchLivePitfall exists to prevent. The entry then retires early, and
 // a rule that is still true is deleted.
-func merge(pre, post generator.PitfallsFile, keepSet map[string]bool) (generator.PitfallsFile, int, int) {
+func merge(pre, post generator.PitfallsFile, keepSet map[string]bool) (generator.PitfallsFile, int, int, map[string]int) {
 	preIdx := map[string]int{}
 	for i, p := range pre.Pitfalls {
 		preIdx[entryKey(p)] = i
@@ -96,6 +102,7 @@ func merge(pre, post generator.PitfallsFile, keepSet map[string]bool) (generator
 
 	out := pre
 	added, refreshed := 0, 0
+	addedBySource := map[string]int{}
 	for _, p := range post.Pitfalls {
 		if !keepSet[p.Source] {
 			continue
@@ -120,8 +127,31 @@ func merge(pre, post generator.PitfallsFile, keepSet map[string]bool) (generator
 		out.Pitfalls = append(out.Pitfalls, p)
 		preIdx[entryKey(p)] = len(out.Pitfalls) - 1
 		added++
+		addedBySource[p.Source]++
 	}
-	return out, added, refreshed
+	return out, added, refreshed, addedBySource
+}
+
+// perSourceCounts renders `kept_avoid=2 kept_live=1 `, or nothing when a
+// merge preserved nothing, so a caller can ratchet on one source without
+// parsing a combined total.
+func perSourceCounts(bySource map[string]int) string {
+	if len(bySource) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, src := range sortedKeys(toBoolSet(bySource)) {
+		fmt.Fprintf(&b, "kept_%s=%d ", src, bySource[src])
+	}
+	return b.String()
+}
+
+func toBoolSet(counts map[string]int) map[string]bool {
+	set := make(map[string]bool, len(counts))
+	for k := range counts {
+		set[k] = true
+	}
+	return set
 }
 
 // newerLastSeen reports whether candidate is a later timestamp than

--- a/cmd/pitfall-merge/main.go
+++ b/cmd/pitfall-merge/main.go
@@ -97,7 +97,7 @@ func main() {
 func merge(pre, post generator.PitfallsFile, keepSet map[string]bool) (generator.PitfallsFile, int, int, map[string]int) {
 	preIdx := map[string]int{}
 	for i, p := range pre.Pitfalls {
-		preIdx[entryKey(p)] = i
+		preIdx[mergeKey(p)] = i
 	}
 
 	out := pre
@@ -107,7 +107,7 @@ func merge(pre, post generator.PitfallsFile, keepSet map[string]bool) (generator
 		if !keepSet[p.Source] {
 			continue
 		}
-		if i, seen := preIdx[entryKey(p)]; seen {
+		if i, seen := preIdx[mergeKey(p)]; seen {
 			// Only refresh LIKE with LIKE. entryKey is (resource, rule)
 			// and deliberately ignores source, so the same rule can
 			// exist as `descriptive` in pre and `live` in post --
@@ -125,7 +125,7 @@ func merge(pre, post generator.PitfallsFile, keepSet map[string]bool) (generator
 			continue
 		}
 		out.Pitfalls = append(out.Pitfalls, p)
-		preIdx[entryKey(p)] = len(out.Pitfalls) - 1
+		preIdx[mergeKey(p)] = len(out.Pitfalls) - 1
 		added++
 		addedBySource[p.Source]++
 	}
@@ -176,6 +176,26 @@ func newerLastSeen(current, candidate string) bool {
 
 func entryKey(p generator.PitfallEntry) string {
 	return p.Resource + "\x00" + p.Rule
+}
+
+// mergeKey adds the source for entries that carry a LIFETIME.
+//
+// `live` is the only source with state that cannot be reconstructed: its
+// last_seen is the whole basis of retirement. Keying it on (resource,
+// rule) alone means an older `descriptive` entry with the same text
+// swallows it as a duplicate, and the observation -- along with the
+// timestamp that decides when it retires -- is silently gone.
+//
+// Every other source keeps the historical (resource, rule) identity.
+// Dropping a duplicate `avoid` loses a rule the corpus already states in
+// other words; dropping a duplicate `live` loses information nothing can
+// rebuild. That asymmetry is the reason for the special case, and the
+// reason it is not applied to everything.
+func mergeKey(p generator.PitfallEntry) string {
+	if p.Source == generator.LiveSource {
+		return entryKey(p) + "\x00" + p.Source
+	}
+	return entryKey(p)
 }
 
 func loadPitfalls(path string) (generator.PitfallsFile, error) {

--- a/cmd/pitfall-merge/main.go
+++ b/cmd/pitfall-merge/main.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/redscaresu/infrafactory/internal/generator"
 	"gopkg.in/yaml.v3"
@@ -66,39 +67,71 @@ func main() {
 		die("read post: %v", err)
 	}
 
-	merged, added := merge(pre, post, keepSet)
+	merged, added, refreshed := merge(pre, post, keepSet)
 
 	if err := savePitfalls(*outFile, merged); err != nil {
 		die("write out: %v", err)
 	}
 
-	fmt.Printf("pitfall-merge: pre=%d post=%d kept_new=%d (sources: %s)\n",
-		len(pre.Pitfalls), len(post.Pitfalls), added, strings.Join(sortedKeys(keepSet), ","))
+	fmt.Printf("pitfall-merge: pre=%d post=%d kept_new=%d refreshed=%d (sources: %s)\n",
+		len(pre.Pitfalls), len(post.Pitfalls), added, refreshed, strings.Join(sortedKeys(keepSet), ","))
 }
 
 // merge returns pre + any post entries whose source is in keepSet and
-// whose (resource, rule) is not already in pre. Returns the count of
-// preserved-new entries.
-func merge(pre, post generator.PitfallsFile, keepSet map[string]bool) (generator.PitfallsFile, int) {
-	preKeys := map[string]bool{}
-	for _, p := range pre.Pitfalls {
-		preKeys[entryKey(p)] = true
+// whose (resource, rule) is not already in pre, and carries forward a
+// newer last_seen for the ones that are. Returns the counts of
+// preserved-new and refreshed entries.
+//
+// The refresh half matters as much as the append half. A live entry
+// re-observed during the sweep exists in BOTH files, so skipping it as a
+// duplicate keeps pre's older timestamp -- which makes retention mean
+// "first observed" instead of "last observed", exactly what
+// TouchLivePitfall exists to prevent. The entry then retires early, and
+// a rule that is still true is deleted.
+func merge(pre, post generator.PitfallsFile, keepSet map[string]bool) (generator.PitfallsFile, int, int) {
+	preIdx := map[string]int{}
+	for i, p := range pre.Pitfalls {
+		preIdx[entryKey(p)] = i
 	}
 
 	out := pre
-	added := 0
+	added, refreshed := 0, 0
 	for _, p := range post.Pitfalls {
 		if !keepSet[p.Source] {
 			continue
 		}
-		if preKeys[entryKey(p)] {
+		if i, seen := preIdx[entryKey(p)]; seen {
+			if newerLastSeen(out.Pitfalls[i].LastSeen, p.LastSeen) {
+				out.Pitfalls[i].LastSeen = p.LastSeen
+				refreshed++
+			}
 			continue
 		}
 		out.Pitfalls = append(out.Pitfalls, p)
-		preKeys[entryKey(p)] = true
+		preIdx[entryKey(p)] = len(out.Pitfalls) - 1
 		added++
 	}
-	return out, added
+	return out, added, refreshed
+}
+
+// newerLastSeen reports whether candidate is a later timestamp than
+// current.
+//
+// An unparseable or absent candidate never wins: the existing value is
+// evidence somebody recorded, and replacing it with something unreadable
+// would make the entry look never-seen and retire it.
+func newerLastSeen(current, candidate string) bool {
+	next, err := time.Parse(time.RFC3339, candidate)
+	if err != nil {
+		return false
+	}
+	prev, err := time.Parse(time.RFC3339, current)
+	if err != nil {
+		// Current is missing or malformed and candidate is valid, so
+		// candidate is strictly more information.
+		return true
+	}
+	return next.After(prev)
 }
 
 func entryKey(p generator.PitfallEntry) string {

--- a/cmd/pitfall-merge/main_test.go
+++ b/cmd/pitfall-merge/main_test.go
@@ -183,10 +183,36 @@ func TestMergeDoesNotRefreshAcrossSources(t *testing.T) {
 	got, added, refreshed, _ := merge(pre, post, map[string]bool{"live": true})
 
 	assert.Zero(t, refreshed, "a live timestamp must not land on a descriptive entry")
-	assert.Zero(t, added, "and the pre-existing duplicate rule still wins, as it always did")
-	require.Len(t, got.Pitfalls, 1)
+
+	// And the live entry is KEPT rather than swallowed as a duplicate.
+	// Pass 63 dropped it to preserve the historical dedup; pass 66
+	// reversed that, because live is the only source carrying state that
+	// cannot be rebuilt -- losing it loses the timestamp retirement runs
+	// on, silently.
+	assert.Equal(t, 1, added)
+	require.Len(t, got.Pitfalls, 2)
 	assert.Equal(t, "descriptive", got.Pitfalls[0].Source)
 	assert.Empty(t, got.Pitfalls[0].LastSeen, "a source with no lifetime gains no timestamp")
+	assert.Equal(t, "live", got.Pitfalls[1].Source)
+	assert.Equal(t, "2026-09-01T00:00:00Z", got.Pitfalls[1].LastSeen)
+}
+
+// The asymmetry is deliberate and only live gets it: dropping a duplicate
+// `avoid` loses a rule the corpus already states in other words, while
+// dropping a duplicate `live` loses information nothing can rebuild.
+func TestMergeKeepsHistoricalIdentityForNonLiveSources(t *testing.T) {
+	const rule = "the same rule"
+	pre := generator.PitfallsFile{Pitfalls: []generator.PitfallEntry{
+		{Resource: "scaleway_lb", Rule: rule, Source: "descriptive"},
+	}}
+	post := generator.PitfallsFile{Pitfalls: []generator.PitfallEntry{
+		{Resource: "scaleway_lb", Rule: rule, Source: "avoid"},
+	}}
+
+	got, added, _, _ := merge(pre, post, map[string]bool{"avoid": true})
+
+	assert.Zero(t, added, "avoid keeps the historical (resource, rule) identity")
+	assert.Len(t, got.Pitfalls, 1)
 }
 
 // AVOID_EMISSIONS in scripts/sweep_39.sh ratchets on whether the avoid

--- a/cmd/pitfall-merge/main_test.go
+++ b/cmd/pitfall-merge/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/redscaresu/infrafactory/internal/generator"
@@ -24,7 +26,7 @@ func TestMerge_KeepsLearnedFromDiffAvoid(t *testing.T) {
 		mk("google_sql_database_instance", "descriptive failure echo", "descriptive"), // should drop
 	}}
 
-	got, added := merge(pre, post, map[string]bool{"avoid": true})
+	got, added, _ := merge(pre, post, map[string]bool{"avoid": true})
 
 	if added != 1 {
 		t.Fatalf("expected 1 added, got %d", added)
@@ -55,7 +57,7 @@ func TestMerge_SkipsDuplicates(t *testing.T) {
 		mk("google_service_account", "do NOT use X", "avoid"), // duplicate
 	}}
 
-	got, added := merge(pre, post, map[string]bool{"avoid": true})
+	got, added, _ := merge(pre, post, map[string]bool{"avoid": true})
 
 	if added != 0 {
 		t.Errorf("expected 0 added (dup), got %d", added)
@@ -78,7 +80,7 @@ func TestMerge_EmptyKeepSet(t *testing.T) {
 		mk("b", "new N13 entry", "avoid"),
 	}}
 
-	got, added := merge(pre, post, map[string]bool{})
+	got, added, _ := merge(pre, post, map[string]bool{})
 
 	if added != 0 {
 		t.Errorf("empty keep-set: expected 0 added, got %d", added)
@@ -100,7 +102,7 @@ func TestMerge_MultipleKeepSources(t *testing.T) {
 		mk("c", "descriptive", "descriptive"),
 	}}
 
-	got, added := merge(pre, post, map[string]bool{
+	got, added, _ := merge(pre, post, map[string]bool{
 		"fix":   true,
 		"avoid": true,
 	})
@@ -110,5 +112,55 @@ func TestMerge_MultipleKeepSources(t *testing.T) {
 	}
 	if len(got.Pitfalls) != 2 {
 		t.Errorf("expected 2 total, got %d", len(got.Pitfalls))
+	}
+}
+
+// A live entry re-observed during the sweep exists in BOTH files.
+// Skipping it as a duplicate keeps pre's older timestamp, which makes
+// retention mean "first observed" instead of "last observed" -- and the
+// rule then retires early while it is still true.
+func TestMergeCarriesForwardARefreshedLastSeen(t *testing.T) {
+	const rule = "a live rule"
+	pre := generator.PitfallsFile{Provider: "scaleway", Pitfalls: []generator.PitfallEntry{
+		{Resource: "scaleway_lb", Rule: rule, Source: "live", LastSeen: "2026-08-01T00:00:00Z"},
+	}}
+	post := generator.PitfallsFile{Provider: "scaleway", Pitfalls: []generator.PitfallEntry{
+		{Resource: "scaleway_lb", Rule: rule, Source: "live", LastSeen: "2026-09-01T00:00:00Z"},
+	}}
+
+	got, added, refreshed := merge(pre, post, map[string]bool{"live": true})
+
+	assert.Zero(t, added, "it is the same entry, not a new one")
+	assert.Equal(t, 1, refreshed)
+	require.Len(t, got.Pitfalls, 1)
+	assert.Equal(t, "2026-09-01T00:00:00Z", got.Pitfalls[0].LastSeen)
+}
+
+// Older or unreadable timestamps never win: the existing value is
+// evidence somebody recorded, and replacing it with something unreadable
+// would make the entry look never-seen and retire it.
+func TestMergeKeepsTheBetterLastSeen(t *testing.T) {
+	const rule = "a live rule"
+	cases := map[string]struct{ pre, post, want string }{
+		"older post":       {"2026-09-01T00:00:00Z", "2026-08-01T00:00:00Z", "2026-09-01T00:00:00Z"},
+		"unparseable post": {"2026-09-01T00:00:00Z", "sometime", "2026-09-01T00:00:00Z"},
+		"empty post":       {"2026-09-01T00:00:00Z", "", "2026-09-01T00:00:00Z"},
+		"empty pre":        {"", "2026-09-01T00:00:00Z", "2026-09-01T00:00:00Z"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			pre := generator.PitfallsFile{Pitfalls: []generator.PitfallEntry{
+				{Resource: "r", Rule: rule, Source: "live", LastSeen: tc.pre},
+			}}
+			post := generator.PitfallsFile{Pitfalls: []generator.PitfallEntry{
+				{Resource: "r", Rule: rule, Source: "live", LastSeen: tc.post},
+			}}
+
+			got, _, _ := merge(pre, post, map[string]bool{"live": true})
+
+			require.Len(t, got.Pitfalls, 1)
+			assert.Equal(t, tc.want, got.Pitfalls[0].LastSeen)
+		})
 	}
 }

--- a/cmd/pitfall-merge/main_test.go
+++ b/cmd/pitfall-merge/main_test.go
@@ -164,3 +164,27 @@ func TestMergeKeepsTheBetterLastSeen(t *testing.T) {
 		})
 	}
 }
+
+// entryKey is (resource, rule) and ignores source, so the same rule can
+// be `descriptive` in pre and `live` in post. Copying the live timestamp
+// onto the descriptive entry would attach a lifetime to something that
+// has none -- and only live entries are ever retired, so the timestamp
+// would sit there meaning nothing while the live record vanished as a
+// duplicate.
+func TestMergeDoesNotRefreshAcrossSources(t *testing.T) {
+	const rule = "the same rule, learned twice"
+	pre := generator.PitfallsFile{Pitfalls: []generator.PitfallEntry{
+		{Resource: "scaleway_lb", Rule: rule, Source: "descriptive"},
+	}}
+	post := generator.PitfallsFile{Pitfalls: []generator.PitfallEntry{
+		{Resource: "scaleway_lb", Rule: rule, Source: "live", LastSeen: "2026-09-01T00:00:00Z"},
+	}}
+
+	got, added, refreshed := merge(pre, post, map[string]bool{"live": true})
+
+	assert.Zero(t, refreshed, "a live timestamp must not land on a descriptive entry")
+	assert.Zero(t, added, "and the pre-existing duplicate rule still wins, as it always did")
+	require.Len(t, got.Pitfalls, 1)
+	assert.Equal(t, "descriptive", got.Pitfalls[0].Source)
+	assert.Empty(t, got.Pitfalls[0].LastSeen, "a source with no lifetime gains no timestamp")
+}

--- a/cmd/pitfall-merge/main_test.go
+++ b/cmd/pitfall-merge/main_test.go
@@ -26,7 +26,7 @@ func TestMerge_KeepsLearnedFromDiffAvoid(t *testing.T) {
 		mk("google_sql_database_instance", "descriptive failure echo", "descriptive"), // should drop
 	}}
 
-	got, added, _ := merge(pre, post, map[string]bool{"avoid": true})
+	got, added, _, _ := merge(pre, post, map[string]bool{"avoid": true})
 
 	if added != 1 {
 		t.Fatalf("expected 1 added, got %d", added)
@@ -57,7 +57,7 @@ func TestMerge_SkipsDuplicates(t *testing.T) {
 		mk("google_service_account", "do NOT use X", "avoid"), // duplicate
 	}}
 
-	got, added, _ := merge(pre, post, map[string]bool{"avoid": true})
+	got, added, _, _ := merge(pre, post, map[string]bool{"avoid": true})
 
 	if added != 0 {
 		t.Errorf("expected 0 added (dup), got %d", added)
@@ -80,7 +80,7 @@ func TestMerge_EmptyKeepSet(t *testing.T) {
 		mk("b", "new N13 entry", "avoid"),
 	}}
 
-	got, added, _ := merge(pre, post, map[string]bool{})
+	got, added, _, _ := merge(pre, post, map[string]bool{})
 
 	if added != 0 {
 		t.Errorf("empty keep-set: expected 0 added, got %d", added)
@@ -102,7 +102,7 @@ func TestMerge_MultipleKeepSources(t *testing.T) {
 		mk("c", "descriptive", "descriptive"),
 	}}
 
-	got, added, _ := merge(pre, post, map[string]bool{
+	got, added, _, _ := merge(pre, post, map[string]bool{
 		"fix":   true,
 		"avoid": true,
 	})
@@ -128,7 +128,7 @@ func TestMergeCarriesForwardARefreshedLastSeen(t *testing.T) {
 		{Resource: "scaleway_lb", Rule: rule, Source: "live", LastSeen: "2026-09-01T00:00:00Z"},
 	}}
 
-	got, added, refreshed := merge(pre, post, map[string]bool{"live": true})
+	got, added, refreshed, _ := merge(pre, post, map[string]bool{"live": true})
 
 	assert.Zero(t, added, "it is the same entry, not a new one")
 	assert.Equal(t, 1, refreshed)
@@ -157,7 +157,7 @@ func TestMergeKeepsTheBetterLastSeen(t *testing.T) {
 				{Resource: "r", Rule: rule, Source: "live", LastSeen: tc.post},
 			}}
 
-			got, _, _ := merge(pre, post, map[string]bool{"live": true})
+			got, _, _, _ := merge(pre, post, map[string]bool{"live": true})
 
 			require.Len(t, got.Pitfalls, 1)
 			assert.Equal(t, tc.want, got.Pitfalls[0].LastSeen)
@@ -180,11 +180,43 @@ func TestMergeDoesNotRefreshAcrossSources(t *testing.T) {
 		{Resource: "scaleway_lb", Rule: rule, Source: "live", LastSeen: "2026-09-01T00:00:00Z"},
 	}}
 
-	got, added, refreshed := merge(pre, post, map[string]bool{"live": true})
+	got, added, refreshed, _ := merge(pre, post, map[string]bool{"live": true})
 
 	assert.Zero(t, refreshed, "a live timestamp must not land on a descriptive entry")
 	assert.Zero(t, added, "and the pre-existing duplicate rule still wins, as it always did")
 	require.Len(t, got.Pitfalls, 1)
 	assert.Equal(t, "descriptive", got.Pitfalls[0].Source)
 	assert.Empty(t, got.Pitfalls[0].LastSeen, "a source with no lifetime gains no timestamp")
+}
+
+// AVOID_EMISSIONS in scripts/sweep_39.sh ratchets on whether the avoid
+// extractor still works. A combined kept_new would let preserved `live`
+// entries mask an avoid-learning regression -- a metric that reads
+// healthy while the thing it measures is broken.
+func TestMergeReportsKeptCountsPerSource(t *testing.T) {
+	pre := generator.PitfallsFile{}
+	post := generator.PitfallsFile{Pitfalls: []generator.PitfallEntry{
+		{Resource: "a", Rule: "1", Source: "avoid"},
+		{Resource: "b", Rule: "2", Source: "live", LastSeen: "2026-09-01T00:00:00Z"},
+		{Resource: "c", Rule: "3", Source: "live", LastSeen: "2026-09-01T00:00:00Z"},
+		{Resource: "d", Rule: "4", Source: "descriptive"},
+	}}
+
+	_, added, _, bySource := merge(pre, post, map[string]bool{"avoid": true, "live": true})
+
+	assert.Equal(t, 3, added)
+	assert.Equal(t, 1, bySource["avoid"], "the avoid ratchet must be readable on its own")
+	assert.Equal(t, 2, bySource["live"])
+	assert.Zero(t, bySource["descriptive"], "not in keepSet, so not preserved")
+
+	rendered := perSourceCounts(bySource)
+	assert.Contains(t, rendered, "kept_avoid=1")
+	assert.Contains(t, rendered, "kept_live=2")
+}
+
+// A sweep that preserved nothing must still print a parseable line: the
+// script greps for kept_avoid and treats a miss as zero, so an absent
+// field is fine but a malformed one is not.
+func TestMergeRendersNothingWhenNothingWasKept(t *testing.T) {
+	assert.Empty(t, perSourceCounts(map[string]int{}))
 }

--- a/docs/decisions/0019-learning-system-vocabulary.md
+++ b/docs/decisions/0019-learning-system-vocabulary.md
@@ -52,3 +52,32 @@ Alternatives considered:
 
 **Follow-up**
 - None mandatory. If a future arc introduces a fourth extractor or a new pitfall source value, it should use concept names from day one — no slice ID in the public vocabulary.
+
+## Amendment, 2026-09-01 (S156a): `live`, and the first source with a lifetime
+
+The vocabulary gains a fourth value: **`live`**, for a pitfall learned from a
+service that was already running rather than from a failed apply.
+
+It is the first source with a **lifetime**. The others do not need one: a rule
+extracted from a reproducible apply failure does not stop being true because
+nobody hit it lately. A live rule does, once the thing it describes is fixed —
+and learning used to be bounded, because a run emits at most
+`repair_iterations_max` failures and a scenario that stops failing stops
+emitting. Live observation removed that bound.
+
+So `live` entries carry `last_seen`, and `pitfalls retire` removes those not seen
+within a retention window. Three rules, all of them about refusing to delete
+learning on weak evidence:
+
+- **No timestamp is never retired.** Absence means nobody recorded when the rule
+  was last true, which is not evidence it stopped being true. An unparseable
+  value counts as absent, because treating it as zero would make every malformed
+  entry infinitely stale and delete it.
+- **The boundary is exclusive**, so a 14-day window does not delete something last
+  seen 14 days ago to the second.
+- **A non-positive window is refused**, on the dry-run path as well as the real
+  one. A mistyped flag would empty the corpus in one command, and a dry-run that
+  accepts what the real run rejects teaches the wrong thing about what is safe.
+
+Removal is reported, never silent — the rule the D6 purge established. A corpus
+that quietly drops entries is indistinguishable from one that never learned them.

--- a/docs/decisions/0019-learning-system-vocabulary.md
+++ b/docs/decisions/0019-learning-system-vocabulary.md
@@ -81,3 +81,10 @@ learning on weak evidence:
 
 Removal is reported, never silent — the rule the D6 purge established. A corpus
 that quietly drops entries is indistinguishable from one that never learned them.
+
+Adding a source value is not a three-line change. `live` had to be learned by the
+two corpus ratchets, the sweep's preservation list, and the path guard on the
+maintenance command — four places, found across four review passes, three of them
+mechanisms that already existed in the repository. **A vocabulary is only as real
+as the things that enforce it**, and the next value added here should start by
+enumerating them rather than by adding the constant.

--- a/docs/plans/live-learning-loop-plan.md
+++ b/docs/plans/live-learning-loop-plan.md
@@ -128,6 +128,20 @@ entries** — an expiry, a supersession rule, or a re-validation against the
 holdout set. Unshelving the full pruning plan is the larger option and may be the
 right one.
 
+## Known gap: genesys is outside the sweep's pitfall handling
+
+`scripts/sweep_39.sh` and `m93_resweep.sh` snapshot and merge
+`aws / gcp / scaleway` and omit **genesys**, and so do all three corpus ratchets —
+consistently, and since long before this arc. `pitfalls/genesys.yaml` is real (19
+entries) but no sweep ever touches it.
+
+That costs nothing today: no live entries exist for any cloud. It starts costing
+at the slice that first produces them. Closing it means deciding whether genesys
+joins the ratchets, whether the no-human-seeding policy applies to a corpus that
+predates it, and what `AVOID_EMISSIONS` means for a cloud with no avoid entries —
+a decision with its own scope, which is why it was declined during the retirement
+slice rather than folded in (review pass 65).
+
 ## Risks
 
 | risk | mitigation |

--- a/docs/review-passes/pass59.md
+++ b/docs/review-passes/pass59.md
@@ -1,0 +1,37 @@
+# Codex review pass 59 — S156a
+
+One finding, accepted. **A vocabulary added without updating what enforces it.**
+
+## [P2] The source ratchets still enforced the old enum
+
+`LiveSource = "live"` was added as a persisted value while two repository
+ratchets still fenced the corpus to `descriptive` / `fix` / `avoid`:
+
+- `TestPitfallsSourceEnum` — the positive set
+- `TestPitfallsNoHumanSeeding` — the "no human authorship" policy
+
+So the moment S156c wrote the first live entry, CI would have rejected the corpus
+and the failure would have pointed at the *entry*, not at the ratchet that never
+learned about it.
+
+Both updated, and `live` earns its place in the seeding ratchet on the merits: it
+is run-derived too, just from a later moment — the run is a service already
+deployed rather than an apply. The policy that ratchet enforces is *no human
+authorship*, and an observation of a real service is the opposite of that.
+
+## What sweeping for the same class found
+
+`cmd/pitfall-merge` preserves `--keep avoid` across a sweep, and
+`scripts/sweep_39.sh` passes exactly that. So **a sweep would have silently
+deleted every live entry** — which is precisely what this slice exists to
+prevent. Retirement names what it removes; a sweep dropping the same entries on
+the floor makes the corpus untrustworthy in the way the reporting was meant to
+fix.
+
+Now `avoid,live`, in both the flag default and the sweep.
+
+That one was not in the finding. It was found by asking *where else does this
+vocabulary have to be known?* — which is the habit the S155b passes were trying
+to teach, applied before the next review rather than after it.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass60.md
+++ b/docs/review-passes/pass60.md
@@ -1,0 +1,31 @@
+# Codex review pass 60 — S156a
+
+One finding, accepted. **The incomplete half of pass 59's own fix.**
+
+## [P2] The sweep merge discarded refreshed timestamps
+
+Pass 59 made `pitfall-merge` preserve `live` entries. It preserved the *entries*
+and not their *freshness*: `merge` skips anything whose `(resource, rule)` is
+already in pre, so a live rule **re-observed during the sweep** kept pre's older
+`last_seen`.
+
+The effect is quiet and bad. Retention silently reverts to *first observed*
+instead of *last observed* — the exact thing `TouchLivePitfall` exists to prevent
+— and the entry then retires early, deleting a rule that is still true.
+
+`merge` now carries forward a newer timestamp for entries it already has, and
+reports `refreshed=N` alongside `kept_new=N`. An older, absent or unparseable
+candidate never wins: the existing value is evidence somebody recorded, and
+replacing it with something unreadable would make the entry look never-seen and
+retire it.
+
+## The pattern, one more time
+
+Pass 59 found a vocabulary added without updating its enforcers. I then swept for
+the same class, found the sweep would delete live entries, and fixed that — and
+introduced this by fixing only the half I had gone looking for.
+
+**Preserving a record is not the same as preserving what the record says**, and
+that distinction is the whole of both findings.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass61.md
+++ b/docs/review-passes/pass61.md
@@ -1,0 +1,24 @@
+# Codex review pass 61 — S156a
+
+One finding, accepted.
+
+## [P2] Corpus maintenance required the LLM to be configured
+
+`pitfalls retire` was wired through `cfg.withRuntime`, and `buildRuntime`
+constructs the Claude transport by default — which can fail on a missing binary
+or an unreadable prompts directory.
+
+This command reads a YAML file and writes it back. Making that impossible because
+the agent is unconfigured is a dependency nobody asked for, and it bites hardest
+on exactly the machine doing housekeeping rather than generation.
+
+`withRuntimeNoGenerator` keeps the logging and error formatting every other
+command has, and substitutes a generator that **refuses** rather than one that
+returns empty output: this command must never generate, so a call is a bug that
+should say so loudly.
+
+The test patches the harness config to point at `/nonexistent/claude`, and
+asserts the patch actually applied — otherwise it would pass by constructing a
+working transport and prove nothing.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass62.md
+++ b/docs/review-passes/pass62.md
@@ -1,0 +1,29 @@
+# Codex review pass 62 — S156a
+
+One finding, accepted. **A guard that already exists in this codebase, not
+carried across.**
+
+## [P2] The cloud name was joined into a path unvalidated
+
+`pitfalls retire <cloud>` takes its argument from the command line and joins it
+straight onto the pitfalls directory. So `retire ../../something` reads **and
+rewrites** a YAML file outside the corpus — a write, not merely a read.
+
+`livestore.validateID` guards deployment ids against exactly this, for exactly
+this reason: a name that came from a caller decides a path. `assertCloudName` now
+applies the same rule, on all three entry points — retire, its dry-run, and
+touch.
+
+## The count for this slice
+
+Four passes, four findings, and **three of them were mechanisms that already
+existed somewhere in this repository**: the source ratchets, the sweep's
+preservation rule, and now the path guard. The fourth was the runtime wiring.
+
+That is the same shape as S155b, and it is worth naming precisely because S156a
+is a *small* slice — so slice size is not the whole story. The other half is:
+**new code that touches an existing mechanism should start by finding every place
+that mechanism is already enforced.** Adding `LiveSource` was three lines; the
+work was the four places that had to learn about it.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass63.md
+++ b/docs/review-passes/pass63.md
@@ -1,0 +1,31 @@
+# Codex review pass 63 — S156a
+
+One finding, accepted. **The third consecutive pass to land on the same merge.**
+
+## [P2] The refresh crossed source boundaries
+
+`entryKey` is `(resource, rule)` and deliberately ignores `source`, so the same
+rule can exist as `descriptive` in pre and `live` in post. Pass 60's refresh then
+copied the live timestamp onto the **descriptive** entry — attaching a lifetime
+to a source that has none, while the live record vanished as a duplicate. Two
+errors from one line, and the timestamp would have sat there meaning nothing,
+because only live entries are ever retired.
+
+Refresh is now like-with-like. A source mismatch keeps the pre-existing
+behaviour: skip it, exactly as this merge did before timestamps existed.
+
+## Passes 59, 60, 63 are one thing
+
+| pass | the merge | what was missed |
+|---|---|---|
+| 59 | preserve live entries | their freshness |
+| 60 | carry a newer timestamp | that the key ignores source |
+| 63 | refresh like with like | — |
+
+Each fix was correct and each was too narrow, on **fifteen lines of code**. The
+lesson S156a has actually taught is not about slice size — this slice is small.
+It is that a change to a data model lands in every place that reads it, and the
+reliable way to find those is to enumerate the readers *before* the first edit
+rather than after each review.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass64.md
+++ b/docs/review-passes/pass64.md
@@ -1,0 +1,37 @@
+# Codex review pass 64 — S156a
+
+One finding, accepted. **The fourth pass to land on the same change, from a new
+direction: not the merge, but what reads its output.**
+
+## [P2] Live preservation could mask an avoid-learning regression
+
+`scripts/sweep_39.sh` parses `kept_new=N` into `AVOID_EMISSIONS`, a ratchet on
+whether the avoid extractor still works — it warns when a sweep emits zero.
+
+Passing `--keep avoid,live` made `kept_new` count both. So a sweep that preserved
+three live entries and produced **zero** avoid pitfalls would report
+`AVOID_EMISSIONS=3` and warn about nothing. A metric that reads healthy while the
+thing it measures is broken is worse than no metric.
+
+`pitfall-merge` now prints per-source counts (`kept_avoid=2 kept_live=1`), and the
+sweep ratchets on `kept_avoid`.
+
+## What this slice has actually been about
+
+Five passes, five findings, all downstream of adding **one constant**:
+
+| pass | who had to learn about `live` |
+|---|---|
+| 59 | the two corpus ratchets; the sweep's preservation list |
+| 60 | the merge's freshness handling |
+| 62 | the path guard on the new command |
+| 63 | the merge's source semantics |
+| 64 | the metric that reads the merge's output |
+
+`LiveSource = "live"` is three lines. Everything since has been the places that
+had to know. **A vocabulary is only as real as the things that enforce it** — and
+the readers are found by enumerating them, not by waiting for a reviewer to name
+them one at a time. That is now written into ADR-0019 for whoever adds the next
+source value.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass65.md
+++ b/docs/review-passes/pass65.md
@@ -1,0 +1,39 @@
+# Codex review pass 65 — S156a
+
+One finding, **declined** — the first decline in this slice.
+
+## [P2] "Preserve live pitfalls for Genesys sweeps" — declined
+
+The finding is that `scripts/sweep_39.sh` loops `aws gcp scaleway` and omits
+genesys, so live entries for a supported cloud could be lost.
+
+Checked rather than assumed:
+
+- `pitfalls/genesys.yaml` exists and holds **19 entries** (18 descriptive, 1 fix).
+- The sweep omits genesys from its **snapshot** (line 40–42), its **merge** (line
+  237), and `m93_resweep.sh` does the same.
+- All three corpus ratchets — `TestPitfallsSourceEnum`,
+  `TestPitfallsNoHumanSeeding`, and the third in that file — also loop
+  `aws / gcp / scaleway` only.
+
+So genesys is excluded from pitfall sweep handling **consistently across the
+repository**, and has been since before this slice. `LiveSource` did not create
+that gap and does not widen it: in the normal path genesys entries are not merged
+and therefore not touched, and in the fallback path (`bin/pitfall-merge` missing)
+the blanket `git checkout pitfalls/` discards *everything* for every cloud —
+avoid entries included — exactly as it always has.
+
+**Declined as out of scope.** Bringing genesys into the sweep's pitfall handling
+means also deciding whether it joins the ratchets, whether the no-human-seeding
+policy applies to a corpus that predates it, and what `AVOID_EMISSIONS` means for
+a cloud with no avoid entries. That is a decision with its own scope, and folding
+it into a slice about retirement is how a small slice becomes S155b.
+
+**Recorded, not dismissed**: noted in the S156 plan as a prerequisite for S156c,
+which is the slice that will actually produce live entries and therefore the first
+point at which this costs anything.
+
+## Where the slice stands
+
+Six passes, six findings, five accepted and one declined — all six downstream of
+adding one constant.

--- a/docs/review-passes/pass66.md
+++ b/docs/review-passes/pass66.md
@@ -1,0 +1,34 @@
+# Codex review pass 66 — S156a
+
+One finding, accepted. **It reverses pass 63's decision, correctly.**
+
+## [P2] A live entry could still be swallowed as a duplicate
+
+Pass 63 stopped the merge refreshing across sources, and chose to keep the
+historical behaviour for the mismatch case: skip the post entry. That preserved
+the old dedup — and silently dropped the live entry whenever an older
+`descriptive` rule happened to share its `(resource, rule)`.
+
+Losing it loses the `last_seen` that retirement runs on. The observation, and the
+timestamp deciding when it retires, are gone with nothing to rebuild them from —
+which is the failure this whole slice exists to prevent, arrived at from the
+other side.
+
+`mergeKey` now includes the source **for `live` only**. The asymmetry is the
+argument: dropping a duplicate `avoid` loses a rule the corpus already states in
+other words; dropping a duplicate `live` loses information nothing can
+reconstruct. Every other source keeps the historical identity.
+
+## A correction to the previous commit
+
+Pass 65's commit message said the declined genesys finding was "noted in the S156
+plan". It was not — the anchor I edited against lives on the unmerged
+`s156-plan` branch, and the edit silently failed while the commit went ahead.
+The note is now in the plan on this branch, under *"Known gap: genesys is outside
+the sweep's pitfall handling"*.
+
+Worth stating rather than quietly fixing: the commit message claimed a record
+that did not exist, which is the same class of thing this slice keeps finding in
+the code.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass67.md
+++ b/docs/review-passes/pass67.md
@@ -1,0 +1,40 @@
+# Codex review pass 67 — S156a
+
+**Clean.** No findings.
+
+> The reviewed changes add live pitfall retention, CLI wiring, and sweep
+> preservation without introducing a correctness issue I could identify.
+
+Converged. Eight passes, eight findings, seven accepted and one declined.
+
+## What the slice was actually about
+
+`LiveSource = "live"` is one constant. Everything else was the places that had to
+know:
+
+| pass | who had to learn about `live` |
+|---|---|
+| 59 | the two corpus ratchets, and the sweep's preservation list |
+| 60 | the merge's handling of freshness |
+| 61 | the runtime wiring (maintenance must not need the LLM) |
+| 62 | the path guard on the new command |
+| 63 | the merge's source semantics |
+| 64 | the metric reading the merge's output |
+| 65 | *(declined)* the sweep's cloud coverage |
+| 66 | the merge's identity for entries carrying state |
+
+Four of those were mechanisms that **already existed in this repository** —
+ratchets, preservation, path validation, dedup identity. None was found by
+reading the new code; each was found by a reviewer asking who else cares.
+
+**A vocabulary is only as real as the things that enforce it.** ADR-0019 now says
+so, and says the next value added here should start by enumerating the readers
+rather than by adding the constant.
+
+## Passes 63 and 66 are worth reading together
+
+63 fixed a bug by preserving historical behaviour; 66 showed that the historical
+behaviour was itself wrong for the new case. Both were right on the evidence
+available at the time. The general lesson is not "think harder" — it is that
+*"keep the old behaviour"* is a decision, not a default, and deserves the same
+justification as changing it.

--- a/internal/cli/pitfalls_command.go
+++ b/internal/cli/pitfalls_command.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redscaresu/infrafactory/internal/generator"
+)
+
+// newPitfallsCmd groups operations on the learned corpus itself, as
+// opposed to the runs that produce it.
+func newPitfallsCmd(cfg *rootConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pitfalls",
+		Short: "Inspect and maintain the learned pitfall corpus",
+	}
+
+	retire := &cobra.Command{
+		Use:   "retire <cloud>",
+		Short: "Remove live-sourced pitfalls that have not been seen for a while",
+		Args:  cobra.ExactArgs(1),
+		RunE:  cfg.withRuntime("pitfalls retire", runPitfallsRetireCommand),
+	}
+	retire.Flags().Duration("older-than", generator.DefaultLiveRetention,
+		"Retire live pitfalls last seen longer ago than this")
+	retire.Flags().Bool("dry-run", false, "Report what would be retired without changing the corpus")
+	cmd.AddCommand(retire)
+
+	return cmd
+}
+
+// runPitfallsRetireCommand is the corpus's only outflow (S156a).
+//
+// Every other part of the learning loop adds entries. Learning used to be
+// bounded -- a run emits at most `repair_iterations_max` failures, and a
+// scenario that stops failing stops emitting -- and live observation
+// removed that bound. Nothing else can take an entry out once the cause
+// behind it is fixed.
+//
+// A stale pitfall is not inert. It steers generation away from something
+// that is no longer broken, which makes every future generation worse
+// **silently**, and silent degradation is the failure mode this project
+// has learned to fear most.
+func runPitfallsRetireCommand(cmd *cobra.Command, args []string, runtime *CommandRuntime) error {
+	cloud := args[0]
+
+	olderThan, err := cmd.Flags().GetDuration("older-than")
+	if err != nil {
+		return &CLIError{Op: "pitfalls retire", Code: errorCodeUsage, Err: err}
+	}
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		return &CLIError{Op: "pitfalls retire", Code: errorCodeUsage, Err: err}
+	}
+
+	dir := runtime.Config.Paths.Pitfalls
+	now := time.Now()
+
+	if dryRun {
+		// Reads the corpus and reports, changing nothing. Worth having
+		// because retirement deletes learning, and an operator should be
+		// able to see what a threshold would remove before it removes it.
+		stale, err := generator.StaleLivePitfalls(dir, cloud, olderThan, now)
+		if err != nil {
+			return &CLIError{Op: "pitfalls retire", Code: errorCodeCommandFailed, Err: err}
+		}
+		return reportRetired(cmd, cloud, stale, true)
+	}
+
+	retired, err := generator.RetireStaleLivePitfalls(dir, cloud, olderThan, now)
+	if err != nil {
+		return &CLIError{Op: "pitfalls retire", Code: errorCodeCommandFailed, Err: err}
+	}
+	return reportRetired(cmd, cloud, retired, false)
+}
+
+// reportRetired names every entry that went, because a corpus that
+// quietly drops entries is indistinguishable from one that never learned
+// them -- the rule the D6 purge established.
+func reportRetired(cmd *cobra.Command, cloud string, retired []generator.RetiredPitfall, dryRun bool) error {
+	stages := []StageSummary{{
+		Layer: "pitfalls", Stage: "retire", Status: StageStatusPass,
+		Detail: retirementSummary(cloud, retired, dryRun),
+	}}
+
+	for _, entry := range retired {
+		stages = append(stages, StageSummary{
+			Layer: "pitfalls", Stage: "retire", Status: StageStatusPass,
+			Detail: fmt.Sprintf("%s: last seen %s (%s ago) — %s",
+				entry.Resource,
+				entry.LastSeen.UTC().Format(time.RFC3339),
+				entry.Age.Round(time.Hour),
+				truncateRule(entry.Rule)),
+		})
+	}
+
+	return writeCommandOutput(cmd, OutputResult{
+		Command: "pitfalls retire",
+		Status:  CommandStatusSuccess,
+		Stages:  stages,
+	})
+}
+
+func retirementSummary(cloud string, retired []generator.RetiredPitfall, dryRun bool) string {
+	if len(retired) == 0 {
+		return fmt.Sprintf("no live pitfalls in %s have gone stale", cloud)
+	}
+	if dryRun {
+		return fmt.Sprintf("--dry-run: %d live pitfall(s) in %s would be retired", len(retired), cloud)
+	}
+	return fmt.Sprintf("retired %d live pitfall(s) from %s", len(retired), cloud)
+}
+
+// truncateRule keeps a summary line readable. Rules can be whole HCL
+// snippets, and a stage list that scrolls for a page is one nobody reads.
+func truncateRule(rule string) string {
+	const limit = 100
+	flat := ""
+	for _, r := range rule {
+		if r == '\n' || r == '\t' {
+			r = ' '
+		}
+		flat += string(r)
+		if len(flat) >= limit {
+			return flat + "…"
+		}
+	}
+	return flat
+}

--- a/internal/cli/pitfalls_command.go
+++ b/internal/cli/pitfalls_command.go
@@ -21,7 +21,7 @@ func newPitfallsCmd(cfg *rootConfig) *cobra.Command {
 		Use:   "retire <cloud>",
 		Short: "Remove live-sourced pitfalls that have not been seen for a while",
 		Args:  cobra.ExactArgs(1),
-		RunE:  cfg.withRuntime("pitfalls retire", runPitfallsRetireCommand),
+		RunE:  cfg.withRuntimeNoGenerator("pitfalls retire", runPitfallsRetireCommand),
 	}
 	retire.Flags().Duration("older-than", generator.DefaultLiveRetention,
 		"Retire live pitfalls last seen longer ago than this")

--- a/internal/cli/pitfalls_command_test.go
+++ b/internal/cli/pitfalls_command_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/redscaresu/infrafactory/internal/config"
+	"github.com/redscaresu/infrafactory/internal/generator"
+)
+
+// retireRuntime points the corpus at a temp dir so a test cannot retire
+// entries from the repository's real pitfalls files.
+func retireRuntime(t *testing.T, entries ...generator.PitfallEntry) (*CommandRuntime, string) {
+	t.Helper()
+	dir := t.TempDir()
+	payload, err := yaml.Marshal(generator.PitfallsFile{Provider: "scaleway", Pitfalls: entries})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "scaleway.yaml"), payload, 0o644))
+
+	return &CommandRuntime{Config: config.Config{Paths: config.PathsConfig{Pitfalls: dir}}}, dir
+}
+
+func runRetire(t *testing.T, rt *CommandRuntime, out *strings.Builder, args ...string) error {
+	t.Helper()
+	cmd := &cobra.Command{Use: "retire"}
+	cmd.Flags().Duration("older-than", generator.DefaultLiveRetention, "")
+	cmd.Flags().Bool("dry-run", false, "")
+	cmd.Flags().String("output", string(OutputModeHuman), "")
+	require.NoError(t, cmd.ParseFlags(args))
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	return runPitfallsRetireCommand(cmd, []string{"scaleway"}, rt)
+}
+
+func staleLive(resource string, age time.Duration) generator.PitfallEntry {
+	return generator.PitfallEntry{
+		Resource: resource, Rule: "a rule about " + resource, Source: generator.LiveSource,
+		LastSeen: time.Now().Add(-age).UTC().Format(time.RFC3339),
+	}
+}
+
+// A corpus that quietly drops entries is indistinguishable from one that
+// never learned them -- the rule the D6 purge established.
+func TestRetireNamesEveryEntryItRemoved(t *testing.T) {
+	rt, _ := retireRuntime(t, staleLive("scaleway_lb", 30*24*time.Hour))
+
+	var out strings.Builder
+	require.NoError(t, runRetire(t, rt, &out, "--older-than", "336h"))
+
+	assert.Contains(t, out.String(), "retired 1 live pitfall(s)")
+	assert.Contains(t, out.String(), "scaleway_lb")
+	assert.Contains(t, out.String(), "last seen")
+	assert.Contains(t, out.String(), "a rule about scaleway_lb", "the rule itself, not just a count")
+}
+
+// Retirement deletes learning, so an operator can see what a threshold
+// would take out before it takes it out.
+func TestRetireDryRunChangesNothing(t *testing.T) {
+	rt, dir := retireRuntime(t, staleLive("scaleway_lb", 30*24*time.Hour))
+
+	var out strings.Builder
+	require.NoError(t, runRetire(t, rt, &out, "--older-than", "336h", "--dry-run"))
+
+	assert.Contains(t, out.String(), "--dry-run")
+	assert.Contains(t, out.String(), "would be retired")
+
+	payload, err := os.ReadFile(filepath.Join(dir, "scaleway.yaml"))
+	require.NoError(t, err)
+	var pf generator.PitfallsFile
+	require.NoError(t, yaml.Unmarshal(payload, &pf))
+	assert.Len(t, pf.Pitfalls, 1, "a dry run must not remove anything")
+}
+
+func TestRetireSaysSoWhenNothingIsStale(t *testing.T) {
+	rt, _ := retireRuntime(t, staleLive("scaleway_lb", time.Hour))
+
+	var out strings.Builder
+	require.NoError(t, runRetire(t, rt, &out, "--older-than", "336h"))
+
+	assert.Contains(t, out.String(), "no live pitfalls in scaleway have gone stale")
+}
+
+// A mistyped threshold would otherwise delete everything learned from
+// running services in one command.
+func TestRetireRefusesANonPositiveThreshold(t *testing.T) {
+	rt, dir := retireRuntime(t, staleLive("scaleway_lb", 30*24*time.Hour))
+
+	for _, flag := range []string{"0s", "-1h"} {
+		err := runRetire(t, rt, &strings.Builder{}, "--older-than", flag)
+		require.Error(t, err, "--older-than %s", flag)
+		assert.Contains(t, err.Error(), "every live pitfall would be retired")
+	}
+
+	payload, err := os.ReadFile(filepath.Join(dir, "scaleway.yaml"))
+	require.NoError(t, err)
+	var pf generator.PitfallsFile
+	require.NoError(t, yaml.Unmarshal(payload, &pf))
+	assert.Len(t, pf.Pitfalls, 1)
+}
+
+// The dry-run must refuse exactly what the real run refuses, or it
+// teaches the operator the wrong thing about what is safe to type.
+func TestRetireDryRunRefusesTheSameThresholds(t *testing.T) {
+	rt, _ := retireRuntime(t, staleLive("scaleway_lb", 30*24*time.Hour))
+
+	err := runRetire(t, rt, &strings.Builder{}, "--older-than", "0s", "--dry-run")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "every live pitfall would be retired")
+}

--- a/internal/cli/pitfalls_command_test.go
+++ b/internal/cli/pitfalls_command_test.go
@@ -116,3 +116,40 @@ func TestRetireDryRunRefusesTheSameThresholds(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "every live pitfall would be retired")
 }
+
+// Corpus maintenance must not depend on the LLM being configured.
+// buildRuntime constructs the Claude transport by default and that
+// construction can fail -- a missing binary, an unreadable prompts
+// directory -- which would make housekeeping impossible on exactly the
+// machine doing housekeeping rather than generation.
+func TestRetireDoesNotRequireAGenerator(t *testing.T) {
+	h := newCommandTestHarness(t)
+	require.NoError(t, os.MkdirAll(h.PitfallsDir(), 0o755))
+	payload, err := yaml.Marshal(generator.PitfallsFile{Provider: "scaleway"})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(h.PitfallsDir(), "scaleway.yaml"), payload, 0o644))
+
+	// The agent points at a binary that does not exist, which is what
+	// makes this a test rather than a tautology: buildRuntime would
+	// otherwise construct a working transport and prove nothing.
+	raw, err := os.ReadFile(h.ConfigPath)
+	require.NoError(t, err)
+	patched := strings.Replace(string(raw), "type: claude-code",
+		"type: claude-code\n  claude:\n    command: /nonexistent/claude", 1)
+	require.NotEqual(t, string(raw), patched, "the harness config must declare a claude-code agent")
+	require.NoError(t, os.WriteFile(h.ConfigPath, []byte(patched), 0o644))
+
+	cmd := &cobra.Command{Use: "retire"}
+	cmd.Flags().Duration("older-than", generator.DefaultLiveRetention, "")
+	cmd.Flags().Bool("dry-run", false, "")
+	cmd.Flags().String("output", string(OutputModeHuman), "")
+	cmd.Flags().String("config", h.ConfigPath, "")
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	handler := (&rootConfig{}).withRuntimeNoGenerator("pitfalls retire", runPitfallsRetireCommand)
+
+	assert.NoError(t, handler(cmd, []string{"scaleway"}),
+		"corpus maintenance must not fail because the agent is unconfigured")
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/redscaresu/infrafactory/internal/config"
+	"github.com/redscaresu/infrafactory/internal/generator"
 	"github.com/spf13/cobra"
 )
 
@@ -46,6 +48,32 @@ func (cfg *rootConfig) withRuntime(op string, next runtimeHandler) func(*cobra.C
 	}
 	opts := defaultRuntimeOptions()
 	opts.deps = cfg.deps
+	return withRuntimeWithOptions(op, opts, next)
+}
+
+// withRuntimeNoGenerator is for commands that never generate.
+//
+// buildRuntime constructs the Claude transport by default, and that
+// construction can fail -- a missing `claude` binary, an unreadable
+// prompts directory. `pitfalls retire` reads and rewrites a YAML file;
+// making corpus maintenance impossible because the LLM is not configured
+// is a dependency nobody asked for, and it would bite hardest on exactly
+// the machine doing housekeeping rather than generation.
+//
+// The stub refuses rather than returning empty output: this command must
+// never generate, so a call is a bug that should say so loudly rather
+// than silently produce nothing.
+func (cfg *rootConfig) withRuntimeNoGenerator(op string, next runtimeHandler) func(*cobra.Command, []string) error {
+	opts := defaultRuntimeOptions()
+	if cfg != nil && cfg.depsSet {
+		opts.deps = cfg.deps
+	}
+	if opts.deps.Generator == nil {
+		opts.deps.Generator = generator.SeedGeneratorFunc(
+			func(context.Context, generator.Request) (*generator.GeneratedCode, error) {
+				return nil, errors.New("this command does not generate")
+			})
+	}
 	return withRuntimeWithOptions(op, opts, next)
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -79,6 +79,7 @@ func NewRootCmd(opts ...RootOption) *cobra.Command {
 		newReapCmd(cfg),
 		newDeployCmd(cfg),
 		newLiveCmd(cfg),
+		newPitfallsCmd(cfg),
 		newMockCmd(cfg),
 		newUICmd(cfg.uiAssets),
 	)

--- a/internal/generator/pitfalls.go
+++ b/internal/generator/pitfalls.go
@@ -17,6 +17,15 @@ type PitfallEntry struct {
 	Rule           string `yaml:"rule"`
 	Source         string `yaml:"source"`
 	DiscoveredFrom string `yaml:"discovered_from,omitempty"`
+
+	// LastSeen is when the signal behind this rule was last observed,
+	// RFC3339. Only `source: live` entries carry it, and only they are
+	// retired for going stale (S156a).
+	//
+	// A rule extracted from a reproducible apply failure does not stop
+	// being true because nobody hit it lately; a rule learned from a
+	// service that was running does, once that service is fixed.
+	LastSeen string `yaml:"last_seen,omitempty"`
 }
 
 // PitfallsFile represents the YAML structure of a pitfalls file.

--- a/internal/generator/pitfalls_retire.go
+++ b/internal/generator/pitfalls_retire.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -151,6 +152,32 @@ func partitionStale(entries []PitfallEntry, retention time.Duration, now time.Ti
 	return kept, stale
 }
 
+// assertCloudName refuses anything that would escape the corpus when
+// joined into a path.
+//
+// `cloud` arrives from the command line -- `pitfalls retire <cloud>` --
+// and is joined straight onto the pitfalls directory. Without this,
+// `retire ../../something` reads and REWRITES a YAML file outside the
+// corpus entirely, which is a write, not just a read.
+//
+// The same guard livestore.validateID applies to deployment ids, for the
+// same reason: a name that came from a caller decides a path.
+func assertCloudName(cloud string) error {
+	if strings.TrimSpace(cloud) == "" {
+		return fmt.Errorf("cloud is required")
+	}
+	if cloud != strings.TrimSpace(cloud) {
+		return fmt.Errorf("cloud %q has leading or trailing whitespace", cloud)
+	}
+	if strings.ContainsRune(cloud, os.PathSeparator) || strings.Contains(cloud, "/") {
+		return fmt.Errorf("cloud %q contains a path separator", cloud)
+	}
+	if cloud == "." || cloud == ".." || strings.Contains(cloud, "..") {
+		return fmt.Errorf("cloud %q contains a parent-directory reference", cloud)
+	}
+	return nil
+}
+
 // loadCloudPitfalls returns nil without error when the cloud has no
 // corpus: nothing to retire is not a failure to retire.
 //
@@ -158,6 +185,9 @@ func partitionStale(entries []PitfallEntry, retention time.Duration, now time.Ti
 // only the entries -- retirement needs the whole file back so it can be
 // written again.
 func loadCloudPitfalls(pitfallsDir, cloud string) (*PitfallsFile, string, error) {
+	if err := assertCloudName(cloud); err != nil {
+		return nil, "", err
+	}
 	filePath := filepath.Join(pitfallsDir, cloud+".yaml")
 	payload, err := os.ReadFile(filePath)
 	if err != nil {
@@ -210,6 +240,9 @@ func (e PitfallEntry) lastSeenAt() (time.Time, bool) {
 // every day for a month would still retire on the anniversary of the day
 // it was learned.
 func TouchLivePitfall(pitfallsDir, cloud, resource, rule string, now time.Time) error {
+	if err := assertCloudName(cloud); err != nil {
+		return err
+	}
 	filePath := filepath.Join(pitfallsDir, cloud+".yaml")
 	payload, err := os.ReadFile(filePath)
 	if err != nil {

--- a/internal/generator/pitfalls_retire.go
+++ b/internal/generator/pitfalls_retire.go
@@ -1,0 +1,233 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LiveSource marks a pitfall learned from a service that was already
+// running, rather than from a failed apply (S156, extending ADR-0019's
+// vocabulary of descriptive / fix / avoid).
+//
+// It exists in this slice before anything produces one, because the
+// retirement path has to be built before the inflow. Every other slice in
+// S156 adds entries; this is the only thing that can take them out.
+const LiveSource = "live"
+
+// DefaultLiveRetention is how long a live-sourced pitfall keeps its place
+// without being seen again.
+//
+// A guess, and labelled as one. There is no corpus of live entries yet to
+// tune it against, so it is deliberately generous: retiring a rule that
+// is still true costs a repeat of the failure it prevented, which is
+// worse than carrying a stale rule for another fortnight. Raise or lower
+// it from evidence once S156c produces real entries.
+const DefaultLiveRetention = 14 * 24 * time.Hour
+
+// RetiredPitfall is one entry that was removed, kept so the caller can
+// report it.
+type RetiredPitfall struct {
+	Resource string
+	Rule     string
+	LastSeen time.Time
+	Age      time.Duration
+}
+
+// RetireStaleLivePitfalls removes `source: live` entries that have not
+// been seen within retention, and returns what it removed.
+//
+// Why live entries need this and the others do not: learning used to be
+// bounded. A run emits at most `repair_iterations_max` failures, and a
+// scenario that stops failing stops emitting. Live observation removed
+// that bound -- a deployment running a broken image emits the same
+// normalized failure on every probe, for its whole TTL, across every
+// deployment of that scenario. The promotion gate limits the rate; only
+// this removes an entry once the cause is fixed.
+//
+// And a stale pitfall is not inert. It steers generation away from
+// something that is no longer broken, which makes every future
+// generation worse **silently** -- the failure mode this project has
+// learned to fear most.
+//
+// Three deliberate limits:
+//
+//   - Only `live` entries. Static, `fix` and `avoid` rules keep their
+//     current unbounded lifetime; a rule extracted from a reproducible
+//     apply failure does not stop being true because nobody hit it
+//     lately.
+//   - An entry with no LastSeen is NEVER retired. Absence of a timestamp
+//     means nobody recorded when it was last true, which is not evidence
+//     that it stopped being true. Guessing would delete rules on the
+//     strength of a missing field.
+//   - Removal is returned, never silent. Same rule as the D6 purge: a
+//     corpus that quietly drops entries is indistinguishable from one
+//     that never learned them.
+func RetireStaleLivePitfalls(pitfallsDir, cloud string, retention time.Duration, now time.Time) ([]RetiredPitfall, error) {
+	if err := assertRetention(retention); err != nil {
+		return nil, err
+	}
+
+	pf, filePath, err := loadCloudPitfalls(pitfallsDir, cloud)
+	if err != nil || pf == nil {
+		return nil, err
+	}
+
+	kept, retired := partitionStale(pf.Pitfalls, retention, now)
+
+	if len(retired) == 0 {
+		// Nothing changed, so nothing is written. Rewriting an unchanged
+		// file would churn its mtime and, on a corpus under review, make
+		// "the retirement ran" look like "the retirement did something".
+		return nil, nil
+	}
+
+	pf.Pitfalls = kept
+	if err := writePitfallsFile(pitfallsDir, filePath, cloud, pf); err != nil {
+		return nil, err
+	}
+	return retired, nil
+}
+
+// StaleLivePitfalls reports what RetireStaleLivePitfalls would remove,
+// without removing it.
+//
+// Retirement deletes learning, so an operator should be able to see what
+// a threshold would take out before it takes it out. Sharing
+// partitionStale rather than reimplementing the rule is the point: a
+// dry-run that can disagree with the real thing is worse than no dry-run.
+func StaleLivePitfalls(pitfallsDir, cloud string, retention time.Duration, now time.Time) ([]RetiredPitfall, error) {
+	if err := assertRetention(retention); err != nil {
+		return nil, err
+	}
+
+	pf, _, err := loadCloudPitfalls(pitfallsDir, cloud)
+	if err != nil || pf == nil {
+		return nil, err
+	}
+	_, stale := partitionStale(pf.Pitfalls, retention, now)
+	return stale, nil
+}
+
+// assertRetention refuses a window that would empty the corpus.
+//
+// Zero or negative makes every live entry infinitely stale, so a mistyped
+// flag would delete everything learned from running services in one
+// command. Checked on BOTH entry points, because a dry-run that accepts a
+// value the real run rejects teaches an operator the wrong thing about
+// what is safe to type.
+func assertRetention(retention time.Duration) error {
+	if retention <= 0 {
+		return fmt.Errorf("retention must be positive, got %s: every live pitfall would be retired", retention)
+	}
+	return nil
+}
+
+// partitionStale splits entries into those that stay and those that go,
+// newest-stale last so the report leads with the most overdue.
+func partitionStale(entries []PitfallEntry, retention time.Duration, now time.Time) ([]PitfallEntry, []RetiredPitfall) {
+	kept := make([]PitfallEntry, 0, len(entries))
+	var stale []RetiredPitfall
+
+	for _, entry := range entries {
+		if !entry.retirable(now, retention) {
+			kept = append(kept, entry)
+			continue
+		}
+		lastSeen, _ := entry.lastSeenAt()
+		stale = append(stale, RetiredPitfall{
+			Resource: entry.Resource,
+			Rule:     entry.Rule,
+			LastSeen: lastSeen,
+			Age:      now.Sub(lastSeen),
+		})
+	}
+
+	sort.Slice(stale, func(i, j int) bool { return stale[i].Age > stale[j].Age })
+	return kept, stale
+}
+
+// loadCloudPitfalls returns nil without error when the cloud has no
+// corpus: nothing to retire is not a failure to retire.
+//
+// Named apart from the existing loadPitfallsFile(path), which returns
+// only the entries -- retirement needs the whole file back so it can be
+// written again.
+func loadCloudPitfalls(pitfallsDir, cloud string) (*PitfallsFile, string, error) {
+	filePath := filepath.Join(pitfallsDir, cloud+".yaml")
+	payload, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, filePath, nil
+		}
+		return nil, filePath, fmt.Errorf("read pitfalls for %s: %w", cloud, err)
+	}
+
+	var pf PitfallsFile
+	if err := yaml.Unmarshal(payload, &pf); err != nil {
+		return nil, filePath, fmt.Errorf("parse pitfalls for %s: %w", cloud, err)
+	}
+	return &pf, filePath, nil
+}
+
+// retirable reports whether this entry has outlived its usefulness.
+func (e PitfallEntry) retirable(now time.Time, retention time.Duration) bool {
+	if e.Source != LiveSource {
+		return false
+	}
+	lastSeen, ok := e.lastSeenAt()
+	if !ok {
+		// No timestamp means nobody recorded when this was last true.
+		// That is not evidence it stopped being true.
+		return false
+	}
+	return now.Sub(lastSeen) > retention
+}
+
+// lastSeenAt parses the entry's timestamp, reporting whether it had a
+// usable one. An unparseable value is treated as absent rather than as
+// zero: zero would make every malformed entry infinitely stale and
+// delete it.
+func (e PitfallEntry) lastSeenAt() (time.Time, bool) {
+	if e.LastSeen == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, e.LastSeen)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
+}
+
+// TouchLivePitfall records that a live-sourced rule was seen again.
+//
+// Refreshing rather than appending is what makes retention mean "last
+// observed" instead of "first observed". Without it, a rule that recurs
+// every day for a month would still retire on the anniversary of the day
+// it was learned.
+func TouchLivePitfall(pitfallsDir, cloud, resource, rule string, now time.Time) error {
+	filePath := filepath.Join(pitfallsDir, cloud+".yaml")
+	payload, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("read pitfalls for %s: %w", cloud, err)
+	}
+
+	var pf PitfallsFile
+	if err := yaml.Unmarshal(payload, &pf); err != nil {
+		return fmt.Errorf("parse pitfalls for %s: %w", cloud, err)
+	}
+
+	for i, entry := range pf.Pitfalls {
+		if entry.Source != LiveSource || entry.Resource != resource || entry.Rule != rule {
+			continue
+		}
+		pf.Pitfalls[i].LastSeen = now.UTC().Format(time.RFC3339)
+		return writePitfallsFile(pitfallsDir, filePath, cloud, &pf)
+	}
+
+	return fmt.Errorf("no live pitfall for %s matching that rule", resource)
+}

--- a/internal/generator/pitfalls_retire_test.go
+++ b/internal/generator/pitfalls_retire_test.go
@@ -205,3 +205,25 @@ func TestTouchReportsWhenThereIsNoSuchLivePitfall(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no live pitfall")
 }
+
+// `cloud` arrives from the command line and is joined straight onto the
+// pitfalls directory, so without a guard `retire ../../x` REWRITES a file
+// outside the corpus. The same guard livestore.validateID applies to
+// deployment ids, for the same reason.
+func TestRetireRefusesACloudNameThatEscapesTheCorpus(t *testing.T) {
+	dir := writeCorpus(t, liveEntry("scaleway_lb", "r", time.Now()))
+
+	for _, cloud := range []string{
+		"../escape", "sub/dir", "..", ".", " scaleway", "scaleway ", "",
+		"a/../../b",
+	} {
+		_, err := RetireStaleLivePitfalls(dir, cloud, time.Hour, time.Now())
+		assert.Error(t, err, "cloud %q must be refused", cloud)
+
+		_, err = StaleLivePitfalls(dir, cloud, time.Hour, time.Now())
+		assert.Error(t, err, "the dry-run must refuse it too: %q", cloud)
+
+		err = TouchLivePitfall(dir, cloud, "r", "r", time.Now())
+		assert.Error(t, err, "touch must refuse it too: %q", cloud)
+	}
+}

--- a/internal/generator/pitfalls_retire_test.go
+++ b/internal/generator/pitfalls_retire_test.go
@@ -1,0 +1,207 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func writeCorpus(t *testing.T, entries ...PitfallEntry) string {
+	t.Helper()
+	dir := t.TempDir()
+	payload, err := yaml.Marshal(PitfallsFile{Provider: "scaleway", Pitfalls: entries})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "scaleway.yaml"), payload, 0o644))
+	return dir
+}
+
+func readCorpus(t *testing.T, dir string) []PitfallEntry {
+	t.Helper()
+	payload, err := os.ReadFile(filepath.Join(dir, "scaleway.yaml"))
+	require.NoError(t, err)
+	var pf PitfallsFile
+	require.NoError(t, yaml.Unmarshal(payload, &pf))
+	return pf.Pitfalls
+}
+
+func liveEntry(resource, rule string, lastSeen time.Time) PitfallEntry {
+	e := PitfallEntry{Resource: resource, Rule: rule, Source: LiveSource}
+	if !lastSeen.IsZero() {
+		e.LastSeen = lastSeen.UTC().Format(time.RFC3339)
+	}
+	return e
+}
+
+func TestRetireRemovesLiveEntriesPastRetention(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	dir := writeCorpus(t,
+		liveEntry("scaleway_lb", "stale rule", now.Add(-30*24*time.Hour)),
+		liveEntry("scaleway_instance_server", "recent rule", now.Add(-1*time.Hour)),
+	)
+
+	retired, err := RetireStaleLivePitfalls(dir, "scaleway", 14*24*time.Hour, now)
+
+	require.NoError(t, err)
+	require.Len(t, retired, 1)
+	assert.Equal(t, "scaleway_lb", retired[0].Resource)
+	assert.Equal(t, 30*24*time.Hour, retired[0].Age)
+
+	kept := readCorpus(t, dir)
+	require.Len(t, kept, 1)
+	assert.Equal(t, "scaleway_instance_server", kept[0].Resource)
+}
+
+// A rule extracted from a reproducible apply failure does not stop being
+// true because nobody hit it lately. Only live entries decay.
+func TestRetireLeavesEveryOtherSourceAlone(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	ancient := now.Add(-365 * 24 * time.Hour).UTC().Format(time.RFC3339)
+
+	dir := writeCorpus(t,
+		PitfallEntry{Resource: "a", Rule: "r", Source: DescriptiveSource, LastSeen: ancient},
+		PitfallEntry{Resource: "b", Rule: "r", Source: FixSource, LastSeen: ancient},
+		PitfallEntry{Resource: "c", Rule: "r", Source: AvoidSource, LastSeen: ancient},
+		PitfallEntry{Resource: "d", Rule: "r", Source: "", LastSeen: ancient},
+	)
+
+	retired, err := RetireStaleLivePitfalls(dir, "scaleway", time.Hour, now)
+
+	require.NoError(t, err)
+	assert.Empty(t, retired)
+	assert.Len(t, readCorpus(t, dir), 4)
+}
+
+// Absence of a timestamp means nobody recorded when the rule was last
+// true. That is not evidence it stopped being true, and deleting on the
+// strength of a missing field would lose learning for free.
+func TestRetireNeverRemovesAnEntryWithNoTimestamp(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	dir := writeCorpus(t,
+		liveEntry("scaleway_lb", "no timestamp", time.Time{}),
+		PitfallEntry{Resource: "scaleway_rdb_instance", Rule: "unparseable", Source: LiveSource, LastSeen: "yesterday"},
+	)
+
+	retired, err := RetireStaleLivePitfalls(dir, "scaleway", time.Nanosecond, now)
+
+	require.NoError(t, err)
+	assert.Empty(t, retired, "a missing or malformed timestamp is unknown, not infinitely stale")
+	assert.Len(t, readCorpus(t, dir), 2)
+}
+
+// Exactly at the boundary the rule is still within retention: retirement
+// needs the age to EXCEED the window, so a threshold of 14d does not
+// delete something last seen 14d ago to the second.
+func TestRetireIsExclusiveAtTheBoundary(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	retention := 14 * 24 * time.Hour
+	dir := writeCorpus(t, liveEntry("scaleway_lb", "exactly at the edge", now.Add(-retention)))
+
+	retired, err := RetireStaleLivePitfalls(dir, "scaleway", retention, now)
+
+	require.NoError(t, err)
+	assert.Empty(t, retired)
+}
+
+// Nothing changed means nothing is written: rewriting an unchanged file
+// would make "the retirement ran" look like "the retirement did
+// something" to anyone watching mtimes.
+func TestRetireDoesNotRewriteAnUnchangedCorpus(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	dir := writeCorpus(t, liveEntry("scaleway_lb", "fresh", now))
+	path := filepath.Join(dir, "scaleway.yaml")
+
+	before, err := os.Stat(path)
+	require.NoError(t, err)
+
+	retired, err := RetireStaleLivePitfalls(dir, "scaleway", time.Hour, now)
+	require.NoError(t, err)
+	require.Empty(t, retired)
+
+	after, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, before.ModTime(), after.ModTime())
+}
+
+// A dry-run that can disagree with the real thing is worse than no
+// dry-run, so both go through one rule.
+func TestStaleLivePitfallsReportsWithoutChangingAnything(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	dir := writeCorpus(t, liveEntry("scaleway_lb", "stale", now.Add(-30*24*time.Hour)))
+
+	stale, err := StaleLivePitfalls(dir, "scaleway", 14*24*time.Hour, now)
+	require.NoError(t, err)
+	require.Len(t, stale, 1)
+
+	assert.Len(t, readCorpus(t, dir), 1, "reporting must not remove")
+
+	retired, err := RetireStaleLivePitfalls(dir, "scaleway", 14*24*time.Hour, now)
+	require.NoError(t, err)
+	assert.Equal(t, stale, retired, "the dry-run and the real thing agree by construction")
+}
+
+// The most overdue first: an operator reading a long list wants the worst
+// offender at the top.
+func TestRetireReportsMostOverdueFirst(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	dir := writeCorpus(t,
+		liveEntry("recent", "r", now.Add(-20*24*time.Hour)),
+		liveEntry("ancient", "r", now.Add(-90*24*time.Hour)),
+		liveEntry("middling", "r", now.Add(-40*24*time.Hour)),
+	)
+
+	retired, err := RetireStaleLivePitfalls(dir, "scaleway", 14*24*time.Hour, now)
+
+	require.NoError(t, err)
+	require.Len(t, retired, 3)
+	assert.Equal(t, "ancient", retired[0].Resource)
+	assert.Equal(t, "middling", retired[1].Resource)
+	assert.Equal(t, "recent", retired[2].Resource)
+}
+
+func TestRetireOnACloudWithNoCorpusIsNotAnError(t *testing.T) {
+	retired, err := RetireStaleLivePitfalls(t.TempDir(), "aws", time.Hour, time.Now())
+
+	assert.NoError(t, err, "nothing to retire is not a failure to retire")
+	assert.Empty(t, retired)
+}
+
+func TestRetireRefusesANonPositiveRetention(t *testing.T) {
+	dir := writeCorpus(t, liveEntry("scaleway_lb", "r", time.Now()))
+
+	for _, retention := range []time.Duration{0, -time.Hour} {
+		_, err := RetireStaleLivePitfalls(dir, "scaleway", retention, time.Now())
+		assert.Error(t, err, "retention %s would retire everything ever learned", retention)
+	}
+}
+
+// Refreshing rather than appending is what makes retention mean "last
+// observed" instead of "first observed". Without it a rule that recurs
+// daily for a month still retires on the anniversary of the day it was
+// learned.
+func TestTouchRefreshesLastSeenSoARecurringRuleSurvives(t *testing.T) {
+	learned := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	dir := writeCorpus(t, liveEntry("scaleway_lb", "the rule", learned))
+
+	require.NoError(t, TouchLivePitfall(dir, "scaleway", "scaleway_lb", "the rule", now))
+
+	retired, err := RetireStaleLivePitfalls(dir, "scaleway", 14*24*time.Hour, now)
+	require.NoError(t, err)
+	assert.Empty(t, retired, "seen today, so not stale despite being learned a month ago")
+}
+
+func TestTouchReportsWhenThereIsNoSuchLivePitfall(t *testing.T) {
+	dir := writeCorpus(t,
+		PitfallEntry{Resource: "scaleway_lb", Rule: "a static rule", Source: DescriptiveSource})
+
+	// Right resource, wrong source: only live entries carry LastSeen.
+	err := TouchLivePitfall(dir, "scaleway", "scaleway_lb", "a static rule", time.Now())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no live pitfall")
+}

--- a/internal/generator/pitfalls_source_enum_test.go
+++ b/internal/generator/pitfalls_source_enum_test.go
@@ -19,6 +19,13 @@ import (
 //     (ExtractFixPitfall).
 //   - `avoid`       — extracted from the REMOVED side of the same diff
 //     (ExtractAvoidPitfall).
+//   - `live`        — learned from a service that was already running
+//     rather than from a failed apply (S156). The only source with a
+//     lifetime: `live` entries carry `last_seen` and are retired by
+//     `pitfalls retire` once the thing they describe stops being
+//     observed. The others do not decay, because a rule extracted from a
+//     reproducible apply failure does not stop being true because nobody
+//     hit it lately.
 //
 // The TestPitfallsNoHumanSeeding ratchet already rejects `seed` /
 // `static` / empty. This test complements it by fencing the positive
@@ -34,6 +41,7 @@ func TestPitfallsSourceEnum(t *testing.T) {
 		"descriptive": true,
 		"fix":         true,
 		"avoid":       true,
+		"live":        true,
 	}
 	for _, cloud := range []string{"aws", "gcp", "scaleway"} {
 		t.Run(cloud, func(t *testing.T) {
@@ -53,7 +61,7 @@ func TestPitfallsSourceEnum(t *testing.T) {
 			}
 			for _, p := range file.Pitfalls {
 				if !allowed[p.Source] {
-					t.Errorf("pitfalls/%s.yaml: %s has source=%q — must be one of descriptive / fix / avoid",
+					t.Errorf("pitfalls/%s.yaml: %s has source=%q — must be one of descriptive / fix / avoid / live",
 						cloud, p.Resource, p.Source)
 				}
 			}

--- a/internal/generator/pitfalls_source_ratchet_test.go
+++ b/internal/generator/pitfalls_source_ratchet_test.go
@@ -70,13 +70,20 @@ func TestPitfallsNoHumanSeeding(t *testing.T) {
 			}
 			sort.Strings(keys)
 			for _, src := range keys {
-				if src == "descriptive" || src == FixSource || src == AvoidSource {
+				if src == "descriptive" || src == FixSource || src == AvoidSource || src == LiveSource {
 					// `fix` is N10's auto-derived source —
 					// strictly a richer shape of run-derived learning,
 					// not a human-authored seed. `avoid`
 					// is the N13 deletion-as-fix companion (same
 					// provenance, different rule shape). Both whitelisted
 					// alongside the legacy `descriptive` tag.
+					//
+					// `live` (S156) is run-derived too, just from a
+					// later moment: the run is a service that was
+					// already deployed rather than an apply. The policy
+					// this ratchet enforces is "no human authorship",
+					// and an observation of a real service is the
+					// opposite of that.
 					continue
 				}
 				t.Errorf("pitfalls/%s.yaml has %d entries with source=%q — M91 forbids human-authored pitfalls. Delete them and let the M86+M90 auto-learning loop rebuild any genuinely-needed entries from real runs.", cloud, bySource[src], src)

--- a/scripts/sweep_39.sh
+++ b/scripts/sweep_39.sh
@@ -241,7 +241,11 @@ else
       --out "pitfalls/$c.yaml" \
       --keep avoid,live 2>&1)
     echo "  $c: $out"
-    added=$(echo "$out" | grep -oE 'kept_new=[0-9]+' | sed 's/kept_new=//')
+    # kept_avoid, not kept_new: kept_new now also counts preserved
+    # `live` entries, and folding those in would let live preservation
+    # mask an avoid-learning regression -- a ratchet that reads healthy
+    # while the thing it measures is broken.
+    added=$(echo "$out" | grep -oE 'kept_avoid=[0-9]+' | sed 's/kept_avoid=//')
     avoid_total=$((avoid_total + ${added:-0}))
   done
 fi

--- a/scripts/sweep_39.sh
+++ b/scripts/sweep_39.sh
@@ -239,7 +239,7 @@ else
       --pre "$PRE/$c.yaml" \
       --post "pitfalls/$c.yaml" \
       --out "pitfalls/$c.yaml" \
-      --keep avoid 2>&1)
+      --keep avoid,live 2>&1)
     echo "  $c: $out"
     added=$(echo "$out" | grep -oE 'kept_new=[0-9]+' | sed 's/kept_new=//')
     avoid_total=$((avoid_total + ${added:-0}))


### PR DESCRIPTION
The prerequisite the plan flagged and nothing was scheduled for: *"S156 should not merge without at least a retirement path for `source: live` entries."*

`pitfalls retire <cloud>` removes live-sourced entries not seen within a retention window, and **names every one it removed**.

## Why this slice comes first

Every other S156 slice *adds* to the corpus. This is the only thing that can take entries out, and building the inflow first is how a corpus becomes something nobody dares prune.

Live entries need a lifetime and the others do not. Learning used to be **bounded** — a run emits at most `repair_iterations_max` failures, and a scenario that stops failing stops emitting. Live observation removed that bound. And a stale pitfall is not inert: it steers generation away from something that is no longer broken, making every future generation worse **silently**.

## Three refusals, all about not deleting learning on weak evidence

- **No timestamp is never retired.** Absence means nobody recorded when the rule was last true — not evidence it stopped being true. An unparseable value counts as absent, because treating it as zero would make every malformed entry infinitely stale.
- **The boundary is exclusive**, so a 14-day threshold does not delete something last seen 14 days ago to the second.
- **A non-positive window is refused on both entry points.** A mistyped flag would empty the corpus in one command, and a dry-run that accepts what the real run rejects teaches the wrong thing about what is safe to type.

`--dry-run` and the real thing share one rule by construction. `TouchLivePitfall` refreshes rather than appends, which is what makes retention mean *last observed* rather than *first observed*.

## What this slice was actually about

`LiveSource = "live"` is **one constant**. Eight review passes later, everything else was the places that had to know:

| pass | who had to learn about `live` |
|---|---|
| 59 | the two corpus ratchets, and the sweep's preservation list |
| 60 | the merge's handling of freshness |
| 61 | the runtime wiring — maintenance must not require the LLM configured |
| 62 | the path guard on the new command |
| 63 | the merge's source semantics |
| 64 | the metric reading the merge's output |
| 65 | *(declined)* the sweep's cloud coverage |
| 66 | the merge's identity for entries carrying state |

**Four were mechanisms that already existed in this repository** — ratchets, sweep preservation, path validation, dedup identity. None was found by reading the new code; each was found by asking who else cares. ADR-0019 now says a vocabulary is only as real as the things that enforce it, and that the next source value should start by enumerating the readers.

Two worth calling out specifically:

- **Pass 62** was path traversal: `<cloud>` went from the command line into `filepath.Join` unvalidated, so `retire ../../x` would have **rewritten** a file outside the corpus. `livestore.validateID` already guards deployment ids against exactly that.
- **Pass 64** was a metric that would have read healthy while broken: preserving live entries folded them into `AVOID_EMISSIONS`, so a sweep producing **zero** avoid pitfalls could have reported three.

## One decline

**Pass 65**: genesys is omitted from the sweep's pitfall handling and from all three ratchets — consistently, and since long before this arc. `LiveSource` neither created that gap nor widens it. Bringing genesys in means deciding whether it joins the ratchets and what `AVOID_EMISSIONS` means for a cloud with no avoid entries: its own scope. Recorded in the plan as a prerequisite for S156c, the first slice that will actually produce live entries.

## Note on passes 63 and 66

63 fixed a bug by preserving historical behaviour; 66 showed the historical behaviour was itself wrong for the new case. Both were right on the evidence at the time. The lesson is that **"keep the old behaviour" is a decision, not a default**, and deserves the same justification as changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD