### PR TITLE
Plan S158: an end-to-end test for the live lifecycle, and refresh the UI arc

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,15 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- 🔗 **Doc links are now ratcheted (2026-09-01)** — `STATUS.md` lives at the repo
+  **root** while what it points at lives under `docs/`, so `](plans/x.md)` looks
+  right and resolves to nothing. **All four** of its relative links were broken;
+  a reviewer caught one and I had written three of the others the same session.
+  `TestDocLinksResolve` now walks `docs/` plus the root documents, verified
+  against synthetic drift, and refuses to pass if it finds fewer than two files —
+  because pass 34 showed an audit that narrows its own scope reads as coverage
+  while the defect lands elsewhere.
+
 - 📋 **S158 planned: the live lifecycle has no end-to-end test (2026-09-01)** —
   `internal/e2e/` holds twelve files and none mentions `deploy`, `live observe`,
   `live upgrade` or `livestore`. Every S151–S156a guarantee is unit tests plus a
@@ -18,7 +27,7 @@ Last updated: 2026-08-31
   which project an apply may touch. **No unit test could have caught any of
   them.**
 
-  Plan: [docs/plans/live-lifecycle-e2e-plan.md](plans/live-lifecycle-e2e-plan.md).
+  Plan: [docs/plans/live-lifecycle-e2e-plan.md](docs/plans/live-lifecycle-e2e-plan.md).
   One test driving the real commands in sequence against mockway, plus one real
   pass — the mock proves the commands agree with each other, only Scaleway proves
   they agree with the world.
@@ -169,7 +178,7 @@ Last updated: 2026-08-31
   It also produced, by accident, exactly what S156 wants: a **failed upgrade with
   both configurations preserved** — the before/after pair `ExtractFixPitfall`
   needs, from a real failure rather than a constructed one. Full record:
-  [docs/status/s155b-upgrade-canary.md](status/s155b-upgrade-canary.md).
+  [docs/status/s155b-upgrade-canary.md](docs/status/s155b-upgrade-canary.md).
 
 - 🚀 **S155b: `live upgrade` — an apply is not an upgrade (2026-08-31)** —
   rolls a live deployment onto new configuration **in place**: same project, same
@@ -329,7 +338,7 @@ Last updated: 2026-08-31
 
   Next slice is small and named: `POST`/`GET`/`DELETE` for
   `private-network-interfaces` in mockway. Detail:
-  [docs/layer3-coverage.md](layer3-coverage.md).
+  [docs/layer3-coverage.md](docs/layer3-coverage.md).
 
 - 🌱 **S154 SHIPPED — `live observe`, the first post-apply signal (2026-08-31)** —
   probes every live deployment's health path once and records what it saw on that
@@ -379,7 +388,7 @@ Last updated: 2026-08-31
   cutover canary named: `deploy` and `live teardown` had never run for real.
   deploy → HTTP 200 → observe healthy → observe again → teardown → account clean.
   Only the healthy path ran for real; `unhealthy`/`unreachable` are unit-covered.
-  [docs/status/s168-cutover-canary.md](status/s168-cutover-canary.md).
+  [docs/status/s168-cutover-canary.md](docs/status/s168-cutover-canary.md).
 
 - ⚠️ **The `layer3-gate` cannot validate this change before it merges (2026-08-31)** —
   it builds its binary from **base**, deliberately (S144-T5a: otherwise a same-repo
@@ -419,7 +428,7 @@ Last updated: 2026-08-31
   Account verified against the API afterwards, not from the sweep's own verdict:
   **zero `if-run-*` projects**, and the only server and volume in the org are
   `openclaw-prod` and its root volume from 2026-02-21. Full record:
-  [docs/status/s168-cutover-canary.md](status/s168-cutover-canary.md).
+  [docs/status/s168-cutover-canary.md](docs/status/s168-cutover-canary.md).
 
 - 🔧 **Pass 41: creation is uncancellable now (2026-08-31)** — pass 40 put
   `ensureRunProject` inside the signal guard and thereby handed it a cancellable

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,32 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- 📋 **S158 planned: the live lifecycle has no end-to-end test (2026-09-01)** —
+  `internal/e2e/` holds twelve files and none mentions `deploy`, `live observe`,
+  `live upgrade` or `livestore`. Every S151–S156a guarantee is unit tests plus a
+  real-cloud run driven by hand, one command at a time. **Nothing re-runs the
+  sequence.**
+
+  The live commands are coupled through a **record**, not through function calls,
+  and each command's unit tests build their own. That is exactly the shape that
+  hides defects, and this session produced three: `observe` failing on a record
+  `deploy` legitimately wrote without an address; `upgrade` discarding
+  observations appended during its apply; the record and marker disagreeing about
+  which project an apply may touch. **No unit test could have caught any of
+  them.**
+
+  Plan: [docs/plans/live-lifecycle-e2e-plan.md](plans/live-lifecycle-e2e-plan.md).
+  One test driving the real commands in sequence against mockway, plus one real
+  pass — the mock proves the commands agree with each other, only Scaleway proves
+  they agree with the world.
+
+  **The UI arc was refreshed to match.** S164 held the only journey coverage, at
+  the end of an arc that has not started, so it moves out to S158 and keeps its
+  Playwright half. And S161's estate page predates observation: it must render
+  `unobserved` and `unchecked` **distinctly**, because a blank cell rebuilds the
+  falsehood the three-state design exists to prevent — that nobody having looked
+  is the same as nothing being wrong.
+
 - 🗂️ **S156 broken into five slices, and its unscheduled prerequisite scheduled
   (2026-09-01)** — `docs/plans/live-learning-loop-plan.md`. The plan already
   warned that **S156 must not merge without a retirement path for `source: live`

--- a/docs/plans/live-lifecycle-e2e-plan.md
+++ b/docs/plans/live-lifecycle-e2e-plan.md
@@ -1,0 +1,84 @@
+# S158: an end-to-end test for the live lifecycle
+
+Planned 2026-09-01. Driver: **there is no test that runs the live journey.**
+
+`internal/e2e/` holds twelve files and none of them mentions `deploy`,
+`live observe`, `live upgrade` or `livestore`. Every guarantee in S151–S156a is
+covered by unit tests plus a real-cloud run that a person drove by hand, one
+command at a time. Nothing re-runs that sequence.
+
+## Why this is worth a slice of its own
+
+The live commands are coupled through a **record**, not through function calls.
+`deploy` writes it, `live observe` appends to it, `live upgrade` rewrites three
+of its fields, `live teardown` releases it, and `live reap` acts on whatever it
+finds. Unit tests cover each command against a record it constructs itself.
+
+That is precisely the shape that hides defects, and this session produced the
+evidence:
+
+- `live observe` failed on a record `deploy` had legitimately written without an
+  address — found by a real deploy, not by a test (S154 pass 44).
+- `live upgrade` wrote back a record it had read before a minutes-long apply,
+  discarding observations `live observe` appended in between — found by review,
+  not by a test (S155b pass 57).
+- The record's project id and the marker's could disagree, and three separate
+  passes were needed to settle which one an apply may trust (S155b passes 53–55).
+
+Every one is an interaction between two commands. **No unit test could have
+caught any of them**, because each command's tests build their own record.
+
+## Why now, and not as part of S164
+
+The UI arc already contains this work, at the very end: S164 is *"Playwright e2e
+over the whole journey, then one real run."* That ordering made sense when the
+UI was the only consumer. It does not now.
+
+The CLI lifecycle is complete and merged. Leaving its only end-to-end coverage
+inside the last slice of an arc that has not started means every UI slice is
+built on four commands that have never been run together by anything but a
+person. Pulling it forward costs one small slice and gives every later slice a
+regression test underneath.
+
+## Scope
+
+One test, driving the real commands in sequence against **mockway**, plus a
+single real-cloud pass.
+
+| step | asserts |
+|---|---|
+| `deploy` | a record exists, with project id, address, port, health path and expiry |
+| `live ls` | the deployment appears, `HEALTH` reads `unobserved` |
+| `live observe` | records an observation and confirms the declared version |
+| `live upgrade` | preflight confirms the old version, apply runs, verify confirms the new one; `.infrafactory-previous/` holds what was replaced |
+| `live observe` again | the second observation appends rather than replacing |
+| `live teardown` | destroy, project delete, sweep, record released |
+| after | `live ls` shows the record released; `live reap` finds nothing to do |
+
+Two properties the sequence exists to pin, which no single-command test can:
+
+- **The record round-trips through every command.** Each writes fields the next
+  reads, and this is the only test that would notice if one stopped agreeing
+  about a field's meaning.
+- **Observations survive an upgrade.** The pass-57 defect, as a test rather than
+  a review finding.
+
+### Against the mock, and once for real
+
+Mockway is the default so the test can run in CI on every PR. The real-cloud
+pass is manual and recorded, exactly as the S154/S155 canaries were — the mock
+proves the commands agree with each other, and only real Scaleway proves they
+agree with the world.
+
+### Explicitly out of scope
+
+`live reap`'s TTL expiry path beyond the trivial "nothing to do" assertion:
+making it fire needs either a clock seam or a real wait, and both are bigger
+than this slice. Noted rather than smuggled in.
+
+## What this does NOT prove
+
+The same limit the S168 canary stated: a mock run proves the commands agree with
+each other. It does not prove any of them is right about Scaleway. That is what
+the real pass is for, and why it stays in the slice rather than being replaced
+by the mock.

--- a/docs/plans/ui-deployment-arc-plan.md
+++ b/docs/plans/ui-deployment-arc-plan.md
@@ -75,6 +75,49 @@ than a CLI that never mentioned it, because the CLI at least required typing.
 **S159 → S160 → S162 is the ordered spine.** S161 depends only on S159. S163 can
 land any time after S162. S164 is last by definition.
 
+## Refresh, 2026-09-01: what S154–S156a changed
+
+This plan was written on 2026-08-30, before live observation and upgrade existed.
+Two changes, and the first matters more than the arc's own contents.
+
+### S164's e2e moves out, into S158
+
+S164 is *"Playwright e2e over the whole journey, then one real run."* That was
+the **only** end-to-end coverage of the live lifecycle anywhere, and it sat at
+the end of an arc that has not started — so every CLI command shipped in
+S151–S156a has no journey test underneath it.
+
+Pulled forward as **S158** (`docs/plans/live-lifecycle-e2e-plan.md`), which
+covers the CLI journey against mockway plus one real pass. S164 keeps its
+Playwright half: the UI journey still needs testing, and now it can sit on top of
+a CLI journey that is already pinned rather than being the first thing to pin it.
+
+### The estate page has more to show than TTL and address
+
+S161 was specified before a deployment could be **observed**. A page built to the
+original description would show what is running and stay silent on whether it is
+actually serving — the exact gap S154 and S155a exist to close, reproduced in the
+UI.
+
+`livestore.Deployment` now carries observations, and `live ls` already renders a
+`HEALTH` column. S161 should show, per deployment:
+
+| field | why the UI specifically needs it |
+|---|---|
+| last observation status | `healthy` / `unhealthy` / `unreachable`, and **`unobserved`** — silence must not read as healthy |
+| version check | `confirmed` / `unconfirmed` / `unchecked`, distinctly. A record claiming `nginx:1.27` while the service says otherwise is the more dangerous state *because it looks fine* |
+| `upgraded_at` | a deployment that was rolled forward is a different thing from one that never moved |
+
+**`unobserved` and `unchecked` are the load-bearing states.** A UI that renders
+them as blank cells rebuilds the falsehood the three-state design exists to
+prevent — that nobody having looked is the same as nothing being wrong.
+
+### Not added: a deploy-time version_path field
+
+`service.version_path` is opt-in and belongs in the scenario, which the UI
+already edits as YAML. Adding a dedicated control would be a second place to set
+one thing.
+
 ### Why reconcile-against-API moves into S159
 
 ADR-0024 always promised it and S153 did not deliver it: the reaper trusts the

--- a/docs/review-passes/pass69.md
+++ b/docs/review-passes/pass69.md
@@ -1,0 +1,54 @@
+# Codex review pass 69 — S158 plan
+
+One finding, accepted — **and it was wider than the finding.**
+
+## [P3] The plan link in STATUS.md did not resolve
+
+`STATUS.md` lives at the repository **root** while almost everything it points at
+lives under `docs/`, so `](plans/live-lifecycle-e2e-plan.md)` looks right and
+resolves to nothing.
+
+Checked rather than fixed-in-place: **all four** relative links in STATUS.md were
+broken, and I wrote three of the others earlier in the same session —
+`layer3-coverage.md`, `status/s155b-upgrade-canary.md`,
+`status/s168-cutover-canary.md`. Codex flagged one; the same mistake had been
+made four times.
+
+## Closed at the seam rather than by inspection
+
+The repository was already clean once those four were fixed, so a ratchet costs
+nothing and starts green: `TestDocLinksResolve` walks `docs/` plus the root
+documents and asserts every relative markdown link resolves. Verified against
+synthetic drift — reverting one link fails it with the file, the target and the
+path it resolved to.
+
+It also refuses to pass if the walk finds fewer than two files, so it cannot
+quietly become vacuous. That guard exists because of pass 34: an audit that
+narrowed its own scope read as coverage for three review passes while the defect
+it was meant to catch landed in three other files.
+
+## Why a P3 got a ratchet
+
+This is a documentation nit by severity and a durable one by nature: nobody
+notices a dead link in review, and the reader who finds it is the person the
+handoff was written for. The cost of prevention was thirty lines.
+
+## Nothing declined this pass.
+
+## Addendum, pass 70: the ratchet failed on the prose describing it
+
+The first version matched links inside **code spans**, so this very file — which
+writes the broken form in backticks as an example of the mistake — failed the
+check it documents. So did STATUS.md's illustration of the same thing.
+
+The pre-commit hook caught it before it landed, which is the guard working: the
+commit was refused rather than the suite going red on main.
+
+`stripCode` blanks fenced blocks first (a fenced region can contain unbalanced
+single backticks that would otherwise throw the inline pass off), then inline
+spans, replacing with spaces so nothing outside a span shifts position.
+Re-verified both ways: it still fails on a genuinely broken link, and no longer
+fails on an illustration of one.
+
+**A checker that cannot tell an example from an instance will always fail hardest
+on the document explaining it.**

--- a/docs/review-passes/pass71.md
+++ b/docs/review-passes/pass71.md
@@ -1,0 +1,9 @@
+# Codex review pass 71 — S158 plan + doc-link ratchet
+
+**Clean.** No findings.
+
+> The changes are documentation plus a focused Markdown-link ratchet, and the
+> added test passes under the repository's noui test configuration.
+
+Converged. Three passes: the broken link (69), the ratchet failing on the prose
+describing it (70), clean (71).

--- a/internal/generator/doc_links_test.go
+++ b/internal/generator/doc_links_test.go
@@ -1,0 +1,108 @@
+package generator
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// relativeMarkdownLink matches `](target.md)` and `](dir/target.md)`,
+// skipping anchors and absolute URLs.
+var relativeMarkdownLink = regexp.MustCompile(`\]\(([^)#][^)]*?\.md)\)`)
+
+// TestDocLinksResolve is a ratchet on relative links between markdown
+// documents.
+//
+// STATUS.md lives at the repository ROOT while almost everything it
+// points at lives under docs/, so `](plans/x.md)` looks right and
+// resolves to nothing. Four such links were written in one session before
+// a reviewer noticed the first (S158, pass 69) — the mistake is easy,
+// invisible in review, and only shows up when somebody follows the link
+// and gives up.
+//
+// Cheap to enforce and the repository was already clean when this landed,
+// so it starts green and stays that way. Same idiom as the cloud-prefix
+// lockstep and pitfall-source ratchets: when a convention needs
+// enforcing, a small audit beats a written rule.
+func TestDocLinksResolve(t *testing.T) {
+	root := repoRoot(t)
+
+	var files []string
+	for _, name := range []string{"STATUS.md", "README.md", "AGENTS.md", "CHANGELOG.md"} {
+		if path := filepath.Join(root, name); fileExists(path) {
+			files = append(files, path)
+		}
+	}
+	err := filepath.Walk(filepath.Join(root, "docs"), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && strings.HasSuffix(path, ".md") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk docs: %v", err)
+	}
+	if len(files) < 2 {
+		t.Fatalf("audited %d file(s); the walk found nothing, so this ratchet is vacuous", len(files))
+	}
+
+	for _, file := range files {
+		payload, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		for _, match := range relativeMarkdownLink.FindAllStringSubmatch(stripCode(string(payload)), -1) {
+			target := match[1]
+			if strings.HasPrefix(target, "http") {
+				continue
+			}
+			resolved := filepath.Join(filepath.Dir(file), target)
+			if !fileExists(resolved) {
+				rel, _ := filepath.Rel(root, file)
+				t.Errorf("%s links to %q, which does not exist (resolved to %s)", rel, target, resolved)
+			}
+		}
+	}
+}
+
+// stripCode blanks fenced blocks and inline code spans before links are
+// matched.
+//
+// A document explaining this very ratchet writes `](plans/x.md)` in
+// backticks as an example of the mistake, and a checker that cannot tell
+// an illustration from a link fails on the prose describing it -- which
+// is exactly what happened when this test first ran.
+//
+// Replaced with spaces rather than deleted so nothing outside the span
+// shifts position and the surrounding text still matches as it should.
+func stripCode(doc string) string {
+	out := []byte(doc)
+	blank := func(from, to int) {
+		for i := from; i < to && i < len(out); i++ {
+			if out[i] != '\n' {
+				out[i] = ' '
+			}
+		}
+	}
+
+	// Fenced blocks first: a ``` region may contain unbalanced single
+	// backticks that would otherwise throw the inline pass off.
+	for _, m := range regexp.MustCompile("(?s)```.*?```").FindAllStringIndex(doc, -1) {
+		blank(m[0], m[1])
+	}
+	// Then inline spans, over what is left.
+	for _, m := range regexp.MustCompile("`[^`\n]*`").FindAllStringIndex(string(out), -1) {
+		blank(m[0], m[1])
+	}
+	return string(out)
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}


### PR DESCRIPTION
Planning plus one small ratchet. No product code.

## The gap

`internal/e2e/` holds twelve files and **none** mentions `deploy`, `live observe`, `live upgrade` or `livestore`. Every guarantee in S151–S156a is unit tests plus a real-cloud run driven by hand, one command at a time. Nothing re-runs the sequence.

The live commands are coupled through a **record**, not through function calls: `deploy` writes it, `observe` appends, `upgrade` rewrites three fields, `teardown` releases it. Each command's unit tests build their own record — which is exactly the shape that hides defects, and this session produced three:

- `observe` failed on a record `deploy` had legitimately written without an address (S154 pass 44)
- `upgrade` discarded observations appended during its own apply (S155b pass 57)
- the record and the marker could disagree about which project an apply may touch (S155b passes 53–55)

**No unit test could have caught any of them** — each is an interaction between two commands.

## Why now rather than in S164

S164 already contains this work: *"Playwright e2e over the whole journey, then one real run."* That ordering made sense when the UI was the only consumer. The CLI lifecycle is complete and merged now, so leaving its only journey coverage at the end of an arc that has not started means every UI slice builds on four commands nothing has ever run together.

Pulled forward as **S158**; S164 keeps its Playwright half and gains a CLI journey that is already pinned.

## UI arc refreshed against what actually shipped

`S161`'s estate page was specified before a deployment could be *observed*. Built to the original description it would show what is running and stay silent on whether it is serving — reproducing in the UI the exact gap S154 and S155a exist to close.

It must render **`unobserved` and `unchecked` distinctly**. A blank cell rebuilds the falsehood the three-state design prevents: that nobody having looked is the same as nothing being wrong.

## The ratchet

Codex flagged one broken link in STATUS.md. Checking rather than fixing in place showed **all four** were broken — `STATUS.md` is at the repo root while what it points at is under `docs/` — and I had written three of the others earlier the same session.

`TestDocLinksResolve` walks `docs/` plus the root documents and asserts every relative markdown link resolves. It starts green, is verified against synthetic drift, and refuses to pass if the walk finds fewer than two files — because pass 34 showed an audit that narrows its own scope reads as coverage while the defect lands in three other files.

**Pass 70 is the part worth reading**: the first version matched links inside code spans, so the documents *explaining* the mistake — which write the broken form in backticks — failed the check they document. The pre-commit hook refused the commit rather than letting main go red. A checker that cannot tell an example from an instance will always fail hardest on the document explaining it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD