### PR TITLE
S158: a journey test for the live lifecycle

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,33 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- 🔁 **S158: the live lifecycle has a journey test (2026-09-01)** — deploy → ls →
+  observe → upgrade (with an observation landing *during* the apply) → observe →
+  teardown → ls → observe, through the **real commands and the real
+  `livestore`**, with only the cloud faked.
+
+  **The plan's premise was wrong and is corrected in place.** It said the test
+  would drive the commands against mockway. It cannot:
+  `assertRealScalewayEndpoint` refuses any Layer 3 apply not pointed at
+  `api.scaleway.com` — checking the passed env, the inherited `SCW_API_URL` *and*
+  the scw config file. `deploy`, `upgrade` and `teardown` all inherit that
+  refusal. Pointing the test at a mock would mean weakening ADR-0023 containment,
+  so the cloud is faked instead and everything touching the record is real.
+
+  That turns out to be the better test anyway: all three defects this slice
+  exists to catch are **record-coupling**, and none needs a cloud.
+
+  **Verified by reverting the fixes.** Undo pass 57 and the journey fails with
+  *"the observation recorded during the apply must survive the upgrade's write"*;
+  undo pass 44 and it fails with *"a live deployment nobody can monitor is a
+  finding, not a skip"*. A journey test nobody has seen fail is a journey test
+  nobody should trust.
+
+  One real transient noted rather than papered over: an `observe` landing after
+  the service has moved but before the upgrade writes the new tag sees record and
+  world genuinely disagree, and reports `unconfirmed`. Correct, and exactly the
+  single-blip noise **S156b's reproduction gate** exists to filter.
+
 - 🔗 **Doc links are now ratcheted (2026-09-01)** — `STATUS.md` lives at the repo
   **root** while what it points at lives under `docs/`, so `](plans/x.md)` looks
   right and resolves to nothing. **All four** of its relative links were broken;

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -551,3 +551,28 @@ observations in exactly that window. Writing back the stale copy discarded them 
 which does not corrupt the record, it quietly weakens the learning signal S156's
 promotion gate counts. An upgrade merges only the three fields it owns (`Tag`,
 `UpgradedAt`, `Address`); anything else belongs to whoever wrote it last.
+
+## Amendment, 2026-09-01 (S158): the record is the interface, so the record is what gets tested
+
+The live commands do not call each other. They are coupled through the
+deployment record: `deploy` writes it, `observe` appends, `upgrade` rewrites three
+fields, `teardown` releases it, `reap` acts on what it finds.
+
+Every command's own tests build the record they read, which is why three defects
+in this arc were interactions no unit test could see — `observe` failing on an
+address-less record `deploy` legitimately wrote, `upgrade` discarding
+observations appended during its apply, and the record and marker disagreeing
+about which project an apply may touch.
+
+The journey test runs the real commands and the real `livestore`, with only the
+cloud faked, and asserts what each step **leaves for the next one**.
+
+It cannot run against a mock, and that is worth recording so nobody tries:
+`assertRealScalewayEndpoint` refuses any Layer 3 apply not pointed at
+`api.scaleway.com`, checking the passed env, the inherited `SCW_API_URL` and the
+`scw` config file. Every command that builds a sandbox env inherits the refusal.
+Pointing a test at a mock would mean weakening that control, and the control is
+right — a green Layer 3 result must not be able to be evidence of nothing.
+
+Faking the cloud rather than the record is also the stronger choice: every defect
+this test exists to catch lives in the record, not in the API.

--- a/docs/plans/live-lifecycle-e2e-plan.md
+++ b/docs/plans/live-lifecycle-e2e-plan.md
@@ -63,12 +63,42 @@ Two properties the sequence exists to pin, which no single-command test can:
 - **Observations survive an upgrade.** The pass-57 defect, as a test rather than
   a review finding.
 
-### Against the mock, and once for real
+### Correction, 2026-09-01: it cannot run against mockway
 
-Mockway is the default so the test can run in CI on every PR. The real-cloud
-pass is manual and recorded, exactly as the S154/S155 canaries were — the mock
-proves the commands agree with each other, and only real Scaleway proves they
-agree with the world.
+The paragraph this replaces said the test would drive the commands against
+mockway. **That is impossible, and should not be made possible.**
+
+`assertRealScalewayEndpoint` refuses any Layer 3 apply whose environment points
+somewhere other than `https://api.scaleway.com` — checking the passed env, the
+inherited `SCW_API_URL`, *and* the default profile in `~/.config/scw/config.yaml`.
+`deploy`, `live upgrade` and `live teardown` all build a sandbox env and so all
+inherit that refusal. It is ADR-0023's containment, and it exists precisely so a
+green Layer 3 result cannot be evidence of nothing.
+
+Pointing the journey test at a mock would mean weakening it. The plan was wrong,
+not the control.
+
+### What the test does instead
+
+The defects this slice exists to catch are **record-coupling** defects, and none
+of them needs a cloud:
+
+| defect | what it actually required |
+|---|---|
+| `observe` failing on an address-less record | a record `deploy` wrote, and `observe` reading it |
+| `upgrade` discarding concurrent observations | a record held across an apply |
+| record and marker disagreeing on the project | two writers of the same identity |
+
+So the journey runs the **real command functions** and the **real `livestore`**,
+with the cloud harnesses faked — `SandboxDeploy`, `SandboxDestroy`, `RunProject`,
+`OrphanSweep`, `ServiceProbe`. Every line that reads or writes a deployment
+record is the production one; only the parts that would talk to Scaleway are not.
+
+That is a stronger test than a mock-driven one would have been, because mockway
+was never reachable from these commands anyway.
+
+The real-cloud pass stays exactly as it was: manual, recorded, and the only thing
+that proves the commands agree with the world rather than with each other.
 
 ### Explicitly out of scope
 

--- a/docs/review-passes/pass72.md
+++ b/docs/review-passes/pass72.md
@@ -1,0 +1,23 @@
+# Codex review pass 72 — S158 journey test
+
+**Clean.** No findings.
+
+> The changes add focused lifecycle coverage and documentation updates without
+> altering production behavior except for a test fake hook.
+
+Converged in one pass — the first slice tonight to do so, and worth noting why:
+it adds **no production code**. Every finding in S155b, S156a and S158's planning
+was in new behaviour or in the places an existing mechanism had to be taught
+about. A test that exercises code which has already converged has nothing new to
+get wrong.
+
+## The verification that mattered more than the pass
+
+The journey was checked by **reverting the fixes it claims to cover**:
+
+| revert | failure |
+|---|---|
+| pass 57's `mergeUpgradeOntoFresh` | *"the observation recorded during the apply must survive the upgrade's write"* |
+| pass 44's fail-not-skip | *"a live deployment nobody can monitor is a finding, not a skip"* |
+
+A journey test nobody has seen fail is a journey test nobody should trust.

--- a/internal/cli/live_lifecycle_test.go
+++ b/internal/cli/live_lifecycle_test.go
@@ -1,0 +1,336 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redscaresu/infrafactory/internal/config"
+	"github.com/redscaresu/infrafactory/internal/harness"
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+// The live commands are coupled through a RECORD, not through function
+// calls. `deploy` writes it, `live observe` appends to it, `live upgrade`
+// rewrites three of its fields, `live teardown` releases it, and
+// `live reap` acts on whatever it finds.
+//
+// Every command's own tests build the record they read. That is exactly
+// the shape that hides defects, and this arc produced three:
+//
+//   - `observe` failed on a record `deploy` had legitimately written
+//     without an address (S154 pass 44)
+//   - `upgrade` wrote back a record it had read before a minutes-long
+//     apply, discarding observations appended in between (S155b pass 57)
+//   - the record's project id and the marker's could disagree, and three
+//     passes were needed to settle which an apply may trust (passes 53-55)
+//
+// None could have been caught by a unit test, because each is an
+// interaction between two commands. This is the test that would have.
+//
+// It cannot run against mockway: assertRealScalewayEndpoint refuses any
+// Layer 3 apply not pointed at api.scaleway.com, checking the passed env,
+// the inherited SCW_API_URL and the scw config file. That is ADR-0023
+// containment and pointing this test at a mock would mean weakening it.
+// So the CLOUD is faked and everything that touches the record is real.
+
+// lifecycleRig wires the real commands and the real livestore to fake
+// cloud harnesses.
+type lifecycleRig struct {
+	t        *testing.T
+	runtime  *CommandRuntime
+	store    *livestore.FilesystemStore
+	deploy   *fakeSandboxDeployHarness
+	destroy  *fakeSandboxDestroyHarness
+	sweep    *fakeOrphanSweep
+	projects *fakeRunProject
+	probe    *stagingVersionProbe
+	scenario string
+	source   string
+}
+
+func newLifecycleRig(t *testing.T) *lifecycleRig {
+	t.Helper()
+	sandboxCredsForTest(t)
+	h := newCommandTestHarness(t)
+
+	cfg, err := config.Load(h.ConfigPath)
+	require.NoError(t, err)
+	cfg.Paths.Output = h.OutputDir()
+	cfg.Validation.Layers.SandboxDeploy.Enabled = true
+
+	rig := &lifecycleRig{
+		t:        t,
+		store:    livestore.NewFilesystemStore(h.LivestoreRoot()),
+		deploy:   &fakeSandboxDeployHarness{},
+		destroy:  &fakeSandboxDestroyHarness{result: &harness.SandboxDestroyResult{Destroy: harness.StageResult{Stage: "destroy"}}},
+		sweep:    &fakeOrphanSweep{},
+		projects: &fakeRunProject{created: harness.RunProject{ID: lifecycleProjectID, Name: harness.RunProjectNamePrefix + "journey"}},
+		probe:    &stagingVersionProbe{running: "nginx/1.27.0"},
+	}
+	rig.runtime = &CommandRuntime{
+		Config:         cfg,
+		scenarioLoader: defaultScenarioLoader,
+		livestoreRoot:  h.LivestoreRoot(),
+		Deps: RuntimeDependencies{
+			SandboxDeploy:  rig.deploy,
+			SandboxDestroy: rig.destroy,
+			OrphanSweep:    rig.sweep,
+			RunProject:     rig.projects,
+			ServiceProbe:   rig.probe,
+		},
+	}
+
+	rig.scenario = filepath.Join(h.WorkspaceDir, "web-live-paris.yaml")
+	require.NoError(t, os.WriteFile(rig.scenario, []byte(lifecycleScenarioYAML), 0o600))
+	_, err = rig.runtime.LoadScenario(rig.scenario)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(rig.runtime.OutputDir(), 0o755))
+
+	// The HCL `deploy` will copy into the deployment's own workdir.
+	writeLifecycleHCL(t, rig.runtime.OutputDir(), 1)
+	rig.source = t.TempDir()
+	writeLifecycleHCL(t, rig.source, 2)
+
+	// A real apply leaves state naming the load balancer, and `deploy`
+	// reads the address out of it. Without this the fake produces a
+	// deployment with no endpoint -- a legitimate shape, but a different
+	// journey from the one under test, and one the second test covers
+	// deliberately.
+	//
+	// Keyed off the workdir the apply is GIVEN, because a first deploy
+	// picks its own and nothing can name it in advance.
+	rig.deploy.onRunDir = func(workDir string) {
+		writeUpgradeStateWithLBAddress(t, workDir, lifecycleAddress)
+	}
+
+	return rig
+}
+
+const lifecycleAddress = "51.15.0.1"
+
+const lifecycleProjectID = "7c98d82e-ad6d-4f4c-99ea-d1886b0f38e5"
+
+const lifecycleScenarioYAML = `scenario: web-live-paris
+version: "1.0"
+cloud: scaleway
+description: >
+  The live journey: deploy, observe, upgrade, observe again, tear down.
+service:
+  image: nginx
+  tag: "1.27"
+  port: 80
+  health_path: /
+  version_path: /version
+  ttl: 4h
+resources:
+  compute:
+    purpose: web-server
+    size: small
+    count: 1
+acceptance_criteria:
+  - type: destruction
+    expect: no_orphans
+`
+
+func writeLifecycleHCL(t *testing.T, dir string, sizeGB int) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "providers.tf"), []byte(deployableProvidersTF), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"),
+		[]byte(fmt.Sprintf("resource \"scaleway_block_volume\" \"v\" { size_in_gb = %d }\n", sizeGB)), 0o644))
+}
+
+func (r *lifecycleRig) run(args ...string) (string, error) {
+	r.t.Helper()
+	cmd := &cobra.Command{Use: args[0]}
+	cmd.Flags().String("output", string(OutputModeHuman), "")
+	cmd.Flags().String("ttl", "", "")
+	cmd.Flags().String("from", "", "")
+	cmd.Flags().String("tag", "", "")
+	cmd.Flags().Bool("dry-run", false, "")
+	require.NoError(r.t, cmd.ParseFlags(args[1:]))
+	var out strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetContext(context.Background())
+
+	positional := cmd.Flags().Args()
+	var err error
+	switch args[0] {
+	case "deploy":
+		err = runDeployCommand(cmd, []string{r.scenario}, r.runtime)
+	case "ls":
+		err = runLiveListCommand(cmd, nil, r.runtime)
+	case "observe":
+		err = runLiveObserveCommand(cmd, nil, r.runtime)
+	case "upgrade":
+		err = runLiveUpgradeCommand(cmd, positional, r.runtime)
+	case "teardown":
+		err = runLiveTeardownCommand(cmd, positional, r.runtime)
+	case "reap":
+		err = runLiveReapCommand(cmd, nil, r.runtime)
+	default:
+		r.t.Fatalf("unknown command %q", args[0])
+	}
+	return out.String(), err
+}
+
+func (r *lifecycleRig) only() livestore.Deployment {
+	r.t.Helper()
+	ds, unreadable, err := r.store.List()
+	require.NoError(r.t, err)
+	require.Empty(r.t, unreadable)
+	require.Len(r.t, ds, 1)
+	return ds[0]
+}
+
+// TestLiveLifecycleJourney runs the whole live sequence through the real
+// commands and the real record.
+//
+// The assertions are deliberately about what each step LEAVES for the
+// next one, rather than about each step in isolation — the isolation
+// cases already have their own tests, and they are not where the defects
+// were.
+func TestLiveLifecycleJourney(t *testing.T) {
+	rig := newLifecycleRig(t)
+
+	// 1. deploy — the record is created, with everything later steps read.
+	out, err := rig.run("deploy", "--ttl", "30m")
+	require.NoError(t, err, out)
+
+	d := rig.only()
+	assert.Equal(t, livestore.StateLive, d.State)
+	assert.Equal(t, lifecycleProjectID, d.ProjectID)
+	assert.Equal(t, 80, d.Port, "observe reads this")
+	assert.Equal(t, "/", d.HealthPath, "observe reads this")
+	assert.Equal(t, "/version", d.VersionPath, "the version check reads this")
+	assert.Equal(t, "nginx", d.Image)
+	assert.Equal(t, "1.27", d.Tag)
+	assert.False(t, d.ExpiresAt.IsZero(), "the reaper reads this")
+
+	// The marker `upgrade` and `teardown` will demand.
+	marker, err := harness.ReadRunProjectMarker(d.WorkDir)
+	require.NoError(t, err, "deploy must leave the marker every later command requires")
+	assert.Equal(t, d.ProjectID, marker.ProjectID, "record and marker must agree from the start")
+
+	// 2. ls — before anything has looked, health is `unobserved`, not blank.
+	out, err = rig.run("ls")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, d.ID)
+	assert.Contains(t, out, "unobserved", "silence must not read as healthy")
+
+	// 3. observe — an observation lands on the record deploy wrote.
+	out, err = rig.run("observe")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "confirms nginx:1.27")
+
+	d = rig.only()
+	require.Len(t, d.Observations, 1)
+	assert.Equal(t, livestore.ObservationHealthy, d.Observations[0].Status)
+	assert.Equal(t, livestore.VersionConfirmed, d.Observations[0].Version)
+
+	// 4. upgrade — and an observation lands DURING the apply, which is
+	//    the pass-57 defect: writing back a stale copy would drop it.
+	// onRunDir fires first, so the applied state exists before the
+	// concurrent observation reads the record.
+	//
+	// The observation happens BEFORE the served version flips, on
+	// purpose. An `observe` that lands after the service has moved but
+	// before the upgrade has written the new tag sees the record and the
+	// world genuinely disagree, and reports `unconfirmed` — correct, and
+	// a real transient during any upgrade. Folding it into this step
+	// would test two things at once; it is noted here because it is
+	// exactly the single-blip noise S156b's reproduction gate exists to
+	// filter out.
+	rig.deploy.onRun = func() {
+		_, obsErr := rig.run("observe")
+		require.NoError(t, obsErr)
+		rig.probe.running = "nginx/1.28.0"
+	}
+	out, err = rig.run("upgrade", d.ID, "--from", rig.source, "--tag", "1.28")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "confirms nginx:1.27 before the upgrade")
+	assert.Contains(t, out, "now confirms nginx:1.28")
+
+	d = rig.only()
+	assert.Equal(t, "1.28", d.Tag)
+	assert.False(t, d.UpgradedAt.IsZero())
+	assert.Len(t, d.Observations, 2,
+		"the observation recorded during the apply must survive the upgrade's write")
+
+	// The superseded configuration is kept — the diff S156d needs.
+	previous, err := os.ReadFile(filepath.Join(d.WorkDir, PreviousHCLDirname, "main.tf"))
+	require.NoError(t, err)
+	assert.Contains(t, string(previous), "size_in_gb = 1")
+	current, err := os.ReadFile(filepath.Join(d.WorkDir, "main.tf"))
+	require.NoError(t, err)
+	assert.Contains(t, string(current), "size_in_gb = 2")
+
+	// 5. observe again — appends rather than replacing.
+	rig.deploy.onRun = nil
+	out, err = rig.run("observe")
+	require.NoError(t, err, out)
+	assert.Len(t, rig.only().Observations, 3)
+
+	// 6. teardown — destroy, delete the project, sweep, release.
+	out, err = rig.run("teardown", d.ID)
+	require.NoError(t, err, out)
+	assert.Equal(t, 1, rig.destroy.calls)
+	assert.Equal(t, 1, rig.projects.deletes, "tofu cannot delete the project; teardown must")
+	assert.Equal(t, 1, rig.sweep.calls)
+
+	// 7. and afterwards the record is released, not deleted, so the
+	//    reaper can prove it acted.
+	released := rig.only()
+	assert.Equal(t, livestore.StateReleased, released.State)
+	assert.Len(t, released.Observations, 3, "the history survives release")
+
+	out, err = rig.run("ls")
+	require.NoError(t, err, out)
+	assert.Contains(t, out, "released")
+
+	// 8. observe skips it now — probing a released address would
+	//    attribute whatever answers there to a service that is gone.
+	probesBefore := rig.probe.probes
+	out, err = rig.run("observe")
+	require.NoError(t, err, out)
+	assert.Equal(t, probesBefore, rig.probe.probes, "a released deployment is not probed")
+	assert.Contains(t, out, "released")
+}
+
+// A deployment whose apply produced no address is a record `deploy`
+// legitimately writes, and the S154 pass-44 defect was `observe` treating
+// it as nothing to see. The journey catches it because the record comes
+// from deploy rather than from the test.
+func TestLiveLifecycleObserveRefusesADeploymentDeployCouldNotAddress(t *testing.T) {
+	rig := newLifecycleRig(t)
+
+	// No state at all, so LiveEndpoint finds no load balancer -- the shape
+	// a real apply leaves when it fails before creating one.
+	rig.deploy.onRunDir = nil
+	rig.deploy.err = &harness.SandboxDeployError{Stage: "apply", Err: assertAnError()}
+
+	out, _ := rig.run("deploy", "--ttl", "30m")
+	d := rig.only()
+	require.Empty(t, d.Address, "the apply produced no endpoint, and deploy records that honestly")
+
+	out, err := rig.run("observe")
+
+	require.Error(t, err, "a live deployment nobody can monitor is a finding, not a skip")
+	assert.Contains(t, out, "cannot be observed")
+	assert.Contains(t, out, d.ProjectID, "the operator gets the handle to what is running")
+}
+
+func assertAnError() error { return &lifecycleErr{} }
+
+type lifecycleErr struct{}
+
+func (*lifecycleErr) Error() string { return "apply failed after creating nothing addressable" }

--- a/internal/cli/test_command_test.go
+++ b/internal/cli/test_command_test.go
@@ -53,6 +53,10 @@ type fakeSandboxDeployHarness struct {
 	// moment a real apply would -- an upgrade's version changes because
 	// the apply changed it, not before.
 	onRun func()
+	// onRunDir is onRun with the workdir the apply was given, for tests
+	// that need to write state into a directory they cannot name in
+	// advance -- a first deploy picks its own workdir.
+	onRunDir func(workDir string)
 }
 
 // Run writes a minimal terraform-live.tfstate, because a real apply
@@ -70,6 +74,9 @@ func (f *fakeSandboxDeployHarness) Run(ctx context.Context, workDir string, _ ma
 	}
 	// Last, so a hook that writes its own state is not overwritten by the
 	// default one above.
+	if f.onRunDir != nil {
+		f.onRunDir(workDir)
+	}
 	if f.onRun != nil {
 		f.onRun()
 	}


### PR DESCRIPTION
`deploy → ls → observe → upgrade → observe → teardown → ls → observe`, through the **real commands** and the **real `livestore`**, with only the cloud faked.

## The plan's premise was wrong, and is corrected in place

The plan merged an hour ago said this would drive the commands against mockway. **It cannot**, and it should not be made to:

```go
return fmt.Errorf("refusing to run a Layer 3 apply against %q: sandbox deploy targets real Scaleway (%s) only", ...)
```

`assertRealScalewayEndpoint` checks the passed env, the inherited `SCW_API_URL` **and** the `scw` config file. `deploy`, `live upgrade` and `live teardown` all build a sandbox env, so all inherit the refusal. That is ADR-0023 containment, and it exists precisely so a green Layer 3 result cannot be evidence of nothing. **The plan was wrong, not the control.**

Faking the cloud instead turns out to be the stronger design: all three defects this slice exists to catch are **record-coupling**, and none needs a cloud.

## Why a journey test at all

The live commands do not call each other. They are coupled through a **record**, and every command's own tests build the record they read — the exact shape that hides defects. This arc produced three:

| defect | found by |
|---|---|
| `observe` failing on an address-less record `deploy` legitimately wrote | a real deploy (S154 pass 44) |
| `upgrade` discarding observations appended during its apply | review (S155b pass 57) |
| record and marker disagreeing about which project an apply may touch | review, over three passes (S155b 53–55) |

**None could have been caught by a unit test.** Each is an interaction between two commands.

## Verified by reverting the fixes

The important check isn't that it passes — it's that it fails for the right reasons:

| revert | failure message |
|---|---|
| pass 57's `mergeUpgradeOntoFresh` | *"the observation recorded during the apply must survive the upgrade's write"* |
| pass 44's fail-not-skip | *"a live deployment nobody can monitor is a finding, not a skip"* |

A journey test nobody has seen fail is a journey test nobody should trust.

## One transient, noted rather than papered over

An `observe` landing after the service has moved but before the upgrade writes the new tag sees record and world genuinely disagree, and reports `unconfirmed`. That is **correct** — and it is exactly the single-blip noise **S156b's reproduction gate** exists to filter. The journey observes before the flip so it tests one thing at a time, with the reason written down.

## Review

Converged in **one pass** — the first tonight to do so, because it adds no production code. The only non-test change is an `onRunDir` hook on an existing fake, so it can write state into a workdir a first deploy names for itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD