### PR TITLE
S156b: the promotion gate — when is an observation a lesson?

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,41 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- 🎯 **S156b: the promotion gate — when is an observation a lesson? (2026-09-01)**
+  — `live candidates` reports observations that have **reproduced**, and says
+  what promoted each one and why.
+
+  Reproduced means either **N consecutive probes on one deployment** (persistent,
+  not a blip) or **≥2 distinct deployments** (a property of the shape, not of one
+  machine). A single 502 never becomes a pitfall.
+
+  It deliberately produces **candidates, not pitfalls**. Turning one into a rule
+  is S156c, and keeping them apart means the gate can be judged on whether it
+  promotes the right things without also arguing about rule text — the harder and
+  far more subjective half.
+
+  Four refusals, each a way the gate could be wrong rather than merely incomplete:
+
+  - **A recovery breaks the run.** A healthy probe between two 503s means the
+    service recovered — precisely the blip this exists to reject. Four failures
+    with a recovery in the middle promote nothing.
+  - **A different failure breaks it too**, because only one thing can be true of
+    a service at a given probe.
+  - **`unhealthy` and `unreachable` never merge.** One of each is not two of
+    either.
+  - **A zero rule promotes nothing.** A misconfigured gate that opens is worse
+    than one that closes.
+
+  **Attribution travels with the candidate rather than filtering it.** Something
+  was broken either way, but a lesson blamed on a version nobody verified is a
+  falsehood (S155a) — so an unattributable candidate is reported as
+  *"version UNCONFIRMED, so nothing may be blamed on a tag"* and the extractor
+  decides.
+
+  Released deployments still count: their observations happened while they were
+  live, and dropping them would discard exactly the reproduced evidence the gate
+  looks for.
+
 - 🔁 **S158: the live lifecycle has a journey test (2026-09-01)** — deploy → ls →
   observe → upgrade (with an observation landing *during* the apply) → observe →
   teardown → ls → observe, through the **real commands and the real

--- a/STATUS.md
+++ b/STATUS.md
@@ -39,6 +39,15 @@ Last updated: 2026-08-31
   live, and dropping them would discard exactly the reproduced evidence the gate
   looks for.
 
+  **Pass 73 caught the gate excluding the signal the arc exists for.** It skipped
+  anything `Healthy()` — and a service answering perfectly while running the wrong
+  version records `Status: healthy`, so **version drift could never be promoted**.
+  Checking it also turned up something the finding did not say: the mismatch was
+  never on the record at all, only in the failure summary, so the reason vanished
+  when the command exited. Both fixed — the record carries it, and `adverse()`
+  covers it. The report names it `version drift (service healthy)`, because
+  "healthy" alone reads as the opposite of a finding.
+
 - 🔁 **S158: the live lifecycle has a journey test (2026-09-01)** — deploy → ls →
   observe → upgrade (with an observation landing *during* the apply) → observe →
   teardown → ls → observe, through the **real commands and the real

--- a/docs/decisions/0019-learning-system-vocabulary.md
+++ b/docs/decisions/0019-learning-system-vocabulary.md
@@ -88,3 +88,35 @@ maintenance command — four places, found across four review passes, three of t
 mechanisms that already existed in the repository. **A vocabulary is only as real
 as the things that enforce it**, and the next value added here should start by
 enumerating them rather than by adding the constant.
+
+## Amendment, 2026-09-01 (S156b): reproduction is the gate, not severity or provenance
+
+An observation becomes a candidate lesson when it has **reproduced** — N
+consecutive probes on one deployment, or ≥2 distinct deployments. Not when it is
+severe, and not when Terraform also failed.
+
+That last one is worth stating because it is the intuitive answer and it is
+wrong. A Terraform failure is already learned from by the run loop; live
+observation exists for the failures Terraform reports as **success**. The
+strongest lesson this arc produced came from an apply that passed while the
+service kept serving the old version — under a terraform-failure gate it would
+produce nothing at all.
+
+Four things the gate refuses, each a way it could be wrong rather than
+incomplete:
+
+- **A recovery breaks the run.** A healthy probe between two failures means the
+  service recovered, which is the blip the gate exists to reject.
+- **A different failure breaks it**, because only one thing can be true of a
+  service at a given probe.
+- **`unhealthy` and `unreachable` never merge.** One of each is not two of either.
+- **A rule with no thresholds promotes nothing.** A misconfigured gate that opens
+  is worse than one that closes.
+
+Attribution is **recorded, not filtered**. Something was broken whether or not
+the running version was confirmed, but a rule blamed on a version nobody verified
+is a falsehood — so the fact travels with the candidate and the extractor decides.
+
+The gate produces candidates and not pitfalls, deliberately: it can then be
+judged on whether it promotes the right things without simultaneously arguing
+about rule text, which is the harder and far more subjective half.

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -576,3 +576,16 @@ right — a green Layer 3 result must not be able to be evidence of nothing.
 
 Faking the cloud rather than the record is also the stronger choice: every defect
 this test exists to catch lives in the record, not in the API.
+
+An observation records **why** it was adverse, including a version mismatch.
+`live observe` originally put the version detail only in its failure summary, so a
+healthy-but-wrong-version observation reached the record as `healthy` with an
+empty detail and the reason vanished when the command exited. It is written onto
+the observation now, unless a health failure already claimed the field — a service
+that is both down and misreporting its version should say the more urgent thing
+first.
+
+This matters beyond readability: the promotion gate groups on that detail, so
+without it the most dangerous shape live observation can find — the service and
+the record disagreeing while every other signal reports success — could never
+become a candidate lesson.

--- a/docs/review-passes/pass73.md
+++ b/docs/review-passes/pass73.md
@@ -1,0 +1,44 @@
+# Codex review pass 73 — S156b promotion gate
+
+One finding, accepted, and **it was the most important one of the slice.**
+
+## [P1] The gate excluded the signal the arc exists for
+
+`PromotionCandidates` skipped anything `Healthy()`. A service that answers
+perfectly while running the wrong version records `Status: healthy`, so **version
+drift could never be promoted** — the exact failure class S155a was built to
+detect, and the one the S155b canary produced from an apply that *succeeded*.
+
+Worse, checking it turned up something the finding did not say: the mismatch was
+never on the record at all. `live observe` put the version detail in the
+`FailureSummary` and left `observation.Detail` empty, so the reason vanished when
+the command exited. Nothing downstream — not the gate, not a human reading the
+record — could see why.
+
+Two fixes:
+
+- **The record carries it.** An unconfirmed version writes its detail onto the
+  observation, unless a health failure already claimed the field: a service that
+  is both down and misreporting should say the more urgent thing first.
+- **The gate treats it as adverse.** `adverse(o)` is `!Healthy() || versionDrift(o)`,
+  and `unchecked` is still not adverse — nobody looked, which is not evidence.
+
+## The key was too coarse, and the tests said so
+
+The first fix put the raw `VersionCheck` in the grouping key, which broke
+`TestAttributionIsRecordedRatherThanFiltered`: two identical health failures
+stopped grouping because one happened to have its version confirmed. That is
+incidental, not a distinction.
+
+Keyed on a `drift bool` instead. And an observation that is **both** unhealthy and
+version-unconfirmed is *not* drift: its detail describes the health failure, which
+is the more urgent story, so it groups with other instances of that failure rather
+than splitting off on a version field.
+
+## The report names it
+
+`version drift (service healthy)`, not `healthy`. On its own, "healthy" reads as
+the opposite of a finding — and this is precisely the shape every other signal in
+the system already reports as fine.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass74.md
+++ b/docs/review-passes/pass74.md
@@ -1,0 +1,49 @@
+# Codex review pass 74 — S156b
+
+One finding, **declined**.
+
+## [P2] "Handle historical version-drift observations" — declined
+
+The finding: observations written before pass 73 have `Status: healthy`,
+`Version: unconfirmed` and an **empty detail**, and the gate skips them on
+`o.Detail == ""`, so a real class of reproduced observation stays invisible.
+
+Two reasons, and the second is the one that decides it.
+
+### There are none
+
+Checked rather than assumed: 4 observations exist on disk, **0** of them
+detail-less drift. `version_path` shipped in S155a earlier today, so the window
+in which such a record could have been written is a few hours on one machine, and
+nothing in it drifted.
+
+### Including them would make the output worse
+
+This is the argument that would hold even if there were hundreds.
+
+A candidate's `Example` is what an eventual rule is written from. A detail-less
+observation has no words — so promoting one produces a candidate that **S156c
+cannot turn into a pitfall**, and the gate's whole contract is that a candidate is
+something worth learning from.
+
+The alternatives are worse still:
+
+- **Synthesise a detail** — fabricating words nobody observed, in a system whose
+  central discipline is that a record states what was seen.
+- **Group them under a placeholder** — every historical drift, whatever it
+  actually was, merging into one candidate whose text is a placeholder. That
+  manufactures reproduction out of ignorance, which is precisely what the
+  reproduction gate exists to prevent.
+
+The right fix was the one pass 73 already made: **new observations carry the
+detail**. A record written before the system could describe itself is not
+evidence that was lost, it is evidence that was never captured — and the gate
+saying nothing about it is correct.
+
+Recorded rather than dismissed: if a future migration ever wants to backfill
+observation details, the constraint is that it must not invent them.
+
+## Where the slice stands
+
+Two passes, two findings — one accepted (and the most important of the slice),
+one declined.

--- a/docs/review-passes/pass75.md
+++ b/docs/review-passes/pass75.md
@@ -1,0 +1,19 @@
+# Codex review pass 75 — S156b
+
+**Clean.** No findings.
+
+> The changes add a live observation promotion gate and candidate reporting with
+> focused tests covering the key reproduction, grouping, attribution, and
+> version-drift cases.
+
+Converged. Three passes, two findings — one accepted, one declined.
+
+The accepted one was the slice's most important: the gate skipped anything
+`Healthy()`, so **version drift could never be promoted** — the exact failure
+class this arc exists for, and the one the S155b canary produced from an apply
+that succeeded. Checking it also revealed the mismatch was never on the record at
+all, only in the failure summary.
+
+The declined one asked to backfill detail-less historical observations. There are
+none, and including them would produce candidates with no text for a rule to be
+written from — the gate's contract is that a candidate is worth learning from.

--- a/internal/cli/live_candidates.go
+++ b/internal/cli/live_candidates.go
@@ -105,7 +105,14 @@ func describeCandidate(c livestore.Candidate) string {
 	if c.Attributable {
 		attribution = "version confirmed"
 	}
+	kind := string(c.Status)
+	if c.VersionDrift {
+		// Naming it plainly matters: "healthy" alone would read as the
+		// opposite of a finding, and this is the shape every other
+		// signal in the system already reports as fine.
+		kind = "version drift (service healthy)"
+	}
 	return fmt.Sprintf("%s across %d deployment(s), longest run %d — %s; %s: %s",
 		c.Reason, len(c.Deployments), c.LongestRun, attribution,
-		c.Status, truncateRule(strings.TrimSpace(c.Example)))
+		kind, truncateRule(strings.TrimSpace(c.Example)))
 }

--- a/internal/cli/live_candidates.go
+++ b/internal/cli/live_candidates.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redscaresu/infrafactory/internal/feedback"
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+// runLiveCandidatesCommand reports the observations that have reproduced
+// enough to be worth learning from (S156b).
+//
+// It deliberately produces **candidates and not pitfalls**. Turning one
+// into a rule is S156c's job, and keeping the two apart means the gate
+// can be judged on whether it promotes the right things without also
+// arguing about rule text — which is the harder and much more subjective
+// half.
+//
+// It is also the only way to see the gate's verdict before anything acts
+// on it. A promotion mechanism whose output is invisible until it has
+// already written to the corpus is one nobody can calibrate.
+func runLiveCandidatesCommand(cmd *cobra.Command, _ []string, runtime *CommandRuntime) error {
+	consecutive, err := cmd.Flags().GetInt("consecutive")
+	if err != nil {
+		return &CLIError{Op: "live candidates", Code: errorCodeUsage, Err: err}
+	}
+	distinct, err := cmd.Flags().GetInt("deployments")
+	if err != nil {
+		return &CLIError{Op: "live candidates", Code: errorCodeUsage, Err: err}
+	}
+
+	store := livestore.NewFilesystemStore(runtime.LiveStoreRoot())
+	deployments, unreadable, err := store.List()
+	if err != nil {
+		return &CLIError{Op: "live candidates", Code: errorCodeCommandFailed, Err: err}
+	}
+
+	rule := livestore.PromotionRule{
+		ConsecutiveProbes:   consecutive,
+		DistinctDeployments: distinct,
+		// The same normalizer the run loop groups failures by, so a
+		// live signal and a run signal describing one problem look
+		// alike rather than merely similar.
+		Normalize: feedback.NormalizeDetail,
+	}
+	candidates := livestore.PromotionCandidates(deployments, rule)
+
+	stages := []StageSummary{{
+		Layer: "live", Stage: "candidates", Status: StageStatusPass,
+		Detail: candidateSummary(candidates, rule),
+	}}
+	for _, c := range candidates {
+		stages = append(stages, StageSummary{
+			Layer: "live", Stage: "candidates", Status: StageStatusPass,
+			Detail: describeCandidate(c),
+		})
+	}
+
+	var failures []FailureSummary
+	// Same rule `live ls` and `live observe` apply: a record that will
+	// not parse may describe running infrastructure, and its
+	// observations are missing from every count above.
+	for _, u := range unreadable {
+		stages = append(stages, StageSummary{Layer: "live", Stage: "candidates", Status: StageStatusFail})
+		failures = append(failures, FailureSummary{
+			Layer: "live", Stage: "candidates", Check: "record",
+			Command: "live candidates",
+			Detail: fmt.Sprintf(
+				"a live record could not be read, so whatever it observed is missing from this verdict: %v", u),
+		})
+	}
+
+	status := CommandStatusSuccess
+	if len(failures) > 0 {
+		status = CommandStatusFailed
+	}
+	if err := writeCommandOutput(cmd, OutputResult{
+		Command: "live candidates", Status: status, Stages: stages, Failures: failures,
+	}); err != nil {
+		return err
+	}
+	if status == CommandStatusFailed {
+		return &CLIError{Op: "live candidates", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+			"%d live record(s) could not be read, so this verdict is incomplete", len(failures))}
+	}
+	return nil
+}
+
+func candidateSummary(candidates []livestore.Candidate, rule livestore.PromotionRule) string {
+	threshold := fmt.Sprintf("%d consecutive probes, or %d distinct deployments",
+		rule.ConsecutiveProbes, rule.DistinctDeployments)
+	if len(candidates) == 0 {
+		return "nothing has reproduced (" + threshold + ")"
+	}
+	return fmt.Sprintf("%d observation(s) have reproduced (%s)", len(candidates), threshold)
+}
+
+// describeCandidate leads with the evidence rather than the text: what
+// promoted it is what a reader has to judge.
+func describeCandidate(c livestore.Candidate) string {
+	attribution := "version UNCONFIRMED, so nothing may be blamed on a tag"
+	if c.Attributable {
+		attribution = "version confirmed"
+	}
+	return fmt.Sprintf("%s across %d deployment(s), longest run %d — %s; %s: %s",
+		c.Reason, len(c.Deployments), c.LongestRun, attribution,
+		c.Status, truncateRule(strings.TrimSpace(c.Example)))
+}

--- a/internal/cli/live_candidates_test.go
+++ b/internal/cli/live_candidates_test.go
@@ -124,3 +124,33 @@ func TestCandidatesGroupsThroughTheSharedNormalizer(t *testing.T) {
 		"line numbers must not make one problem look like two")
 	assert.Contains(t, out.String(), "across 2 deployment(s)")
 }
+
+// "healthy" alone would read as the opposite of a finding, and version
+// drift is the shape every other signal in the system already reports as
+// fine. The report has to name it.
+func TestCandidatesNamesVersionDriftRatherThanCallingItHealthy(t *testing.T) {
+	rt, store := candidatesRuntime(t)
+
+	now := time.Now()
+	d := livestore.Deployment{
+		ID: "dep-drift", Scenario: "web-live-paris",
+		ProjectID: "7c98d82e-ad6d-4f4c-99ea-d1886b0f38e5",
+		State:     livestore.StateLive,
+		CreatedAt: now.Add(-time.Hour), ExpiresAt: now.Add(time.Hour),
+	}
+	for i := 0; i < 3; i++ {
+		d.RecordObservation(livestore.Observation{
+			At: now, Status: livestore.ObservationHealthy,
+			Version: livestore.VersionUnconfirmed,
+			Detail:  `the record claims nginx:1.28 but / does not mention "1.28"`,
+		})
+	}
+	require.NoError(t, store.Put(d))
+
+	var out strings.Builder
+	require.NoError(t, runCandidates(t, rt, &out))
+
+	assert.Contains(t, out.String(), "version drift (service healthy)")
+	assert.Contains(t, out.String(), "does not mention")
+	assert.NotContains(t, out.String(), "nothing has reproduced")
+}

--- a/internal/cli/live_candidates_test.go
+++ b/internal/cli/live_candidates_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+func candidatesRuntime(t *testing.T) (*CommandRuntime, *livestore.FilesystemStore) {
+	t.Helper()
+	h := newCommandTestHarness(t)
+	return &CommandRuntime{livestoreRoot: h.LivestoreRoot()},
+		livestore.NewFilesystemStore(h.LivestoreRoot())
+}
+
+func failingDeployment(t *testing.T, store *livestore.FilesystemStore, id, detail string, n int) {
+	t.Helper()
+	now := time.Now()
+	d := livestore.Deployment{
+		ID: id, Scenario: "web-live-paris",
+		ProjectID: "7c98d82e-ad6d-4f4c-99ea-d1886b0f38e5",
+		State:     livestore.StateLive,
+		CreatedAt: now.Add(-time.Hour), ExpiresAt: now.Add(time.Hour),
+	}
+	for i := 0; i < n; i++ {
+		d.RecordObservation(livestore.Observation{
+			At: now, Status: livestore.ObservationUnhealthy, Detail: detail,
+		})
+	}
+	require.NoError(t, store.Put(d))
+}
+
+func runCandidates(t *testing.T, rt *CommandRuntime, out *strings.Builder, args ...string) error {
+	t.Helper()
+	cmd := &cobra.Command{Use: "candidates"}
+	cmd.Flags().Int("consecutive", livestore.DefaultPromotionRule.ConsecutiveProbes, "")
+	cmd.Flags().Int("deployments", livestore.DefaultPromotionRule.DistinctDeployments, "")
+	cmd.Flags().String("output", string(OutputModeHuman), "")
+	require.NoError(t, cmd.ParseFlags(args))
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetContext(context.Background())
+	return runLiveCandidatesCommand(cmd, nil, rt)
+}
+
+// The gate's verdict has to be visible before anything acts on it: a
+// promotion mechanism whose output only appears once it has written to
+// the corpus is one nobody can calibrate.
+func TestCandidatesReportsWhatPromotedAndWhy(t *testing.T) {
+	rt, store := candidatesRuntime(t)
+	failingDeployment(t, store, "dep-1", "returned HTTP 502", 3)
+
+	var out strings.Builder
+	require.NoError(t, runCandidates(t, rt, &out))
+
+	assert.Contains(t, out.String(), "1 observation(s) have reproduced")
+	assert.Contains(t, out.String(), "persistent")
+	assert.Contains(t, out.String(), "longest run 3")
+	assert.Contains(t, out.String(), "HTTP 502", "the real words, not just the normalized form")
+}
+
+// A lesson blamed on a version nobody verified is a falsehood, so the
+// report says so rather than leaving it to be assumed.
+func TestCandidatesSaysWhenNothingMayBeBlamedOnATag(t *testing.T) {
+	rt, store := candidatesRuntime(t)
+	failingDeployment(t, store, "dep-1", "returned HTTP 502", 3)
+
+	var out strings.Builder
+	require.NoError(t, runCandidates(t, rt, &out))
+
+	assert.Contains(t, out.String(), "version UNCONFIRMED")
+	assert.Contains(t, out.String(), "nothing may be blamed on a tag")
+}
+
+// Nothing reproduced is a normal, successful answer — and it states the
+// threshold, so a reader can tell "nothing is wrong" from "the bar is
+// set too high".
+func TestCandidatesStatesTheThresholdWhenNothingReproduced(t *testing.T) {
+	rt, store := candidatesRuntime(t)
+	failingDeployment(t, store, "dep-1", "returned HTTP 502", 1)
+
+	var out strings.Builder
+	require.NoError(t, runCandidates(t, rt, &out))
+
+	assert.Contains(t, out.String(), "nothing has reproduced")
+	assert.Contains(t, out.String(), "3 consecutive probes, or 2 distinct deployments")
+}
+
+func TestCandidatesHonoursThresholdFlags(t *testing.T) {
+	rt, store := candidatesRuntime(t)
+	failingDeployment(t, store, "dep-1", "returned HTTP 502", 2)
+
+	var out strings.Builder
+	require.NoError(t, runCandidates(t, rt, &out, "--consecutive", "2"))
+	assert.Contains(t, out.String(), "1 observation(s) have reproduced")
+
+	var stricter strings.Builder
+	require.NoError(t, runCandidates(t, rt, &stricter, "--consecutive", "5"))
+	assert.Contains(t, stricter.String(), "nothing has reproduced")
+}
+
+// Grouping goes through the same normalizer the run loop uses, so one
+// problem with shifting line numbers reproduces with itself.
+func TestCandidatesGroupsThroughTheSharedNormalizer(t *testing.T) {
+	rt, store := candidatesRuntime(t)
+	// Two deployments, same failure, different line references — the
+	// exact variation feedback.NormalizeDetail exists to collapse.
+	failingDeployment(t, store, "dep-1",
+		"exit status 1 | stderr: Error: backend unhealthy on line 12", 1)
+	failingDeployment(t, store, "dep-2",
+		"exit status 1 | stderr: Error: backend unhealthy on line 47", 1)
+
+	var out strings.Builder
+	require.NoError(t, runCandidates(t, rt, &out))
+
+	assert.Contains(t, out.String(), "1 observation(s) have reproduced",
+		"line numbers must not make one problem look like two")
+	assert.Contains(t, out.String(), "across 2 deployment(s)")
+}

--- a/internal/cli/live_command.go
+++ b/internal/cli/live_command.go
@@ -64,6 +64,18 @@ func newLiveCmd(cfg *rootConfig) *cobra.Command {
 	upgrade.Flags().String("tag", "", "Tag the deployment now claims to run; recorded and verified against the service")
 	cmd.AddCommand(upgrade)
 
+	candidates := &cobra.Command{
+		Use:   "candidates",
+		Short: "Show observations that have reproduced enough to be worth learning from",
+		Args:  cobra.NoArgs,
+		RunE:  cfg.withRuntimeNoGenerator("live candidates", runLiveCandidatesCommand),
+	}
+	candidates.Flags().Int("consecutive", livestore.DefaultPromotionRule.ConsecutiveProbes,
+		"Probes in a row on one deployment before a failure counts as persistent")
+	candidates.Flags().Int("deployments", livestore.DefaultPromotionRule.DistinctDeployments,
+		"Distinct deployments before a failure counts as a property of the shape")
+	cmd.AddCommand(candidates)
+
 	reap := &cobra.Command{
 		Use:   "reap",
 		Short: "Destroy every live deployment whose TTL has run out",

--- a/internal/cli/live_observe.go
+++ b/internal/cli/live_observe.go
@@ -177,6 +177,19 @@ func observeDeployment(
 		observation.Status = livestore.ObservationUnreachable
 	}
 
+	// A version mismatch must reach the RECORD, not only the failure
+	// summary. A healthy service running the wrong version has an empty
+	// health detail, so without this the record says "healthy" and
+	// nothing else -- the reason is gone the moment the command exits,
+	// and the promotion gate has nothing to group on.
+	//
+	// It never overwrites a health detail: a service that is both down
+	// and misreporting its version should say the more urgent thing
+	// first, and the version state is on the observation regardless.
+	if observation.Version == livestore.VersionUnconfirmed && observation.Detail == "" {
+		observation.Detail = versionDetail
+	}
+
 	// Re-read before writing. `live observe` is the command most likely
 	// to be on a cron, so it is the one most likely to be mid-probe when
 	// an operator runs `live teardown` -- and a read-modify-write over a

--- a/internal/livestore/promotion.go
+++ b/internal/livestore/promotion.go
@@ -1,0 +1,232 @@
+package livestore
+
+import "sort"
+
+// PromotionRule decides when an observation stops being an incident and
+// becomes a candidate lesson (S156b).
+//
+// The question this slice exists to answer is "when is an observation a
+// lesson?", and the answer is **when it has reproduced** — not when it is
+// severe, and not when Terraform also failed. A terraform failure is
+// already learned from by the run loop; live observation exists for the
+// failures Terraform reports as success.
+type PromotionRule struct {
+	// ConsecutiveProbes is how many probes in a row must report the same
+	// thing on ONE deployment before it counts as persistent rather than
+	// a blip.
+	ConsecutiveProbes int
+
+	// DistinctDeployments is how many separate deployments must report
+	// the same thing before it counts as a property of the shape rather
+	// than of one machine.
+	DistinctDeployments int
+
+	// Normalize collapses cosmetic variation — line numbers, instance
+	// suffixes, provider phrasing — so the same underlying failure
+	// groups with itself.
+	//
+	// Injected rather than imported so this package keeps its
+	// deliberately small dependency set; `feedback.NormalizeDetail` is
+	// what callers pass.
+	Normalize func(string) string
+}
+
+// DefaultPromotionRule is the starting threshold.
+//
+// Both numbers are guesses and are stated as such. There is no corpus of
+// live observations to tune them against, and the plan is explicit that
+// thresholds live in configuration so they can be raised when a real one
+// arrives. Three consecutive probes is enough to outlast a restart; two
+// deployments is the smallest number that can distinguish a property of
+// the shape from a property of one machine.
+var DefaultPromotionRule = PromotionRule{
+	ConsecutiveProbes:   3,
+	DistinctDeployments: 2,
+}
+
+// Candidate is one reproduced observation, with the evidence for it.
+//
+// It is deliberately not a pitfall. Turning it into one is S156c's job,
+// and keeping the two apart means the gate can be judged on whether it
+// promotes the right things without also arguing about rule text.
+type Candidate struct {
+	// Status distinguishes "it told us it is broken" from "we got no
+	// answer" — different facts that must not merge (ADR-0024, S154).
+	Status ObservationStatus
+
+	// Detail is the normalized form, and the identity of the candidate.
+	Detail string
+
+	// Example is one raw detail exactly as observed. The normalized form
+	// is for grouping; a human, and eventually a rule, needs the real
+	// words.
+	Example string
+
+	// Scenarios are the scenarios that exhibited it, sorted. More than
+	// one is strong evidence of a shape-level problem.
+	Scenarios []string
+
+	// Deployments are the deployment ids that exhibited it, sorted.
+	Deployments []string
+
+	// LongestRun is the most consecutive probes on a single deployment.
+	LongestRun int
+
+	// Attributable reports whether at least one exhibiting deployment
+	// had its running version CONFIRMED at the time.
+	//
+	// Not a filter, deliberately. An unattributable observation is still
+	// real — something was broken — but a lesson blamed on a version
+	// nobody verified is a falsehood (S155a), so the fact travels with
+	// the candidate and the extractor decides what to do with it.
+	Attributable bool
+
+	// Reason records which half of the rule promoted it, because
+	// "persistent on one deployment" and "seen on several" are different
+	// kinds of evidence and a reader should not have to infer which.
+	Reason PromotionReason
+}
+
+// PromotionReason is why a candidate cleared the gate.
+type PromotionReason string
+
+const (
+	// PromotedByPersistence means one deployment reported it enough
+	// times in a row.
+	PromotedByPersistence PromotionReason = "persistent"
+	// PromotedByBreadth means separate deployments reported it.
+	PromotedByBreadth PromotionReason = "reproduced across deployments"
+	// PromotedByBoth is the strongest evidence available here.
+	PromotedByBoth PromotionReason = "persistent and reproduced across deployments"
+)
+
+// PromotionCandidates returns the observations that have reproduced.
+//
+// Three rules worth stating, because each one is a way the gate could be
+// wrong rather than merely incomplete:
+//
+//   - **Healthy observations are not candidates.** They carry no detail;
+//     there is nothing to learn from a service that worked.
+//   - **A run is broken by anything that is not the same failure.** A
+//     healthy probe between two 503s means the service recovered, which
+//     is precisely the blip this gate exists to reject. Counting them as
+//     consecutive would promote a flapping service as a structural fact.
+//   - **Released deployments still count.** Their observations happened
+//     while they were live, and the record keeps its history on purpose.
+//     Dropping them would discard exactly the reproduced evidence the
+//     gate is looking for.
+func PromotionCandidates(deployments []Deployment, rule PromotionRule) []Candidate {
+	normalize := rule.Normalize
+	if normalize == nil {
+		normalize = func(s string) string { return s }
+	}
+
+	type key struct {
+		status ObservationStatus
+		detail string
+	}
+	type evidence struct {
+		example      string
+		scenarios    map[string]bool
+		deployments  map[string]bool
+		longestRun   int
+		attributable bool
+	}
+
+	seen := map[key]*evidence{}
+
+	for _, d := range deployments {
+		// Per deployment, walk the observations in order so a run is a
+		// run in time rather than a count.
+		runs := map[key]int{}
+		for _, o := range d.Observations {
+			if o.Healthy() || o.Detail == "" {
+				// Anything that is not a failure ends every run: a
+				// service that recovered did not keep failing.
+				runs = map[key]int{}
+				continue
+			}
+
+			k := key{status: o.Status, detail: normalize(o.Detail)}
+
+			// This observation continues its own run and breaks every
+			// other, because only one thing can be true of a service at
+			// a given probe.
+			current := runs[k] + 1
+			runs = map[key]int{k: current}
+
+			e := seen[k]
+			if e == nil {
+				e = &evidence{
+					example:     o.Detail,
+					scenarios:   map[string]bool{},
+					deployments: map[string]bool{},
+				}
+				seen[k] = e
+			}
+			if d.Scenario != "" {
+				e.scenarios[d.Scenario] = true
+			}
+			e.deployments[d.ID] = true
+			if current > e.longestRun {
+				e.longestRun = current
+			}
+			if o.Version == VersionConfirmed {
+				e.attributable = true
+			}
+		}
+	}
+
+	var out []Candidate
+	for k, e := range seen {
+		persistent := rule.ConsecutiveProbes > 0 && e.longestRun >= rule.ConsecutiveProbes
+		broad := rule.DistinctDeployments > 0 && len(e.deployments) >= rule.DistinctDeployments
+		if !persistent && !broad {
+			continue
+		}
+
+		out = append(out, Candidate{
+			Status:       k.status,
+			Detail:       k.detail,
+			Example:      e.example,
+			Scenarios:    sortedKeys(e.scenarios),
+			Deployments:  sortedKeys(e.deployments),
+			LongestRun:   e.longestRun,
+			Attributable: e.attributable,
+			Reason:       promotionReason(persistent, broad),
+		})
+	}
+
+	// Strongest evidence first: more deployments, then longer runs, then
+	// detail for a stable order.
+	sort.Slice(out, func(i, j int) bool {
+		if len(out[i].Deployments) != len(out[j].Deployments) {
+			return len(out[i].Deployments) > len(out[j].Deployments)
+		}
+		if out[i].LongestRun != out[j].LongestRun {
+			return out[i].LongestRun > out[j].LongestRun
+		}
+		return out[i].Detail < out[j].Detail
+	})
+	return out
+}
+
+func promotionReason(persistent, broad bool) PromotionReason {
+	switch {
+	case persistent && broad:
+		return PromotedByBoth
+	case broad:
+		return PromotedByBreadth
+	default:
+		return PromotedByPersistence
+	}
+}
+
+func sortedKeys(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/livestore/promotion.go
+++ b/internal/livestore/promotion.go
@@ -54,6 +54,14 @@ type Candidate struct {
 	// answer" — different facts that must not merge (ADR-0024, S154).
 	Status ObservationStatus
 
+	// VersionDrift marks a candidate that is a version mismatch rather
+	// than a health failure: the service answered fine and is running
+	// something other than what the record claims.
+	//
+	// The most dangerous shape live observation can find, because every
+	// other signal in the system reports it as healthy.
+	VersionDrift bool
+
 	// Detail is the normalized form, and the identity of the candidate.
 	Detail string
 
@@ -105,8 +113,12 @@ const (
 // Three rules worth stating, because each one is a way the gate could be
 // wrong rather than merely incomplete:
 //
-//   - **Healthy observations are not candidates.** They carry no detail;
-//     there is nothing to learn from a service that worked.
+//   - **A healthy probe is not automatically fine.** A service can answer
+//     perfectly while running something other than what the record
+//     claims, and that is the most dangerous shape live observation can
+//     find precisely because every other signal reports it as healthy.
+//     `adverse` treats an unconfirmed version as a failure; a genuinely
+//     healthy observation carries no detail and teaches nothing.
 //   - **A run is broken by anything that is not the same failure.** A
 //     healthy probe between two 503s means the service recovered, which
 //     is precisely the blip this gate exists to reject. Counting them as
@@ -123,6 +135,15 @@ func PromotionCandidates(deployments []Deployment, rule PromotionRule) []Candida
 
 	type key struct {
 		status ObservationStatus
+		// drift separates "healthy but running the wrong version" from
+		// "down", because they are different problems with different
+		// fixes and their details come from different probes.
+		//
+		// Deliberately a bool rather than the VersionCheck itself:
+		// keying on the raw value would also split two identical health
+		// failures merely because one happened to have its version
+		// confirmed and the other did not, which is incidental.
+		drift  bool
 		detail string
 	}
 	type evidence struct {
@@ -140,14 +161,14 @@ func PromotionCandidates(deployments []Deployment, rule PromotionRule) []Candida
 		// run in time rather than a count.
 		runs := map[key]int{}
 		for _, o := range d.Observations {
-			if o.Healthy() || o.Detail == "" {
+			if !adverse(o) || o.Detail == "" {
 				// Anything that is not a failure ends every run: a
 				// service that recovered did not keep failing.
 				runs = map[key]int{}
 				continue
 			}
 
-			k := key{status: o.Status, detail: normalize(o.Detail)}
+			k := key{status: o.Status, drift: versionDrift(o), detail: normalize(o.Detail)}
 
 			// This observation continues its own run and breaks every
 			// other, because only one thing can be true of a service at
@@ -187,6 +208,7 @@ func PromotionCandidates(deployments []Deployment, rule PromotionRule) []Candida
 
 		out = append(out, Candidate{
 			Status:       k.status,
+			VersionDrift: k.drift,
 			Detail:       k.detail,
 			Example:      e.example,
 			Scenarios:    sortedKeys(e.scenarios),
@@ -229,4 +251,28 @@ func sortedKeys(set map[string]bool) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// adverse reports whether an observation is something to learn from.
+//
+// Not simply "unhealthy". The S155b canary produced an apply that
+// SUCCEEDED while the service kept serving the old version, and its
+// observation is `healthy` with an unconfirmed version -- so a gate
+// keyed on health alone would silently exclude the strongest signal this
+// arc has produced.
+//
+// `unchecked` is not adverse: nobody looked, which is not evidence of
+// anything (S155a).
+func adverse(o Observation) bool {
+	return !o.Healthy() || versionDrift(o)
+}
+
+// versionDrift is the healthy-but-wrong-version case specifically.
+//
+// An observation that is BOTH unhealthy and version-unconfirmed is not
+// drift: its detail describes the health failure, which is the more
+// urgent story, and it should group with other instances of that
+// failure rather than splitting off on a version field.
+func versionDrift(o Observation) bool {
+	return o.Healthy() && o.Version == VersionUnconfirmed
 }

--- a/internal/livestore/promotion_test.go
+++ b/internal/livestore/promotion_test.go
@@ -1,0 +1,247 @@
+package livestore
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// obs builds one failing observation.
+func obs(status ObservationStatus, detail string) Observation {
+	return Observation{At: time.Now(), Status: status, Detail: detail}
+}
+
+func healthy() Observation {
+	return Observation{At: time.Now(), Status: ObservationHealthy}
+}
+
+func deploymentWith(id, scenario string, os ...Observation) Deployment {
+	return Deployment{ID: id, Scenario: scenario, Observations: os}
+}
+
+var testRule = PromotionRule{ConsecutiveProbes: 3, DistinctDeployments: 2}
+
+// A single 502 never becomes a pitfall. Without this gate one broken
+// deployment emits the same lesson forever and the corpus rots.
+func TestOneObservationIsNeverPromoted(t *testing.T) {
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web", obs(ObservationUnhealthy, "returned HTTP 502")),
+	}, testRule)
+
+	assert.Empty(t, got)
+}
+
+// Persistent on one deployment: enough probes in a row that it is not a
+// restart or a blip.
+func TestPersistenceOnOneDeploymentPromotes(t *testing.T) {
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web",
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+		),
+	}, testRule)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, 3, got[0].LongestRun)
+	assert.Equal(t, PromotedByPersistence, got[0].Reason)
+	assert.Equal(t, []string{"dep-1"}, got[0].Deployments)
+}
+
+// A healthy probe between two failures means the service RECOVERED,
+// which is precisely the blip this gate exists to reject. Counting them
+// as consecutive would promote a flapping service as a structural fact.
+func TestARecoveryBreaksTheRun(t *testing.T) {
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web",
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+			healthy(),
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+		),
+	}, testRule)
+
+	assert.Empty(t, got, "four failures, but never three in a row")
+}
+
+// A different failure in between breaks the run too: only one thing can
+// be true of a service at a given probe.
+func TestADifferentFailureBreaksTheRun(t *testing.T) {
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web",
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+			obs(ObservationUnhealthy, "returned HTTP 503"),
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+		),
+	}, testRule)
+
+	assert.Empty(t, got)
+}
+
+// Two separate deployments reporting the same thing is a property of the
+// shape rather than of one machine — the other half of the rule, and it
+// does not need persistence.
+func TestBreadthAcrossDeploymentsPromotes(t *testing.T) {
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web", obs(ObservationUnhealthy, "returned HTTP 502")),
+		deploymentWith("dep-2", "web", obs(ObservationUnhealthy, "returned HTTP 502")),
+	}, testRule)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, PromotedByBreadth, got[0].Reason)
+	assert.Equal(t, []string{"dep-1", "dep-2"}, got[0].Deployments)
+	assert.Equal(t, 1, got[0].LongestRun)
+}
+
+// The same deployment observed twice is not two deployments.
+func TestTheSameDeploymentTwiceIsNotBreadth(t *testing.T) {
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web",
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+			healthy(),
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+		),
+	}, testRule)
+
+	assert.Empty(t, got, "two failures on one deployment, with a recovery between")
+}
+
+// "It told us it is broken" and "we got no answer" are different facts
+// (ADR-0024). Merging them would produce a lesson about neither.
+func TestUnhealthyAndUnreachableDoNotMerge(t *testing.T) {
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web", obs(ObservationUnhealthy, "the same words")),
+		deploymentWith("dep-2", "web", obs(ObservationUnreachable, "the same words")),
+	}, testRule)
+
+	assert.Empty(t, got, "one of each is not two of either")
+}
+
+// Grouping is on the NORMALIZED detail, so the same underlying failure
+// with shifting line numbers reproduces with itself.
+func TestNormalizationGroupsTheSameFailure(t *testing.T) {
+	rule := testRule
+	rule.Normalize = func(s string) string {
+		// Stand-in for feedback.NormalizeDetail: drop line references.
+		if i := strings.Index(s, " on line "); i >= 0 {
+			return s[:i]
+		}
+		return s
+	}
+
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web", obs(ObservationUnhealthy, "backend down on line 12")),
+		deploymentWith("dep-2", "web", obs(ObservationUnhealthy, "backend down on line 47")),
+	}, rule)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "backend down", got[0].Detail, "the identity is the normalized form")
+	assert.Contains(t, got[0].Example, "line 12", "but a human needs the real words")
+}
+
+// A lesson blamed on a version nobody verified is a falsehood (S155a),
+// so attribution travels with the candidate rather than filtering it:
+// something WAS broken either way, and the extractor decides.
+func TestAttributionIsRecordedRatherThanFiltered(t *testing.T) {
+	confirmed := obs(ObservationUnhealthy, "returned HTTP 502")
+	confirmed.Version = VersionConfirmed
+
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web", obs(ObservationUnhealthy, "returned HTTP 502")),
+		deploymentWith("dep-2", "web", confirmed),
+	}, testRule)
+	require.Len(t, got, 1)
+	assert.True(t, got[0].Attributable, "one confirmed exhibiting deployment is enough to attribute")
+
+	unattributable := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web", obs(ObservationUnhealthy, "returned HTTP 502")),
+		deploymentWith("dep-2", "web", obs(ObservationUnhealthy, "returned HTTP 502")),
+	}, testRule)
+	require.Len(t, unattributable, 1)
+	assert.False(t, unattributable[0].Attributable, "still promoted, but marked")
+}
+
+// A released deployment's observations happened while it was live, and
+// the record keeps its history on purpose. Dropping them would discard
+// exactly the reproduced evidence the gate looks for.
+func TestReleasedDeploymentsStillCount(t *testing.T) {
+	released := deploymentWith("dep-1", "web", obs(ObservationUnhealthy, "returned HTTP 502"))
+	released.State = StateReleased
+
+	got := PromotionCandidates([]Deployment{
+		released,
+		deploymentWith("dep-2", "web", obs(ObservationUnhealthy, "returned HTTP 502")),
+	}, testRule)
+
+	require.Len(t, got, 1)
+	assert.Contains(t, got[0].Deployments, "dep-1")
+}
+
+// Both halves at once is the strongest evidence available here, and a
+// reader should not have to infer which rule fired.
+func TestBothHalvesAreReportedDistinctly(t *testing.T) {
+	three := []Observation{
+		obs(ObservationUnhealthy, "returned HTTP 502"),
+		obs(ObservationUnhealthy, "returned HTTP 502"),
+		obs(ObservationUnhealthy, "returned HTTP 502"),
+	}
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web", three...),
+		deploymentWith("dep-2", "other", three...),
+	}, testRule)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, PromotedByBoth, got[0].Reason)
+	assert.Equal(t, []string{"other", "web"}, got[0].Scenarios,
+		"more than one scenario is strong evidence of a shape-level problem")
+}
+
+// Strongest evidence first: an operator reading a list wants the most
+// reproduced thing at the top.
+func TestCandidatesAreOrderedByStrengthOfEvidence(t *testing.T) {
+	twice := []Observation{
+		obs(ObservationUnhealthy, "weak"),
+		obs(ObservationUnhealthy, "weak"),
+		obs(ObservationUnhealthy, "weak"),
+	}
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web", twice...),
+		deploymentWith("dep-2", "web", obs(ObservationUnhealthy, "strong")),
+		deploymentWith("dep-3", "web", obs(ObservationUnhealthy, "strong")),
+		deploymentWith("dep-4", "web", obs(ObservationUnhealthy, "strong")),
+	}, testRule)
+
+	require.Len(t, got, 2)
+	assert.Equal(t, "strong", got[0].Detail, "three deployments beats one long run")
+	assert.Equal(t, "weak", got[1].Detail)
+}
+
+// A healthy service has no detail and nothing to teach.
+func TestHealthyObservationsAreNeverCandidates(t *testing.T) {
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web", healthy(), healthy(), healthy(), healthy()),
+		deploymentWith("dep-2", "web", healthy()),
+	}, testRule)
+
+	assert.Empty(t, got)
+}
+
+// A rule with no thresholds must promote nothing rather than everything:
+// a misconfigured gate that opens is worse than one that closes.
+func TestAZeroRulePromotesNothing(t *testing.T) {
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web",
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+			obs(ObservationUnhealthy, "returned HTTP 502"),
+		),
+		deploymentWith("dep-2", "web", obs(ObservationUnhealthy, "returned HTTP 502")),
+	}, PromotionRule{})
+
+	assert.Empty(t, got)
+}

--- a/internal/livestore/promotion_test.go
+++ b/internal/livestore/promotion_test.go
@@ -245,3 +245,75 @@ func TestAZeroRulePromotesNothing(t *testing.T) {
 
 	assert.Empty(t, got)
 }
+
+// The most dangerous shape live observation can find: the service
+// answers perfectly and is running something other than what the record
+// claims. Every other signal in the system reports it as healthy, which
+// is exactly why the gate must not.
+//
+// This is the S155b canary's shape — an apply that SUCCEEDED while the
+// service kept serving the old version.
+func TestVersionDriftIsPromotableEvenThoughTheServiceIsHealthy(t *testing.T) {
+	drift := func() Observation {
+		o := healthy()
+		o.Version = VersionUnconfirmed
+		o.Detail = `the record claims nginx:1.28 but / does not mention "1.28"`
+		return o
+	}
+
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web", drift(), drift(), drift()),
+	}, testRule)
+
+	require.Len(t, got, 1, "a healthy service running the wrong version is a lesson")
+	assert.True(t, got[0].VersionDrift)
+	assert.Equal(t, ObservationHealthy, got[0].Status, "healthy, and still wrong")
+	assert.Contains(t, got[0].Example, "does not mention")
+}
+
+// Drift and a health failure are different problems with different
+// fixes, and their details come from different probes.
+func TestVersionDriftDoesNotMergeWithAHealthFailure(t *testing.T) {
+	drift := healthy()
+	drift.Version = VersionUnconfirmed
+	drift.Detail = "same words"
+
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web", drift),
+		deploymentWith("dep-2", "web", obs(ObservationUnhealthy, "same words")),
+	}, testRule)
+
+	assert.Empty(t, got, "one of each is not two of either")
+}
+
+// An observation that is BOTH unhealthy and version-unconfirmed is not
+// drift: its detail describes the health failure, which is the more
+// urgent story, and it must group with other instances of that failure
+// rather than splitting off on a version field.
+func TestAnUnhealthyObservationGroupsByItsFailureNotItsVersion(t *testing.T) {
+	both := obs(ObservationUnhealthy, "returned HTTP 502")
+	both.Version = VersionUnconfirmed
+
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web", both),
+		deploymentWith("dep-2", "web", obs(ObservationUnhealthy, "returned HTTP 502")),
+	}, testRule)
+
+	require.Len(t, got, 1, "the health failure is the story; the version is incidental")
+	assert.False(t, got[0].VersionDrift)
+	assert.Len(t, got[0].Deployments, 2)
+}
+
+// `unchecked` is not adverse: nobody looked, which is not evidence of
+// anything (S155a).
+func TestAnUncheckedVersionIsNotDrift(t *testing.T) {
+	unchecked := healthy()
+	unchecked.Detail = "irrelevant"
+
+	got := PromotionCandidates([]Deployment{
+		deploymentWith("dep-1", "web", unchecked, unchecked, unchecked),
+		deploymentWith("dep-2", "web", unchecked),
+	}, testRule)
+
+	assert.Empty(t, got, "nobody having looked is not a failure")
+}


### PR DESCRIPTION
`live candidates` reports observations that have **reproduced**, and says what promoted each one and why.

## The gate

Reproduced means either **N consecutive probes on one deployment** (persistent, not a blip) or **≥2 distinct deployments** (a property of the shape, not of one machine). A single 502 never becomes a pitfall.

**Not "when Terraform fails."** That is the intuitive answer and it is wrong: a Terraform failure is already learned from by the run loop, and live observation exists for the failures Terraform reports as **success**. The strongest lesson this arc produced came from an apply that passed while the service kept serving the old version — under a terraform-failure gate it yields nothing.

It produces **candidates, not pitfalls**, deliberately. Turning one into a rule is S156c, and keeping them apart means the gate can be judged on whether it promotes the right things without simultaneously arguing about rule text — the harder and far more subjective half.

## Four refusals

Each is a way the gate could be *wrong* rather than merely incomplete:

- **A recovery breaks the run.** A healthy probe between two 503s means the service recovered — exactly the blip this rejects. Four failures with a recovery in the middle promote nothing.
- **A different failure breaks it too**, because only one thing can be true of a service at a given probe.
- **`unhealthy` and `unreachable` never merge.** One of each is not two of either.
- **A zero rule promotes nothing.** A misconfigured gate that opens is worse than one that closes.

Attribution is **recorded, not filtered**: something was broken either way, but a lesson blamed on a version nobody verified is a falsehood, so an unattributable candidate reads *"version UNCONFIRMED, so nothing may be blamed on a tag"*.

## Pass 73 — the finding that mattered

The gate skipped anything `Healthy()`. A service answering perfectly while running the wrong version records `Status: healthy`, so **version drift could never be promoted** — the exact class S155a was built to detect.

Checking it revealed something the finding did not say: **the mismatch was never on the record at all.** `live observe` put the version detail in the `FailureSummary` and left `observation.Detail` empty, so the reason vanished when the command exited — invisible to the gate *and* to a human reading the record.

Both fixed. The first attempt keyed the raw `VersionCheck`, which broke an existing test by splitting two identical health failures merely because one had its version confirmed — incidental, not a distinction. Keyed on a `drift` bool instead, and an observation that is *both* unhealthy and version-unconfirmed is not drift: its detail describes the health failure, which is the more urgent story.

The report says **`version drift (service healthy)`**, because "healthy" alone reads as the opposite of a finding.

## One decline (pass 74)

Backfilling detail-less historical drift observations. There are **none** on disk — but the argument that decides it would hold with hundreds: a candidate's example is what a rule gets written from, so a detail-less observation produces a candidate S156c cannot use. Synthesising a detail fabricates words nobody observed; grouping under a placeholder manufactures reproduction out of ignorance, which is what the gate exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD