### PR TITLE
S156c: live observations become pitfalls the generator will act on

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -42,6 +42,17 @@ Last updated: 2026-08-31
   Third time in this arc that reusing an existing mechanism was the mistake rather
   than the shortcut. **A mechanism's semantics travel with it.**
 
+  **Pass 77 caught pass 76's consequence.** Exact-text identity is unstable,
+  because a live rule *states its evidence* and that evidence grows — so the
+  corpus gained an entry every time the counters ticked, while appearing to
+  refresh. `ObservedKey` now holds the normalized detail the gate grouped by:
+  identity separated from presentation, so a refresh rewrites the text and the
+  corpus carries the **strongest** evidence rather than the first written.
+
+  Then the same bug one layer out, found by **enumerating the readers before the
+  next review** rather than after: `pitfall-merge` keyed live entries on rule text
+  too, so a sweep would have duplicated every refreshed lesson.
+
   **Every entry is stamped**, and that is a hard coupling rather than a nicety:
   S156a never retires an entry without `last_seen`, so an unstamped live entry
   would be **immortal** — the inflow quietly undoing the slice built to bound it.

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,6 +4,38 @@ Last updated: 2026-08-31
 
 ## Current phase
 
+- 🔄 **S156c: the loop closes — reproduced observations become pitfalls
+  (2026-09-01)** — `live learn` writes promoted candidates into the corpus as
+  `source: live`, and the generator sees them on the next run.
+
+  **The hard part was not writing; it was attribution.** The corpus is keyed by
+  resource and the generator steers on it — but a live observation names none:
+  *"the thing at this address returned 503"* is about an endpoint.
+  `ExtractDescriptivePitfall` already refuses to invent a resource
+  (*"skip rather than fabricate"*), and inventing one here would have been the
+  same mistake with a new name.
+
+  The honest answer is **the resource the address was resolved from**.
+  `LiveEndpointResource` now reports it alongside the address, and `deploy`
+  records it — at the only moment it is a fact rather than an inference.
+
+  Four refusals, each preferring silence to a guess:
+
+  - **No resource, nothing written** — and the operator is told, so the corpus
+    does not look complete when it is not.
+  - **Deployments that disagree on the resource write nothing.** If one served
+    from an `scaleway_lb_ip` and another from an `scaleway_instance_ip`, the
+    failure they share is a fact about neither.
+  - **Deployments that disagree on the cloud write nothing**, because the corpus
+    is per-cloud and either choice files half the evidence where it does not apply.
+  - **No remedy is invented.** A descriptive rule states what was seen and stops;
+    the prescriptive form comes from an upgrade diff in S156d.
+
+  **Every entry is stamped**, and that is a hard coupling rather than a nicety:
+  S156a never retires an entry without `last_seen`, so an unstamped live entry
+  would be **immortal** — the inflow quietly undoing the slice built to bound it.
+  Learning the same lesson twice refreshes rather than duplicates.
+
 - 🎯 **S156b: the promotion gate — when is an observation a lesson? (2026-09-01)**
   — `live candidates` reports observations that have **reproduced**, and says
   what promoted each one and why.

--- a/STATUS.md
+++ b/STATUS.md
@@ -53,6 +53,13 @@ Last updated: 2026-08-31
   next review** rather than after: `pitfall-merge` keyed live entries on rule text
   too, so a sweep would have duplicated every refreshed lesson.
 
+  **Pass 85 then caught the other half of the same identity question.** The key
+  was the normalized detail, but the gate groups on *(status, drift, detail)* —
+  `unhealthy` apart from `unreachable`, a health failure apart from a version
+  mismatch. Persisting anything narrower let one reproduced failure overwrite
+  another. `Candidate.Key()` now lives beside the gate and is what gets
+  persisted: derived rather than reassembled, so the two identities cannot drift.
+
   **Every entry is stamped**, and that is a hard coupling rather than a nicety:
   S156a never retires an entry without `last_seen`, so an unstamped live entry
   would be **immortal** — the inflow quietly undoing the slice built to bound it.

--- a/STATUS.md
+++ b/STATUS.md
@@ -31,6 +31,17 @@ Last updated: 2026-08-31
   - **No remedy is invented.** A descriptive rule states what was seen and stops;
     the prescriptive form comes from an upgrade diff in S156d.
 
+  **Pass 76 caught the slice's main behaviour being defeated by reuse.**
+  `AppendPitfall` dedupes on *word overlap* — right for provider diagnostics that
+  vary in phrasing, wrong for live rules generated from a template, where two
+  genuinely different failures on one resource share nearly every word. The second
+  lesson was dropped as a duplicate, silently. Live entries append on **exact
+  identity** now, which is sound precisely because the text is derived
+  deterministically from the candidate.
+
+  Third time in this arc that reusing an existing mechanism was the mistake rather
+  than the shortcut. **A mechanism's semantics travel with it.**
+
   **Every entry is stamped**, and that is a hard coupling rather than a nicety:
   S156a never retires an entry without `last_seen`, so an unstamped live entry
   would be **immortal** — the inflow quietly undoing the slice built to bound it.

--- a/STATUS.md
+++ b/STATUS.md
@@ -60,6 +60,15 @@ Last updated: 2026-08-31
   another. `Candidate.Key()` now lives beside the gate and is what gets
   persisted: derived rather than reassembled, so the two identities cannot drift.
 
+  **Pass 86 found the grouping wrong one dimension further out.** The gate ran
+  over every deployment and filtered cross-cloud candidates afterwards, which
+  both discarded sufficient single-cloud evidence and counted breadth *across*
+  clouds — one observation apiece promoting a coincidence of wording. The corpus
+  is per-cloud, so the partition belongs before the gate; the old test had
+  encoded the bug by relying on cross-cloud breadth to promote. Same pass: the
+  first live write could not create its own corpus, because `MkdirAll` was an
+  obligation on callers rather than on the writer that needs the directory.
+
   **Every entry is stamped**, and that is a hard coupling rather than a nicety:
   S156a never retires an entry without `last_seen`, so an unstamped live entry
   would be **immortal** — the inflow quietly undoing the slice built to bound it.

--- a/STATUS.md
+++ b/STATUS.md
@@ -69,6 +69,12 @@ Last updated: 2026-08-31
   first live write could not create its own corpus, because `MkdirAll` was an
   obligation on callers rather than on the writer that needs the directory.
 
+  **Converged on pass 87.** Three of the four passes were one question at
+  widening scope — *what is the identity of a live lesson?* — and each answer was
+  correct and incomplete in a way visible from the one before. What ended it was
+  not a better answer but a structural move: stop restating the identity at the
+  persistence layer and derive it from the gate that defines it.
+
   **Every entry is stamped**, and that is a hard coupling rather than a nicety:
   S156a never retires an entry without `last_seen`, so an unstamped live entry
   would be **immortal** — the inflow quietly undoing the slice built to bound it.

--- a/cmd/pitfall-merge/main.go
+++ b/cmd/pitfall-merge/main.go
@@ -120,6 +120,14 @@ func merge(pre, post generator.PitfallsFile, keepSet map[string]bool) (generator
 			// exactly as this merge did before timestamps existed.
 			if out.Pitfalls[i].Source == p.Source && newerLastSeen(out.Pitfalls[i].LastSeen, p.LastSeen) {
 				out.Pitfalls[i].LastSeen = p.LastSeen
+				// The text travels with the timestamp for live entries:
+				// a later observation of the same failure carries better
+				// evidence, and keeping the older wording would preserve
+				// the weaker claim.
+				if p.Source == generator.LiveSource {
+					out.Pitfalls[i].Rule = p.Rule
+					out.Pitfalls[i].DiscoveredFrom = p.DiscoveredFrom
+				}
 				refreshed++
 			}
 			continue
@@ -192,10 +200,24 @@ func entryKey(p generator.PitfallEntry) string {
 // rebuild. That asymmetry is the reason for the special case, and the
 // reason it is not applied to everything.
 func mergeKey(p generator.PitfallEntry) string {
-	if p.Source == generator.LiveSource {
-		return entryKey(p) + "\x00" + p.Source
+	if p.Source != generator.LiveSource {
+		return entryKey(p)
 	}
-	return entryKey(p)
+	// Live entries are identified by their OBSERVED KEY, not their rule
+	// text. The text states its evidence -- how many deployments, how
+	// long a run -- and that evidence grows as the same failure keeps
+	// being observed, so keying on the text would make one lesson look
+	// like a new one on every sweep and the corpus would gain a copy per
+	// merge (S156c, pass 77).
+	//
+	// Falls back to the text for entries written before observed_key
+	// existed: no key is worse than a stale one, but treating a
+	// keyless entry as brand new every sweep would be worse still.
+	identity := p.ObservedKey
+	if identity == "" {
+		identity = p.Rule
+	}
+	return p.Resource + "\x00" + identity + "\x00" + p.Source
 }
 
 func loadPitfalls(path string) (generator.PitfallsFile, error) {

--- a/cmd/pitfall-merge/main_test.go
+++ b/cmd/pitfall-merge/main_test.go
@@ -246,3 +246,45 @@ func TestMergeReportsKeptCountsPerSource(t *testing.T) {
 func TestMergeRendersNothingWhenNothingWasKept(t *testing.T) {
 	assert.Empty(t, perSourceCounts(map[string]int{}))
 }
+
+// A live rule states its evidence, and that evidence grows. Keying the
+// merge on the text would make one lesson look new on every sweep, so the
+// corpus would gain a copy per merge.
+func TestMergeIdentifiesLiveEntriesByObservedKeyNotRuleText(t *testing.T) {
+	const key = "health path returned HTTP 503"
+	pre := generator.PitfallsFile{Pitfalls: []generator.PitfallEntry{{
+		Resource: "scaleway_lb_ip", Source: "live", ObservedKey: key,
+		Rule:     "Observed: 503. Evidence: across 1 deployment(s).",
+		LastSeen: "2026-08-01T00:00:00Z",
+	}}}
+	post := generator.PitfallsFile{Pitfalls: []generator.PitfallEntry{{
+		Resource: "scaleway_lb_ip", Source: "live", ObservedKey: key,
+		Rule:     "Observed: 503. Evidence: across 4 deployment(s).",
+		LastSeen: "2026-09-01T00:00:00Z",
+	}}}
+
+	got, added, refreshed, _ := merge(pre, post, map[string]bool{"live": true})
+
+	assert.Zero(t, added, "more evidence for one failure is not a second lesson")
+	assert.Equal(t, 1, refreshed)
+	require.Len(t, got.Pitfalls, 1)
+	assert.Contains(t, got.Pitfalls[0].Rule, "4 deployment(s)",
+		"the text travels with the timestamp: a later observation carries better evidence")
+}
+
+// Entries written before observed_key existed fall back to the text. No
+// key is worse than a stale one, but treating a keyless entry as brand
+// new on every sweep would be worse still.
+func TestMergeFallsBackToTheTextForKeylessLiveEntries(t *testing.T) {
+	entry := generator.PitfallEntry{
+		Resource: "scaleway_lb_ip", Source: "live", Rule: "an old keyless rule",
+		LastSeen: "2026-08-01T00:00:00Z",
+	}
+	pre := generator.PitfallsFile{Pitfalls: []generator.PitfallEntry{entry}}
+	post := generator.PitfallsFile{Pitfalls: []generator.PitfallEntry{entry}}
+
+	got, added, _, _ := merge(pre, post, map[string]bool{"live": true})
+
+	assert.Zero(t, added)
+	assert.Len(t, got.Pitfalls, 1)
+}

--- a/docs/decisions/0019-learning-system-vocabulary.md
+++ b/docs/decisions/0019-learning-system-vocabulary.md
@@ -160,5 +160,14 @@ the append path and the sweep merge — keys on `observed_key`, and a refresh
 rewrites the text so the corpus carries the strongest evidence rather than
 whichever was written first.
 
+The key is the **whole** of the gate's identity — status, version drift, and the
+normalized detail — and not the detail alone. The gate keeps `unhealthy` apart
+from `unreachable`, and a health failure apart from a version mismatch, because
+they are different facts with different fixes; a corpus keyed more narrowly would
+collapse distinctions the gate had just been careful to preserve, and one
+reproduced failure would overwrite another. It is therefore derived by the gate
+(`Candidate.Key()`) rather than reassembled by whatever persists it, so the two
+cannot drift apart.
+
 An entry without a key is refused: it could never be recognised again, and
 writing something unmaintainable is worse than writing nothing.

--- a/docs/decisions/0019-learning-system-vocabulary.md
+++ b/docs/decisions/0019-learning-system-vocabulary.md
@@ -120,3 +120,31 @@ is a falsehood — so the fact travels with the candidate and the extractor deci
 The gate produces candidates and not pitfalls, deliberately: it can then be
 judged on whether it promotes the right things without simultaneously arguing
 about rule text, which is the harder and far more subjective half.
+
+## Amendment, 2026-09-01 (S156c): a live lesson is attributed to what was probed
+
+The corpus is keyed by resource. A live observation names none — *"the thing at
+this address returned 503"* is about an endpoint — and
+`ExtractDescriptivePitfall` refuses such a detail on purpose: **skip rather than
+fabricate**.
+
+The resource a live lesson belongs to is **the one the probed address was
+resolved from**. `LiveEndpointResource` reports it and `deploy` records it, at
+the only moment it is a fact rather than an inference. Where it cannot be
+established, or where the deployments exhibiting a candidate disagree about it,
+nothing is written and the operator is told — a corpus that looks complete when
+it is not is worse than one that admits a gap.
+
+Two further rules follow from the corpus's own shape:
+
+- **A candidate spanning two clouds writes nothing.** The corpus is per-cloud, so
+  either choice files half the evidence where it does not apply.
+- **Every live entry is stamped with `last_seen`.** S156a never retires an
+  unstamped entry, so writing one without a timestamp would make it immortal —
+  the inflow silently undoing the outflow. Re-learning refreshes rather than
+  duplicates.
+
+And the rule text stays descriptive: it states what was observed and what the
+evidence was, and does not invent a remedy. A descriptive rule that fabricates a
+fix is worse than one admitting it has none; the prescriptive form comes from an
+upgrade diff (S156d).

--- a/docs/decisions/0019-learning-system-vocabulary.md
+++ b/docs/decisions/0019-learning-system-vocabulary.md
@@ -171,3 +171,10 @@ cannot drift apart.
 
 An entry without a key is refused: it could never be recognised again, and
 writing something unmaintainable is worse than writing nothing.
+
+Because the corpus is per-cloud, the **cloud is part of the identity too**, and
+the partition happens before promotion rather than as a filter afterwards. A
+filter would discard evidence that was sufficient on its own merely because
+another cloud observed the same words, and — in the other direction — would let a
+breadth threshold count deployments across clouds, promoting a coincidence of
+wording that is a fact about neither.

--- a/docs/decisions/0019-learning-system-vocabulary.md
+++ b/docs/decisions/0019-learning-system-vocabulary.md
@@ -148,3 +148,17 @@ And the rule text stays descriptive: it states what was observed and what the
 evidence was, and does not invent a remedy. A descriptive rule that fabricates a
 fix is worse than one admitting it has none; the prescriptive form comes from an
 upgrade diff (S156d).
+
+A `source: live` entry's identity is its **`observed_key`** — the normalized
+detail the promotion gate grouped by — and not its rule text.
+
+The text is unstable by design: a live rule states its evidence, and the evidence
+grows as the same failure keeps being observed. Identifying an entry by its text
+therefore makes one lesson look new on every pass, so the corpus gains a copy per
+cron tick while appearing to refresh. Everything that identifies a live entry —
+the append path and the sweep merge — keys on `observed_key`, and a refresh
+rewrites the text so the corpus carries the strongest evidence rather than
+whichever was written first.
+
+An entry without a key is refused: it could never be recognised again, and
+writing something unmaintainable is worse than writing nothing.

--- a/docs/review-passes/pass76.md
+++ b/docs/review-passes/pass76.md
@@ -1,0 +1,36 @@
+# Codex review pass 76 — S156c
+
+One finding, accepted. **It defeated the slice's main behaviour.**
+
+## [P2] Fuzzy deduplication silently discarded distinct live lessons
+
+`AppendLivePitfall` routed through `AppendPitfall`, whose `isDuplicate` matches on
+**significant word overlap**. That is right for provider diagnostics, which vary
+in phrasing between runs and should collapse.
+
+Live rules are the opposite. They are generated from a template, so two genuinely
+different failures on one resource share nearly every word:
+
+```
+Observed on a RUNNING deployment, after the apply reported success: <detail>. Evidence: <...>
+```
+
+So the second lesson for a resource would be dropped as a duplicate of the first,
+and the corpus would keep whichever was observed earliest — **silently**, because
+my wrapper treated "AppendPitfall deduped it" as success.
+
+Live entries now append on **exact identity**. That is not merely narrower, it is
+*sound* here in a way it is not on the fuzzy path: the rule text is derived
+deterministically from the candidate, so the same candidate always produces the
+same string and a different string means a different candidate.
+
+## The general shape
+
+This is the third time in this arc that reusing an existing mechanism was the
+mistake rather than the shortcut — after the marker guard and the re-read pattern.
+The rule that keeps emerging: **a mechanism's semantics travel with it.** Fuzzy
+dedup is correct for text a machine varies and wrong for text a machine
+generates, and reusing it without asking which kind this was is what produced the
+defect.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass77.md
+++ b/docs/review-passes/pass77.md
@@ -1,0 +1,44 @@
+# Codex review pass 77 — S156c
+
+One finding, accepted. **It is the direct consequence of pass 76 that I should
+have seen while making it.**
+
+## [P2] The rule text is not stable, so exact identity duplicated
+
+Pass 76 gave live entries **exact-text identity** to stop fuzzy dedup discarding
+distinct lessons. But a live rule *states its evidence*:
+
+```
+... Evidence: persistent, across 3 deployment(s), longest run 5.
+```
+
+Those numbers grow as the same failure keeps being observed. So the next
+`live learn` produces a different string for the same lesson, exact identity sees
+something new, and **the corpus gains an entry every time the counters tick** —
+while appearing to refresh.
+
+My own `TestLearnTwiceRefreshesRatherThanDuplicating` passed only because the
+evidence did not change between the two runs. It does now.
+
+## Identity separated from presentation
+
+`ObservedKey` holds the **normalized detail the gate grouped by** — the thing that
+does not change however much evidence accumulates. Refresh matches on it and
+rewrites the rule text, so the corpus carries the *strongest* evidence rather
+than whichever was written first.
+
+An entry with no key is refused outright: it could never be recognised again, and
+writing something unmaintainable is worse than refusing.
+
+## And the same bug one layer out, found by enumerating readers
+
+`cmd/pitfall-merge` keyed live entries on `resource + rule + source`. With the
+text now changing, a sweep would treat a refreshed lesson as a new one and
+duplicate it — the identical defect, in the identical shape, one component away.
+
+Found by asking *who else reads this?* before running the next pass, which is
+S156a's lesson applied on purpose rather than after the fact. The merge keys on
+`ObservedKey` now, falling back to the text for entries written before the field
+existed.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass85.md
+++ b/docs/review-passes/pass85.md
@@ -1,0 +1,32 @@
+# Codex review pass 85 — S156c
+
+One finding, accepted.
+
+## [P2] The persisted identity was narrower than the gate's
+
+Pass 77 keyed live entries on the **normalized detail**, which fixed the
+instability. But the gate does not group on the detail alone — it groups on
+`(status, drift, detail)`, and it does that deliberately:
+
+- `unhealthy` is "it told us it is broken"; `unreachable` is "we got no answer".
+  Different facts, and ADR-0024 says they must not merge.
+- A health failure and a version mismatch are different problems with different
+  fixes, and their details come from different probes.
+
+So two candidates the gate had just been careful to keep apart could land on the
+same corpus key, and the second would refresh over the first. **A reproduced
+failure would be silently lost** — the exact outcome the promotion gate exists to
+prevent.
+
+## Derived, not reassembled
+
+`Candidate.Key()` now lives beside the gate and composes the same three fields it
+groups by, and `live learn` persists that. The alternative — building the key in
+the CLI — is how the two identities drift apart the next time the gate learns to
+distinguish something new.
+
+Same reason `StaleLivePitfalls` and `RetireStaleLivePitfalls` share one
+`partitionStale`: when two places must agree, make one of them the other's
+source rather than asking a reader to keep them in step.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass86.md
+++ b/docs/review-passes/pass86.md
@@ -1,0 +1,43 @@
+# Codex review pass 86 — S156c
+
+Two findings, both accepted.
+
+## [P2] Promotion grouped across clouds, and the filter came too late
+
+`live learn` ran the gate over **every** deployment and then refused any
+candidate whose deployments disagreed on a cloud. That reads as caution and is
+the opposite:
+
+- A Scaleway deployment that met the threshold **on its own** was dropped because
+  a GCP deployment happened to observe the same words. Sufficient evidence
+  discarded by unrelated evidence.
+- Worse in the other direction: `--deployments 2` counted breadth **across**
+  clouds, so one observation on each of two clouds promoted — a coincidence of
+  wording that is a fact about neither of them.
+
+The corpus is per-cloud. The cloud is therefore part of what makes an observation
+*the same observation*, exactly as its status is, so the partition belongs before
+the gate rather than after it. Promotion now runs per cloud and `agreedValue` on
+clouds is gone.
+
+`TestLearnRefusesWhenDeploymentsDisagreeOnTheCloud` **encoded the bug**: it
+seeded one observation on each of two clouds and relied on cross-cloud breadth to
+promote so it could then watch the filter reject it. It now asserts the rule that
+should have been there — one apiece is not reproduction — alongside a new test
+that a cloud reproducing on its own is never suppressed by another.
+
+Records that name no cloud are reported by count rather than dropped.
+
+## [P2] The first live write could not create its own corpus
+
+A reader treats a missing pitfalls file as an empty corpus, so writing the first
+lesson into a fresh corpus is a normal thing to do. `AppendLivePitfall` went
+straight to `writePitfallsFile`, whose `os.CreateTemp(pitfallsDir, …)` fails with
+ENOENT if the directory is not there.
+
+`AppendPitfall` had its own `MkdirAll`, which is exactly why this was missed: the
+obligation lived in the callers, so a new caller could simply not know about it.
+Moved into `writePitfallsFile`, which is the function that actually needs the
+directory — the caller's copy is gone rather than duplicated.
+
+## Nothing declined this pass.

--- a/docs/review-passes/pass87.md
+++ b/docs/review-passes/pass87.md
@@ -1,0 +1,22 @@
+# Codex review pass 87 — S156c
+
+**Clean.** No correctness, safety, or maintainability findings in the diff.
+
+S156c converged in four passes (77, 85, 86, 87), and three of the four were the
+**same question asked at successively wider scope**: what is the identity of a
+live lesson?
+
+- **77** — not the rule text, because a live rule states its evidence and the
+  evidence grows.
+- **85** — not the detail alone either, because the gate keeps `unhealthy` apart
+  from `unreachable` and health apart from version drift.
+- **86** — and the cloud belongs in it as well, because the corpus is per-cloud;
+  filtering afterwards both discarded sufficient evidence and counted breadth
+  across clouds.
+
+Each answer was correct and incomplete, and each incompleteness was visible from
+the one before it. The generalisable move, and the one that finally ended it, was
+to stop **restating** the identity at the persistence layer and make it
+`Candidate.Key()` — derived by the thing that defines it. The pass-86 `MkdirAll`
+finding is the same shape in miniature: an obligation held by callers is an
+obligation a new caller can fail to know about.

--- a/internal/cli/deploy_command.go
+++ b/internal/cli/deploy_command.go
@@ -296,7 +296,11 @@ func registerDeployment(
 
 	// Best effort: an unreachable address is worth recording as empty
 	// rather than failing a deploy that otherwise worked.
-	address, _ := harness.LiveEndpoint(workDir, "load_balancer")
+	//
+	// The resource type comes back with it, because a live observation of
+	// this address names no resource and the corpus is keyed by one.
+	// Capturing it here is the only point at which it is a fact.
+	address, addressResource, _ := harness.LiveEndpointResource(workDir, "load_balancer")
 
 	now := time.Now()
 	d := livestore.Deployment{
@@ -309,13 +313,15 @@ func registerDeployment(
 		// Snapshotted, not looked up later: the scenario file changes,
 		// this record describes one deployment that already happened
 		// (S154).
-		Port:        sc.Service.Port,
-		HealthPath:  sc.Service.HealthPath,
-		VersionPath: sc.Service.VersionPath,
-		State:       livestore.StateLive,
-		WorkDir:     workDir,
-		CreatedAt:   now,
-		ExpiresAt:   now.Add(ttl),
+		Port:            sc.Service.Port,
+		HealthPath:      sc.Service.HealthPath,
+		VersionPath:     sc.Service.VersionPath,
+		AddressResource: addressResource,
+		Cloud:           sc.Cloud,
+		State:           livestore.StateLive,
+		WorkDir:         workDir,
+		CreatedAt:       now,
+		ExpiresAt:       now.Add(ttl),
 	}
 
 	if err := store.Put(d); err != nil {

--- a/internal/cli/live_command.go
+++ b/internal/cli/live_command.go
@@ -76,6 +76,19 @@ func newLiveCmd(cfg *rootConfig) *cobra.Command {
 		"Distinct deployments before a failure counts as a property of the shape")
 	cmd.AddCommand(candidates)
 
+	learn := &cobra.Command{
+		Use:   "learn",
+		Short: "Record reproduced observations in the pitfall corpus as source: live",
+		Args:  cobra.NoArgs,
+		RunE:  cfg.withRuntimeNoGenerator("live learn", runLiveLearnCommand),
+	}
+	learn.Flags().Int("consecutive", livestore.DefaultPromotionRule.ConsecutiveProbes,
+		"Probes in a row on one deployment before a failure counts as persistent")
+	learn.Flags().Int("deployments", livestore.DefaultPromotionRule.DistinctDeployments,
+		"Distinct deployments before a failure counts as a property of the shape")
+	learn.Flags().Bool("dry-run", false, "Report what would be learned without writing to the corpus")
+	cmd.AddCommand(learn)
+
 	reap := &cobra.Command{
 		Use:   "reap",
 		Short: "Destroy every live deployment whose TTL has run out",

--- a/internal/cli/live_learn.go
+++ b/internal/cli/live_learn.go
@@ -1,0 +1,246 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redscaresu/infrafactory/internal/feedback"
+	"github.com/redscaresu/infrafactory/internal/generator"
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+// runLiveLearnCommand writes reproduced observations into the corpus as
+// `source: live` pitfalls (S156c).
+//
+// This is the step that closes the loop, and the one place in the arc
+// where the system writes something it will later act on. Two properties
+// follow from that, and both are refusals rather than features:
+//
+//   - **Nothing is written without a resource.** The corpus is keyed by
+//     resource and the generator steers on it, but a live observation
+//     names none: "the thing at this address returned 503" is about an
+//     endpoint. `ExtractDescriptivePitfall` already refuses to invent one
+//     ("skip rather than fabricate"), and this refuses for the same
+//     reason — using the resource the address was RESOLVED from, which is
+//     a fact recorded at deploy time, or writing nothing.
+//   - **Nothing is written that cannot later be retired.** Every entry
+//     carries `last_seen`, so S156a's retirement can act on it. An entry
+//     the corpus cannot shed is one that steers generation forever.
+func runLiveLearnCommand(cmd *cobra.Command, _ []string, runtime *CommandRuntime) error {
+	consecutive, err := cmd.Flags().GetInt("consecutive")
+	if err != nil {
+		return &CLIError{Op: "live learn", Code: errorCodeUsage, Err: err}
+	}
+	distinct, err := cmd.Flags().GetInt("deployments")
+	if err != nil {
+		return &CLIError{Op: "live learn", Code: errorCodeUsage, Err: err}
+	}
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		return &CLIError{Op: "live learn", Code: errorCodeUsage, Err: err}
+	}
+
+	store := livestore.NewFilesystemStore(runtime.LiveStoreRoot())
+	deployments, unreadable, err := store.List()
+	if err != nil {
+		return &CLIError{Op: "live learn", Code: errorCodeCommandFailed, Err: err}
+	}
+
+	candidates := livestore.PromotionCandidates(deployments, livestore.PromotionRule{
+		ConsecutiveProbes:   consecutive,
+		DistinctDeployments: distinct,
+		Normalize:           feedback.NormalizeDetail,
+	})
+
+	resources := addressResources(deployments)
+	clouds := deploymentClouds(deployments)
+	now := time.Now()
+
+	var stages []StageSummary
+	var failures []FailureSummary
+	written := 0
+
+	for _, c := range candidates {
+		resource := resourceForCandidate(c, resources)
+		if resource == "" {
+			// Said out loud rather than dropped. A reproduced failure
+			// nobody can attribute is a real signal that this system
+			// cannot yet use, and hiding that would make the corpus look
+			// like it had learned everything available.
+			stages = append(stages, StageSummary{
+				Layer: "live", Stage: "learn", Status: StageStatusSkip,
+				Detail: fmt.Sprintf(
+					"reproduced across %d deployment(s) but no resource can be attributed, so nothing is written: %s",
+					len(c.Deployments), truncateRule(strings.TrimSpace(c.Example))),
+			})
+			continue
+		}
+
+		cloud := agreedValue(c.Deployments, clouds)
+		if cloud == "" {
+			// The corpus is per-cloud. A candidate spanning two of them
+			// is not one lesson, and picking either would file it where
+			// half its evidence does not apply.
+			stages = append(stages, StageSummary{
+				Layer: "live", Stage: "learn", Status: StageStatusSkip,
+				Detail: fmt.Sprintf(
+					"reproduced across %d deployment(s) that do not agree on a cloud, so nothing is written",
+					len(c.Deployments)),
+			})
+			continue
+		}
+
+		rule := liveRuleText(c)
+		if dryRun {
+			stages = append(stages, StageSummary{
+				Layer: "live", Stage: "learn", Status: StageStatusSkip,
+				Detail: fmt.Sprintf("--dry-run: would learn for %s — %s", resource, truncateRule(rule)),
+			})
+			continue
+		}
+
+		pitfall := generator.LearnedPitfall{
+			Resource:       resource,
+			Rule:           rule,
+			Source:         generator.LiveSource,
+			DiscoveredFrom: strings.Join(c.Scenarios, ", "),
+		}
+		if err := generator.AppendLivePitfall(runtime.Config.Paths.Pitfalls, cloud, pitfall, now); err != nil {
+			failures = append(failures, FailureSummary{
+				Layer: "live", Stage: "learn", Check: "append",
+				Command: "live learn",
+				Detail:  fmt.Sprintf("could not record the lesson for %s: %v", resource, err),
+			})
+			continue
+		}
+		written++
+		stages = append(stages, StageSummary{
+			Layer: "live", Stage: "learn", Status: StageStatusPass,
+			Detail: fmt.Sprintf("%s: %s", resource, truncateRule(rule)),
+		})
+	}
+
+	for _, u := range unreadable {
+		failures = append(failures, FailureSummary{
+			Layer: "live", Stage: "learn", Check: "record",
+			Command: "live learn",
+			Detail: fmt.Sprintf(
+				"a live record could not be read, so whatever it observed was not considered: %v", u),
+		})
+	}
+
+	stages = append([]StageSummary{{
+		Layer: "live", Stage: "learn", Status: StageStatusPass,
+		Detail: learnSummary(len(candidates), written, dryRun),
+	}}, stages...)
+
+	status := CommandStatusSuccess
+	if len(failures) > 0 {
+		status = CommandStatusFailed
+	}
+	if err := writeCommandOutput(cmd, OutputResult{
+		Command: "live learn", Status: status, Stages: stages, Failures: failures,
+	}); err != nil {
+		return err
+	}
+	if status == CommandStatusFailed {
+		return &CLIError{Op: "live learn", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+			"%d lesson(s) could not be recorded", len(failures))}
+	}
+	return nil
+}
+
+func learnSummary(candidates, written int, dryRun bool) string {
+	if candidates == 0 {
+		return "nothing has reproduced, so there is nothing to learn"
+	}
+	if dryRun {
+		return fmt.Sprintf("--dry-run: %d candidate(s) considered, nothing written", candidates)
+	}
+	return fmt.Sprintf("%d candidate(s) considered, %d written as source: live", candidates, written)
+}
+
+// addressResources maps deployment id to the resource its probed address
+// came from.
+func addressResources(deployments []livestore.Deployment) map[string]string {
+	out := map[string]string{}
+	for _, d := range deployments {
+		if d.AddressResource != "" {
+			out[d.ID] = d.AddressResource
+		}
+	}
+	return out
+}
+
+// resourceForCandidate returns the resource every exhibiting deployment
+// agrees on, or "" when they do not.
+//
+// Unanimity is the bar on purpose. If one deployment served from an
+// `scaleway_lb_ip` and another from an `scaleway_instance_ip`, the
+// failure they share is not a fact about either — attributing it to
+// whichever happened to be first would be a guess dressed as a finding.
+func resourceForCandidate(c livestore.Candidate, byDeployment map[string]string) string {
+	return agreedValue(c.Deployments, byDeployment)
+}
+
+// agreedValue returns the value every id maps to, or "" if any is
+// missing or they disagree.
+func agreedValue(ids []string, byID map[string]string) string {
+	agreed := ""
+	for _, id := range ids {
+		v := byID[id]
+		if v == "" {
+			return ""
+		}
+		if agreed == "" {
+			agreed = v
+			continue
+		}
+		if agreed != v {
+			return ""
+		}
+	}
+	return agreed
+}
+
+// deploymentClouds maps deployment id to the cloud it was applied to.
+func deploymentClouds(deployments []livestore.Deployment) map[string]string {
+	out := map[string]string{}
+	for _, d := range deployments {
+		if d.Cloud != "" {
+			out[d.ID] = d.Cloud
+		}
+	}
+	return out
+}
+
+// liveRuleText phrases what was observed for a reader who will meet it
+// as generation guidance, months later, with none of this context.
+//
+// It says what happened and what the evidence was, and stops there. It
+// does NOT say what to do: a descriptive rule that invents a remedy is
+// worse than one that admits it has none, and the prescriptive form
+// comes from an upgrade diff in S156d.
+func liveRuleText(c livestore.Candidate) string {
+	evidence := fmt.Sprintf("%s, across %d deployment(s), longest run %d",
+		c.Reason, len(c.Deployments), c.LongestRun)
+
+	if c.VersionDrift {
+		return fmt.Sprintf(
+			"Observed on a RUNNING deployment: the service answered normally while serving a version "+
+				"other than the one deployed (%s). An apply reaching its desired state does not mean the "+
+				"service restarted or picked up the new configuration. Evidence: %s.",
+			strings.TrimSpace(c.Example), evidence)
+	}
+
+	attribution := ""
+	if !c.Attributable {
+		attribution = " The running version was never confirmed, so nothing here may be attributed to a particular image tag."
+	}
+	return fmt.Sprintf(
+		"Observed on a RUNNING deployment, after the apply reported success: %s. Evidence: %s.%s",
+		strings.TrimSpace(c.Example), evidence, attribution)
+}

--- a/internal/cli/live_learn.go
+++ b/internal/cli/live_learn.go
@@ -108,7 +108,10 @@ func runLiveLearnCommand(cmd *cobra.Command, _ []string, runtime *CommandRuntime
 			Source:         generator.LiveSource,
 			DiscoveredFrom: strings.Join(c.Scenarios, ", "),
 		}
-		if err := generator.AppendLivePitfall(runtime.Config.Paths.Pitfalls, cloud, pitfall, now); err != nil {
+		// c.Detail is the NORMALIZED form the gate grouped by, and it is
+		// what stays the same as evidence accumulates -- unlike the rule
+		// text, which states that evidence.
+		if err := generator.AppendLivePitfall(runtime.Config.Paths.Pitfalls, cloud, c.Detail, pitfall, now); err != nil {
 			failures = append(failures, FailureSummary{
 				Layer: "live", Stage: "learn", Check: "append",
 				Command: "live learn",

--- a/internal/cli/live_learn.go
+++ b/internal/cli/live_learn.go
@@ -108,10 +108,12 @@ func runLiveLearnCommand(cmd *cobra.Command, _ []string, runtime *CommandRuntime
 			Source:         generator.LiveSource,
 			DiscoveredFrom: strings.Join(c.Scenarios, ", "),
 		}
-		// c.Detail is the NORMALIZED form the gate grouped by, and it is
-		// what stays the same as evidence accumulates -- unlike the rule
-		// text, which states that evidence.
-		if err := generator.AppendLivePitfall(runtime.Config.Paths.Pitfalls, cloud, c.Detail, pitfall, now); err != nil {
+		// c.Key() is the gate's OWN identity: status, drift and the
+		// normalized detail. Persisting anything narrower would collapse
+		// distinctions the gate had just been careful to preserve --
+		// `unhealthy` and `unreachable` with the same words are two
+		// reproduced failures, and one must not overwrite the other.
+		if err := generator.AppendLivePitfall(runtime.Config.Paths.Pitfalls, cloud, c.Key(), pitfall, now); err != nil {
 			failures = append(failures, FailureSummary{
 				Layer: "live", Stage: "learn", Check: "append",
 				Command: "live learn",

--- a/internal/cli/live_learn.go
+++ b/internal/cli/live_learn.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -49,82 +50,57 @@ func runLiveLearnCommand(cmd *cobra.Command, _ []string, runtime *CommandRuntime
 		return &CLIError{Op: "live learn", Code: errorCodeCommandFailed, Err: err}
 	}
 
-	candidates := livestore.PromotionCandidates(deployments, livestore.PromotionRule{
-		ConsecutiveProbes:   consecutive,
-		DistinctDeployments: distinct,
-		Normalize:           feedback.NormalizeDetail,
-	})
+	// Promotion runs PER CLOUD, and the partition happens before the gate
+	// rather than after it.
+	//
+	// Filtering cross-cloud candidates out afterwards looks equivalent
+	// and is not. Two things go wrong. A Scaleway deployment that met the
+	// threshold on its own is DROPPED because a GCP deployment happened
+	// to observe the same words — evidence sufficient on its own is
+	// discarded by unrelated evidence. And `--deployments` would count
+	// breadth across clouds, promoting on a coincidence that is a fact
+	// about neither of them.
+	//
+	// The corpus is per-cloud, so the cloud is part of what makes an
+	// observation the same observation, exactly as its status is.
+	byCloud, uncloudedCount := partitionByCloud(deployments)
 
 	resources := addressResources(deployments)
-	clouds := deploymentClouds(deployments)
 	now := time.Now()
 
 	var stages []StageSummary
 	var failures []FailureSummary
 	written := 0
+	considered := 0
 
-	for _, c := range candidates {
-		resource := resourceForCandidate(c, resources)
-		if resource == "" {
-			// Said out loud rather than dropped. A reproduced failure
-			// nobody can attribute is a real signal that this system
-			// cannot yet use, and hiding that would make the corpus look
-			// like it had learned everything available.
-			stages = append(stages, StageSummary{
-				Layer: "live", Stage: "learn", Status: StageStatusSkip,
-				Detail: fmt.Sprintf(
-					"reproduced across %d deployment(s) but no resource can be attributed, so nothing is written: %s",
-					len(c.Deployments), truncateRule(strings.TrimSpace(c.Example))),
-			})
-			continue
-		}
+	for _, cloud := range sortedKeys(byCloud) {
+		candidates := livestore.PromotionCandidates(byCloud[cloud], livestore.PromotionRule{
+			ConsecutiveProbes:   consecutive,
+			DistinctDeployments: distinct,
+			Normalize:           feedback.NormalizeDetail,
+		})
+		considered += len(candidates)
 
-		cloud := agreedValue(c.Deployments, clouds)
-		if cloud == "" {
-			// The corpus is per-cloud. A candidate spanning two of them
-			// is not one lesson, and picking either would file it where
-			// half its evidence does not apply.
-			stages = append(stages, StageSummary{
-				Layer: "live", Stage: "learn", Status: StageStatusSkip,
-				Detail: fmt.Sprintf(
-					"reproduced across %d deployment(s) that do not agree on a cloud, so nothing is written",
-					len(c.Deployments)),
-			})
-			continue
+		for _, c := range candidates {
+			s, f, w := learnCandidate(learnContext{
+				cloud: cloud, resources: resources, dryRun: dryRun,
+				pitfallsDir: runtime.Config.Paths.Pitfalls, now: now,
+			}, c)
+			stages = append(stages, s...)
+			failures = append(failures, f...)
+			written += w
 		}
+	}
 
-		rule := liveRuleText(c)
-		if dryRun {
-			stages = append(stages, StageSummary{
-				Layer: "live", Stage: "learn", Status: StageStatusSkip,
-				Detail: fmt.Sprintf("--dry-run: would learn for %s — %s", resource, truncateRule(rule)),
-			})
-			continue
-		}
-
-		pitfall := generator.LearnedPitfall{
-			Resource:       resource,
-			Rule:           rule,
-			Source:         generator.LiveSource,
-			DiscoveredFrom: strings.Join(c.Scenarios, ", "),
-		}
-		// c.Key() is the gate's OWN identity: status, drift and the
-		// normalized detail. Persisting anything narrower would collapse
-		// distinctions the gate had just been careful to preserve --
-		// `unhealthy` and `unreachable` with the same words are two
-		// reproduced failures, and one must not overwrite the other.
-		if err := generator.AppendLivePitfall(runtime.Config.Paths.Pitfalls, cloud, c.Key(), pitfall, now); err != nil {
-			failures = append(failures, FailureSummary{
-				Layer: "live", Stage: "learn", Check: "append",
-				Command: "live learn",
-				Detail:  fmt.Sprintf("could not record the lesson for %s: %v", resource, err),
-			})
-			continue
-		}
-		written++
+	if uncloudedCount > 0 {
+		// Said out loud. The corpus is per-cloud, so a record that names
+		// none cannot be filed anywhere -- but whatever it observed was
+		// real, and silently ignoring it would make the run look like it
+		// had considered everything.
 		stages = append(stages, StageSummary{
-			Layer: "live", Stage: "learn", Status: StageStatusPass,
-			Detail: fmt.Sprintf("%s: %s", resource, truncateRule(rule)),
+			Layer: "live", Stage: "learn", Status: StageStatusSkip,
+			Detail: fmt.Sprintf(
+				"%d live record(s) name no cloud, so nothing they observed can be filed", uncloudedCount),
 		})
 	}
 
@@ -139,7 +115,7 @@ func runLiveLearnCommand(cmd *cobra.Command, _ []string, runtime *CommandRuntime
 
 	stages = append([]StageSummary{{
 		Layer: "live", Stage: "learn", Status: StageStatusPass,
-		Detail: learnSummary(len(candidates), written, dryRun),
+		Detail: learnSummary(considered, written, dryRun),
 	}}, stages...)
 
 	status := CommandStatusSuccess
@@ -211,17 +187,6 @@ func agreedValue(ids []string, byID map[string]string) string {
 	return agreed
 }
 
-// deploymentClouds maps deployment id to the cloud it was applied to.
-func deploymentClouds(deployments []livestore.Deployment) map[string]string {
-	out := map[string]string{}
-	for _, d := range deployments {
-		if d.Cloud != "" {
-			out[d.ID] = d.Cloud
-		}
-	}
-	return out
-}
-
 // liveRuleText phrases what was observed for a reader who will meet it
 // as generation guidance, months later, with none of this context.
 //
@@ -248,4 +213,88 @@ func liveRuleText(c livestore.Candidate) string {
 	return fmt.Sprintf(
 		"Observed on a RUNNING deployment, after the apply reported success: %s. Evidence: %s.%s",
 		strings.TrimSpace(c.Example), evidence, attribution)
+}
+
+// learnContext is what learning one candidate needs beyond the candidate.
+type learnContext struct {
+	cloud       string
+	resources   map[string]string
+	dryRun      bool
+	pitfallsDir string
+	now         time.Time
+}
+
+// learnCandidate turns one promoted candidate into a corpus entry, or
+// says why it did not.
+func learnCandidate(ctx learnContext, c livestore.Candidate) ([]StageSummary, []FailureSummary, int) {
+	resource := resourceForCandidate(c, ctx.resources)
+	if resource == "" {
+		// Said out loud rather than dropped. A reproduced failure
+		// nobody can attribute is a real signal that this system
+		// cannot yet use, and hiding that would make the corpus look
+		// like it had learned everything available.
+		return []StageSummary{{
+			Layer: "live", Stage: "learn", Status: StageStatusSkip,
+			Detail: fmt.Sprintf(
+				"%s: reproduced across %d deployment(s) but no resource can be attributed, so nothing is written: %s",
+				ctx.cloud, len(c.Deployments), truncateRule(strings.TrimSpace(c.Example))),
+		}}, nil, 0
+	}
+
+	rule := liveRuleText(c)
+	if ctx.dryRun {
+		return []StageSummary{{
+			Layer: "live", Stage: "learn", Status: StageStatusSkip,
+			Detail: fmt.Sprintf("--dry-run: would learn for %s/%s — %s", ctx.cloud, resource, truncateRule(rule)),
+		}}, nil, 0
+	}
+
+	pitfall := generator.LearnedPitfall{
+		Resource:       resource,
+		Rule:           rule,
+		Source:         generator.LiveSource,
+		DiscoveredFrom: strings.Join(c.Scenarios, ", "),
+	}
+	// c.Key() is the gate's OWN identity: status, drift and the
+	// normalized detail. Persisting anything narrower would collapse
+	// distinctions the gate had just been careful to preserve --
+	// `unhealthy` and `unreachable` with the same words are two
+	// reproduced failures, and one must not overwrite the other.
+	if err := generator.AppendLivePitfall(ctx.pitfallsDir, ctx.cloud, c.Key(), pitfall, ctx.now); err != nil {
+		return nil, []FailureSummary{{
+			Layer: "live", Stage: "learn", Check: "append",
+			Command: "live learn",
+			Detail:  fmt.Sprintf("could not record the lesson for %s: %v", resource, err),
+		}}, 0
+	}
+
+	return []StageSummary{{
+		Layer: "live", Stage: "learn", Status: StageStatusPass,
+		Detail: fmt.Sprintf("%s/%s: %s", ctx.cloud, resource, truncateRule(rule)),
+	}}, nil, 1
+}
+
+// partitionByCloud groups deployments by the cloud they were applied to,
+// reporting how many named none rather than dropping them quietly.
+func partitionByCloud(deployments []livestore.Deployment) (map[string][]livestore.Deployment, int) {
+	out := map[string][]livestore.Deployment{}
+	unclouded := 0
+	for _, d := range deployments {
+		if d.Cloud == "" {
+			unclouded++
+			continue
+		}
+		out[d.Cloud] = append(out[d.Cloud], d)
+	}
+	return out, unclouded
+}
+
+// sortedKeys keeps the per-cloud output deterministic; map order is not.
+func sortedKeys(byCloud map[string][]livestore.Deployment) []string {
+	out := make([]string, 0, len(byCloud))
+	for k := range byCloud {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/cli/live_learn_test.go
+++ b/internal/cli/live_learn_test.go
@@ -221,11 +221,22 @@ func TestLearnTwiceRefreshesRatherThanDuplicating(t *testing.T) {
 	})
 
 	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
-	first := corpus(t, pitfalls)
-	require.Len(t, first, 1)
+	require.Len(t, corpus(t, pitfalls), 1)
+
+	// A second deployment exhibits the SAME failure, so the evidence
+	// grows and the rule text changes with it. Identity must survive
+	// that, or the corpus gains an entry every time the counters tick.
+	seedLearnDeployment(t, store, learnDeployment{
+		id: "dep-2", detail: "health path returned HTTP 503",
+		resource: "scaleway_lb_ip", cloud: "scaleway", observations: 3,
+	})
 
 	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
-	assert.Len(t, corpus(t, pitfalls), 1, "the same lesson twice is one lesson")
+
+	entries := corpus(t, pitfalls)
+	require.Len(t, entries, 1, "more evidence for one failure is not a second lesson")
+	assert.Contains(t, entries[0].Rule, "2 deployment(s)",
+		"and the corpus carries the stronger evidence")
 }
 
 // The version-drift rule says the thing that is actually surprising: the

--- a/internal/cli/live_learn_test.go
+++ b/internal/cli/live_learn_test.go
@@ -274,3 +274,38 @@ func TestLearnDoesNotInventARemedy(t *testing.T) {
 	}
 	assert.Contains(t, rule, "never confirmed", "and it says what it could not establish")
 }
+
+// The gate keeps `unhealthy` apart from `unreachable` on purpose. A store
+// that keyed on the detail alone would collapse that distinction and one
+// reproduced failure would overwrite the other.
+func TestLearnKeepsUnhealthyAndUnreachableApartInTheCorpus(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	now := time.Now()
+
+	for _, spec := range []struct {
+		id     string
+		status livestore.ObservationStatus
+	}{
+		{"dep-sick", livestore.ObservationUnhealthy},
+		{"dep-gone", livestore.ObservationUnreachable},
+	} {
+		d := livestore.Deployment{
+			ID: spec.id, Scenario: "web-live-paris", Cloud: "scaleway",
+			ProjectID:       "7c98d82e-ad6d-4f4c-99ea-d1886b0f38e5",
+			AddressResource: "scaleway_lb_ip",
+			State:           livestore.StateLive,
+			CreatedAt:       now.Add(-time.Hour), ExpiresAt: now.Add(time.Hour),
+		}
+		for i := 0; i < 3; i++ {
+			d.RecordObservation(livestore.Observation{
+				At: now, Status: spec.status, Detail: "the same words exactly",
+			})
+		}
+		require.NoError(t, store.Put(d))
+	}
+
+	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
+
+	assert.Len(t, corpus(t, pitfalls), 2,
+		"one of each is two lessons, and neither may overwrite the other")
+}

--- a/internal/cli/live_learn_test.go
+++ b/internal/cli/live_learn_test.go
@@ -77,7 +77,12 @@ func runLearn(t *testing.T, rt *CommandRuntime, out *strings.Builder, args ...st
 
 func corpus(t *testing.T, dir string) []generator.PitfallEntry {
 	t.Helper()
-	payload, err := os.ReadFile(filepath.Join(dir, "scaleway.yaml"))
+	return corpusFor(t, dir, "scaleway")
+}
+
+func corpusFor(t *testing.T, dir, cloud string) []generator.PitfallEntry {
+	t.Helper()
+	payload, err := os.ReadFile(filepath.Join(dir, cloud+".yaml"))
 	require.NoError(t, err)
 	var pf generator.PitfallsFile
 	require.NoError(t, yaml.Unmarshal(payload, &pf))
@@ -162,8 +167,10 @@ func TestLearnRefusesWhenDeploymentsDisagreeOnTheResource(t *testing.T) {
 	assert.Empty(t, corpus(t, pitfalls), "attributing it to whichever came first would be a guess")
 }
 
-// The corpus is per-cloud. A candidate spanning two is not one lesson.
-func TestLearnRefusesWhenDeploymentsDisagreeOnTheCloud(t *testing.T) {
+// Breadth means "reproduced on this cloud", not "seen once on each of
+// two". One observation apiece is a coincidence of wording, and a fact
+// about neither cloud.
+func TestLearnDoesNotCountBreadthAcrossClouds(t *testing.T) {
 	rt, store, pitfalls := learnRuntime(t)
 	for _, c := range []struct{ id, cloud string }{
 		{"dep-1", "scaleway"},
@@ -178,7 +185,22 @@ func TestLearnRefusesWhenDeploymentsDisagreeOnTheCloud(t *testing.T) {
 	var out strings.Builder
 	require.NoError(t, runLearn(t, rt, &out))
 	assert.Empty(t, corpus(t, pitfalls))
-	assert.Contains(t, out.String(), "do not agree on a cloud")
+	assert.Contains(t, out.String(), "nothing has reproduced")
+}
+
+// A record naming no cloud cannot be filed anywhere, but what it observed
+// was real -- so the run says so rather than looking like it considered
+// everything.
+func TestLearnReportsRecordsThatNameNoCloud(t *testing.T) {
+	rt, store, _ := learnRuntime(t)
+	seedLearnDeployment(t, store, learnDeployment{
+		id: "dep-nocloud", detail: "health path returned HTTP 503",
+		resource: "scaleway_lb_ip", cloud: "", observations: 3,
+	})
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out))
+	assert.Contains(t, out.String(), "name no cloud")
 }
 
 // Nothing reproduced is a normal answer, and writing nothing is correct.
@@ -208,7 +230,7 @@ func TestLearnDryRunWritesNothing(t *testing.T) {
 	require.NoError(t, runLearn(t, rt, &out, "--dry-run"))
 
 	assert.Empty(t, corpus(t, pitfalls))
-	assert.Contains(t, out.String(), "would learn for scaleway_lb_ip")
+	assert.Contains(t, out.String(), "would learn for scaleway/scaleway_lb_ip")
 }
 
 // Learning twice must refresh rather than duplicate, or the corpus grows
@@ -308,4 +330,65 @@ func TestLearnKeepsUnhealthyAndUnreachableApartInTheCorpus(t *testing.T) {
 
 	assert.Len(t, corpus(t, pitfalls), 2,
 		"one of each is two lessons, and neither may overwrite the other")
+}
+
+// Evidence sufficient on its own must not be discarded by unrelated
+// evidence from another cloud. The gate runs per cloud, so a Scaleway
+// deployment that reproduced a failure teaches its lesson whatever a GCP
+// deployment happened to observe.
+func TestLearnPerCloudSoOneCloudDoesNotSuppressAnother(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	now := time.Now()
+
+	for _, spec := range []struct{ id, cloud, resource string }{
+		{"dep-scw", "scaleway", "scaleway_lb_ip"},
+		{"dep-gcp", "gcp", "google_compute_address"},
+	} {
+		d := livestore.Deployment{
+			ID: spec.id, Scenario: "web-live", Cloud: spec.cloud,
+			ProjectID:       "7c98d82e-ad6d-4f4c-99ea-d1886b0f38e5",
+			AddressResource: spec.resource,
+			State:           livestore.StateLive,
+			CreatedAt:       now.Add(-time.Hour), ExpiresAt: now.Add(time.Hour),
+		}
+		for i := 0; i < 3; i++ {
+			d.RecordObservation(livestore.Observation{
+				At: now, Status: livestore.ObservationUnhealthy, Detail: "HTTP 503 from the health path",
+			})
+		}
+		require.NoError(t, store.Put(d))
+	}
+
+	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
+
+	for _, cloud := range []string{"scaleway", "gcp"} {
+		entries := corpusFor(t, pitfalls, cloud)
+		assert.Len(t, entries, 1, "%s reproduced on its own and must teach its own lesson", cloud)
+	}
+}
+
+// A first live lesson against a corpus that does not exist yet is a
+// normal thing to happen -- a reader treats a missing file as an empty
+// corpus, so a writer must be able to create one.
+func TestLearnBootstrapsAPitfallsDirectoryThatDoesNotExistYet(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	require.NoError(t, os.RemoveAll(pitfalls))
+
+	now := time.Now()
+	d := livestore.Deployment{
+		ID: "dep-first", Scenario: "web-live-paris", Cloud: "scaleway",
+		ProjectID:       "7c98d82e-ad6d-4f4c-99ea-d1886b0f38e5",
+		AddressResource: "scaleway_lb_ip",
+		State:           livestore.StateLive,
+		CreatedAt:       now.Add(-time.Hour), ExpiresAt: now.Add(time.Hour),
+	}
+	for i := 0; i < 3; i++ {
+		d.RecordObservation(livestore.Observation{
+			At: now, Status: livestore.ObservationUnhealthy, Detail: "HTTP 503 from the health path",
+		})
+	}
+	require.NoError(t, store.Put(d))
+
+	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
+	assert.Len(t, corpus(t, pitfalls), 1, "the first lesson has nowhere to go unless the writer makes it")
 }

--- a/internal/cli/live_learn_test.go
+++ b/internal/cli/live_learn_test.go
@@ -1,0 +1,265 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/redscaresu/infrafactory/internal/config"
+	"github.com/redscaresu/infrafactory/internal/generator"
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+func learnRuntime(t *testing.T) (*CommandRuntime, *livestore.FilesystemStore, string) {
+	t.Helper()
+	h := newCommandTestHarness(t)
+	pitfalls := filepath.Join(h.WorkspaceDir, "pitfalls")
+	require.NoError(t, os.MkdirAll(pitfalls, 0o755))
+	payload, err := yaml.Marshal(generator.PitfallsFile{Provider: "scaleway"})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(pitfalls, "scaleway.yaml"), payload, 0o644))
+
+	rt := &CommandRuntime{
+		Config:        config.Config{Paths: config.PathsConfig{Pitfalls: pitfalls}},
+		livestoreRoot: h.LivestoreRoot(),
+	}
+	return rt, livestore.NewFilesystemStore(h.LivestoreRoot()), pitfalls
+}
+
+type learnDeployment struct {
+	id, detail, resource, cloud string
+	observations                int
+	drift                       bool
+}
+
+func seedLearnDeployment(t *testing.T, store *livestore.FilesystemStore, spec learnDeployment) {
+	t.Helper()
+	now := time.Now()
+	d := livestore.Deployment{
+		ID: spec.id, Scenario: "web-live-paris", Cloud: spec.cloud,
+		ProjectID:       "7c98d82e-ad6d-4f4c-99ea-d1886b0f38e5",
+		AddressResource: spec.resource,
+		State:           livestore.StateLive,
+		CreatedAt:       now.Add(-time.Hour), ExpiresAt: now.Add(time.Hour),
+	}
+	for i := 0; i < spec.observations; i++ {
+		o := livestore.Observation{At: now, Status: livestore.ObservationUnhealthy, Detail: spec.detail}
+		if spec.drift {
+			o.Status = livestore.ObservationHealthy
+			o.Version = livestore.VersionUnconfirmed
+		}
+		d.RecordObservation(o)
+	}
+	require.NoError(t, store.Put(d))
+}
+
+func runLearn(t *testing.T, rt *CommandRuntime, out *strings.Builder, args ...string) error {
+	t.Helper()
+	cmd := &cobra.Command{Use: "learn"}
+	cmd.Flags().Int("consecutive", livestore.DefaultPromotionRule.ConsecutiveProbes, "")
+	cmd.Flags().Int("deployments", livestore.DefaultPromotionRule.DistinctDeployments, "")
+	cmd.Flags().Bool("dry-run", false, "")
+	cmd.Flags().String("output", string(OutputModeHuman), "")
+	require.NoError(t, cmd.ParseFlags(args))
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetContext(context.Background())
+	return runLiveLearnCommand(cmd, nil, rt)
+}
+
+func corpus(t *testing.T, dir string) []generator.PitfallEntry {
+	t.Helper()
+	payload, err := os.ReadFile(filepath.Join(dir, "scaleway.yaml"))
+	require.NoError(t, err)
+	var pf generator.PitfallsFile
+	require.NoError(t, yaml.Unmarshal(payload, &pf))
+	return pf.Pitfalls
+}
+
+// The loop closes here: a reproduced observation becomes a rule the
+// generator will see.
+func TestLearnWritesAReproducedObservationAsSourceLive(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedLearnDeployment(t, store, learnDeployment{
+		id: "dep-1", detail: "health path returned HTTP 503",
+		resource: "scaleway_lb_ip", cloud: "scaleway", observations: 3,
+	})
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out))
+
+	entries := corpus(t, pitfalls)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "scaleway_lb_ip", entries[0].Resource, "the resource the address was resolved from")
+	assert.Equal(t, generator.LiveSource, entries[0].Source)
+	assert.Contains(t, entries[0].Rule, "RUNNING deployment")
+	assert.Contains(t, entries[0].Rule, "HTTP 503")
+}
+
+// An entry with no `last_seen` is never retired (S156a), so a live entry
+// written without one would be immortal — undoing the slice built to
+// bound the corpus.
+func TestLearnStampsEveryEntrySoItCanBeRetired(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedLearnDeployment(t, store, learnDeployment{
+		id: "dep-1", detail: "health path returned HTTP 503",
+		resource: "scaleway_lb_ip", cloud: "scaleway", observations: 3,
+	})
+
+	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
+
+	entries := corpus(t, pitfalls)
+	require.Len(t, entries, 1)
+	require.NotEmpty(t, entries[0].LastSeen, "an unstamped live entry can never be retired")
+
+	// And retirement can actually act on it.
+	retired, err := generator.RetireStaleLivePitfalls(pitfalls, "scaleway", time.Nanosecond,
+		time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	assert.Len(t, retired, 1, "the inflow must produce something the outflow can remove")
+}
+
+// The corpus is keyed by resource and a live observation names none.
+// ExtractDescriptivePitfall refuses to invent one; so does this.
+func TestLearnWritesNothingWhenNoResourceCanBeAttributed(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedLearnDeployment(t, store, learnDeployment{
+		id: "dep-1", detail: "health path returned HTTP 503",
+		resource: "", cloud: "scaleway", observations: 3,
+	})
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out))
+
+	assert.Empty(t, corpus(t, pitfalls), "a lesson nobody can attribute is not written")
+	assert.Contains(t, out.String(), "no resource can be attributed",
+		"and the operator is told, rather than the corpus looking complete")
+}
+
+// If one deployment served from an lb_ip and another from an
+// instance_ip, the failure they share is not a fact about either.
+func TestLearnRefusesWhenDeploymentsDisagreeOnTheResource(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	for _, r := range []struct{ id, resource string }{
+		{"dep-1", "scaleway_lb_ip"},
+		{"dep-2", "scaleway_instance_ip"},
+	} {
+		seedLearnDeployment(t, store, learnDeployment{
+			id: r.id, detail: "health path returned HTTP 503",
+			resource: r.resource, cloud: "scaleway", observations: 1,
+		})
+	}
+
+	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
+	assert.Empty(t, corpus(t, pitfalls), "attributing it to whichever came first would be a guess")
+}
+
+// The corpus is per-cloud. A candidate spanning two is not one lesson.
+func TestLearnRefusesWhenDeploymentsDisagreeOnTheCloud(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	for _, c := range []struct{ id, cloud string }{
+		{"dep-1", "scaleway"},
+		{"dep-2", "gcp"},
+	} {
+		seedLearnDeployment(t, store, learnDeployment{
+			id: c.id, detail: "health path returned HTTP 503",
+			resource: "scaleway_lb_ip", cloud: c.cloud, observations: 1,
+		})
+	}
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out))
+	assert.Empty(t, corpus(t, pitfalls))
+	assert.Contains(t, out.String(), "do not agree on a cloud")
+}
+
+// Nothing reproduced is a normal answer, and writing nothing is correct.
+func TestLearnWritesNothingWhenNothingReproduced(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedLearnDeployment(t, store, learnDeployment{
+		id: "dep-1", detail: "health path returned HTTP 503",
+		resource: "scaleway_lb_ip", cloud: "scaleway", observations: 1,
+	})
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out))
+	assert.Empty(t, corpus(t, pitfalls))
+	assert.Contains(t, out.String(), "nothing has reproduced")
+}
+
+// Writing to the corpus is the one irreversible act in this arc, so it
+// can be previewed.
+func TestLearnDryRunWritesNothing(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedLearnDeployment(t, store, learnDeployment{
+		id: "dep-1", detail: "health path returned HTTP 503",
+		resource: "scaleway_lb_ip", cloud: "scaleway", observations: 3,
+	})
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out, "--dry-run"))
+
+	assert.Empty(t, corpus(t, pitfalls))
+	assert.Contains(t, out.String(), "would learn for scaleway_lb_ip")
+}
+
+// Learning twice must refresh rather than duplicate, or the corpus grows
+// once per cron tick and retention means "first observed".
+func TestLearnTwiceRefreshesRatherThanDuplicating(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedLearnDeployment(t, store, learnDeployment{
+		id: "dep-1", detail: "health path returned HTTP 503",
+		resource: "scaleway_lb_ip", cloud: "scaleway", observations: 3,
+	})
+
+	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
+	first := corpus(t, pitfalls)
+	require.Len(t, first, 1)
+
+	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
+	assert.Len(t, corpus(t, pitfalls), 1, "the same lesson twice is one lesson")
+}
+
+// The version-drift rule says the thing that is actually surprising: the
+// apply succeeded and the service did not change.
+func TestLearnDescribesVersionDriftAsWhatItIs(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedLearnDeployment(t, store, learnDeployment{
+		id: "dep-1", detail: `the record claims nginx:1.28 but / does not mention "1.28"`,
+		resource: "scaleway_lb_ip", cloud: "scaleway", observations: 3, drift: true,
+	})
+
+	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
+
+	entries := corpus(t, pitfalls)
+	require.Len(t, entries, 1)
+	assert.Contains(t, entries[0].Rule, "answered normally while serving a version")
+	assert.Contains(t, entries[0].Rule, "does not mean the service restarted")
+}
+
+// A descriptive rule that invents a remedy is worse than one that admits
+// it has none; the prescriptive form comes from an upgrade diff (S156d).
+func TestLearnDoesNotInventARemedy(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedLearnDeployment(t, store, learnDeployment{
+		id: "dep-1", detail: "health path returned HTTP 503",
+		resource: "scaleway_lb_ip", cloud: "scaleway", observations: 3,
+	})
+
+	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
+
+	rule := corpus(t, pitfalls)[0].Rule
+	for _, imperative := range []string{"you should", "add a", "set the", "use a"} {
+		assert.NotContains(t, strings.ToLower(rule), imperative,
+			"a descriptive rule states what was seen, not what to do")
+	}
+	assert.Contains(t, rule, "never confirmed", "and it says what it could not establish")
+}

--- a/internal/cli/live_upgrade.go
+++ b/internal/cli/live_upgrade.go
@@ -233,7 +233,11 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 		// balancer. Verifying against the address captured at first
 		// deploy would probe infrastructure this deployment no longer
 		// owns, and leave every later observation pointed there too.
-		if address, addrErr := harness.LiveEndpoint(d.WorkDir, "load_balancer"); addrErr == nil && address != "" {
+		// The resource type moves with the address. Replacement HCL can
+		// serve the same deployment from a different resource, and a
+		// stale type would attribute every later live lesson to
+		// something the deployment no longer has.
+		if address, resource, addrErr := harness.LiveEndpointResource(d.WorkDir, "load_balancer"); addrErr == nil && address != "" {
 			if address != d.Address {
 				stages = append(stages, StageSummary{
 					Layer: "live", Stage: "upgrade_address", Status: StageStatusPass,
@@ -241,6 +245,7 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 				})
 			}
 			d.Address = address
+			d.AddressResource = resource
 		} else if d.Address != "" {
 			// Said out loud rather than assumed unchanged: everything
 			// after this probes an address nothing just confirmed.
@@ -624,11 +629,12 @@ func assertRunProjectOurs(ctx context.Context, runtime *CommandRuntime, projectI
 // losing them does not corrupt the record -- it quietly weakens the
 // learning signal, which is harder to notice.
 //
-// An allow-list of three fields, not a blanket copy: anything an upgrade
-// does not own belongs to whoever wrote it last.
+// An allow-list of the four fields an upgrade owns, not a blanket copy:
+// anything else belongs to whoever wrote it last.
 func mergeUpgradeOntoFresh(fresh, upgraded livestore.Deployment) livestore.Deployment {
 	fresh.Tag = upgraded.Tag
 	fresh.UpgradedAt = upgraded.UpgradedAt
 	fresh.Address = upgraded.Address
+	fresh.AddressResource = upgraded.AddressResource
 	return fresh
 }

--- a/internal/generator/pitfalls.go
+++ b/internal/generator/pitfalls.go
@@ -18,6 +18,20 @@ type PitfallEntry struct {
 	Source         string `yaml:"source"`
 	DiscoveredFrom string `yaml:"discovered_from,omitempty"`
 
+	// ObservedKey is the stable identity of a `source: live` entry: the
+	// normalized detail the observation was grouped by.
+	//
+	// It exists because the rule TEXT is not stable. A live rule states
+	// its evidence — how many deployments, how long a run — and those
+	// numbers grow as the same failure keeps being observed. Matching on
+	// the text would therefore append a new entry every time the counters
+	// ticked, so the corpus would grow once per cron tick while looking
+	// like it was refreshing (S156c, pass 77).
+	//
+	// The key is what does not change: the same failure, however much
+	// evidence accumulates for it.
+	ObservedKey string `yaml:"observed_key,omitempty"`
+
 	// LastSeen is when the signal behind this rule was last observed,
 	// RFC3339. Only `source: live` entries carry it, and only they are
 	// retired for going stale (S156a).

--- a/internal/generator/pitfalls.go
+++ b/internal/generator/pitfalls.go
@@ -19,7 +19,8 @@ type PitfallEntry struct {
 	DiscoveredFrom string `yaml:"discovered_from,omitempty"`
 
 	// ObservedKey is the stable identity of a `source: live` entry: the
-	// normalized detail the observation was grouped by.
+	// promotion gate's OWN key for the observation it came from — the
+	// status, whether it was version drift, and the normalized detail.
 	//
 	// It exists because the rule TEXT is not stable. A live rule states
 	// its evidence — how many deployments, how long a run — and those
@@ -27,6 +28,13 @@ type PitfallEntry struct {
 	// the text would therefore append a new entry every time the counters
 	// ticked, so the corpus would grow once per cron tick while looking
 	// like it was refreshing (S156c, pass 77).
+	//
+	// It carries the whole of the gate's key rather than the detail alone
+	// because the gate keeps `unhealthy` apart from `unreachable`, and a
+	// health failure apart from a version mismatch. Persisting anything
+	// narrower would collapse distinctions it had just been careful to
+	// preserve, and one reproduced failure would overwrite another
+	// (pass 85).
 	//
 	// The key is what does not change: the same failure, however much
 	// evidence accumulates for it.

--- a/internal/generator/pitfalls_learn.go
+++ b/internal/generator/pitfalls_learn.go
@@ -835,10 +835,8 @@ func AppendPitfall(pitfallsDir, cloud string, pitfall LearnedPitfall) error {
 
 	filePath := filepath.Join(pitfallsDir, cloud+".yaml")
 
-	// Ensure directory exists.
-	if err := os.MkdirAll(pitfallsDir, 0o755); err != nil {
-		return fmt.Errorf("create pitfalls directory: %w", err)
-	}
+	// The directory is created by writePitfallsFile, which is the thing
+	// that needs it.
 
 	// Load existing file or start fresh.
 	var pf PitfallsFile
@@ -919,6 +917,15 @@ func writePitfallsFile(pitfallsDir, filePath, cloud string, pf *PitfallsFile) er
 	out, err := yaml.Marshal(pf)
 	if err != nil {
 		return fmt.Errorf("marshal pitfalls: %w", err)
+	}
+	// Here rather than in each caller. Every write needs the directory,
+	// the temp file below is created INSIDE it, and a reader is a missing
+	// file away from an empty corpus -- so a first write against a fresh
+	// corpus is a normal thing to do, not an error. It was an obligation
+	// each caller had to remember, and AppendLivePitfall did not (S156c,
+	// pass 86).
+	if err := os.MkdirAll(pitfallsDir, 0o755); err != nil {
+		return fmt.Errorf("create pitfalls directory: %w", err)
 	}
 	// Use os.CreateTemp so two concurrent learn-paths racing on the
 	// same provider can't clobber each other's tmp file before either

--- a/internal/generator/pitfalls_retire.go
+++ b/internal/generator/pitfalls_retire.go
@@ -285,16 +285,36 @@ func AppendLivePitfall(pitfallsDir, cloud string, pitfall LearnedPitfall, now ti
 		return nil
 	}
 
-	if err := AppendPitfall(pitfallsDir, cloud, pitfall); err != nil {
+	// Appended directly rather than through AppendPitfall, whose
+	// deduplication is deliberately FUZZY -- it matches on significant
+	// word overlap, which is right for provider diagnostics that vary in
+	// phrasing between runs.
+	//
+	// Live rules are the opposite: generated from a template, so two
+	// genuinely different failures on the same resource share nearly
+	// every word ("Observed on a RUNNING deployment, after the apply
+	// reported success: ... Evidence: ..."). Fuzzy matching would drop
+	// the second as a duplicate of the first and the corpus would keep
+	// whichever happened to be observed earliest, silently.
+	//
+	// Exact identity is also SOUND here in a way it is not for the fuzzy
+	// path: the text is derived deterministically from the candidate, so
+	// the same candidate always produces the same string, and a different
+	// string means a different candidate.
+	pf, filePath, err := loadCloudPitfalls(pitfallsDir, cloud)
+	if err != nil {
 		return err
 	}
-
-	// Stamp it. AppendPitfall may have deduplicated against a similar
-	// existing rule, in which case there is nothing carrying this exact
-	// text to stamp -- and that is not an error: the corpus already says
-	// what this observation would have said.
-	if err := TouchLivePitfall(pitfallsDir, cloud, pitfall.Resource, pitfall.Rule, now); err != nil {
-		return nil
+	if pf == nil {
+		pf = &PitfallsFile{Provider: cloud}
 	}
-	return nil
+
+	pf.Pitfalls = append(pf.Pitfalls, PitfallEntry{
+		Resource:       pitfall.Resource,
+		Rule:           pitfall.Rule,
+		Source:         LiveSource,
+		DiscoveredFrom: pitfall.DiscoveredFrom,
+		LastSeen:       now.UTC().Format(time.RFC3339),
+	})
+	return writePitfallsFile(pitfallsDir, filePath, cloud, pf)
 }

--- a/internal/generator/pitfalls_retire.go
+++ b/internal/generator/pitfalls_retire.go
@@ -277,11 +277,21 @@ func TouchLivePitfall(pitfallsDir, cloud, resource, rule string, now time.Time) 
 //
 // A rule seen again REFRESHES rather than duplicates, which is what makes
 // retention mean "last observed" rather than "first observed".
-func AppendLivePitfall(pitfallsDir, cloud string, pitfall LearnedPitfall, now time.Time) error {
+func AppendLivePitfall(pitfallsDir, cloud, observedKey string, pitfall LearnedPitfall, now time.Time) error {
 	pitfall.Source = LiveSource
+	if observedKey == "" {
+		return fmt.Errorf("a live pitfall needs an observed key, or it can never be recognised again")
+	}
 
 	// Already known: this is a re-observation, not a new lesson.
-	if err := TouchLivePitfall(pitfallsDir, cloud, pitfall.Resource, pitfall.Rule, now); err == nil {
+	//
+	// Matched on the KEY rather than the rule text, because the text
+	// states its evidence and that evidence grows. Refreshing updates the
+	// text too, so the corpus carries the strongest evidence seen rather
+	// than the first.
+	if refreshed, err := refreshLivePitfall(pitfallsDir, cloud, observedKey, pitfall, now); err != nil {
+		return err
+	} else if refreshed {
 		return nil
 	}
 
@@ -314,7 +324,33 @@ func AppendLivePitfall(pitfallsDir, cloud string, pitfall LearnedPitfall, now ti
 		Rule:           pitfall.Rule,
 		Source:         LiveSource,
 		DiscoveredFrom: pitfall.DiscoveredFrom,
+		ObservedKey:    observedKey,
 		LastSeen:       now.UTC().Format(time.RFC3339),
 	})
 	return writePitfallsFile(pitfallsDir, filePath, cloud, pf)
+}
+
+// refreshLivePitfall updates an existing live entry in place, reporting
+// whether it found one.
+//
+// The rule text is rewritten as well as the timestamp: a candidate seen
+// on more deployments is the same lesson with better evidence, and the
+// corpus should carry the better version rather than whichever was
+// written first.
+func refreshLivePitfall(pitfallsDir, cloud, observedKey string, pitfall LearnedPitfall, now time.Time) (bool, error) {
+	pf, filePath, err := loadCloudPitfalls(pitfallsDir, cloud)
+	if err != nil || pf == nil {
+		return false, err
+	}
+
+	for i, entry := range pf.Pitfalls {
+		if entry.Source != LiveSource || entry.Resource != pitfall.Resource || entry.ObservedKey != observedKey {
+			continue
+		}
+		pf.Pitfalls[i].Rule = pitfall.Rule
+		pf.Pitfalls[i].DiscoveredFrom = pitfall.DiscoveredFrom
+		pf.Pitfalls[i].LastSeen = now.UTC().Format(time.RFC3339)
+		return true, writePitfallsFile(pitfallsDir, filePath, cloud, pf)
+	}
+	return false, nil
 }

--- a/internal/generator/pitfalls_retire.go
+++ b/internal/generator/pitfalls_retire.go
@@ -264,3 +264,37 @@ func TouchLivePitfall(pitfallsDir, cloud, resource, rule string, now time.Time) 
 
 	return fmt.Errorf("no live pitfall for %s matching that rule", resource)
 }
+
+// AppendLivePitfall records a lesson learned from a running service,
+// stamped so it can later be retired.
+//
+// The stamp is not optional. S156a never retires an entry with no
+// `last_seen` -- absence means nobody recorded when the rule was last
+// true, which is not evidence it stopped being true -- so a live entry
+// written without one would be **immortal**, which is precisely what the
+// retirement path exists to prevent. Writing the inflow without the
+// timestamp would quietly undo the slice built to bound it.
+//
+// A rule seen again REFRESHES rather than duplicates, which is what makes
+// retention mean "last observed" rather than "first observed".
+func AppendLivePitfall(pitfallsDir, cloud string, pitfall LearnedPitfall, now time.Time) error {
+	pitfall.Source = LiveSource
+
+	// Already known: this is a re-observation, not a new lesson.
+	if err := TouchLivePitfall(pitfallsDir, cloud, pitfall.Resource, pitfall.Rule, now); err == nil {
+		return nil
+	}
+
+	if err := AppendPitfall(pitfallsDir, cloud, pitfall); err != nil {
+		return err
+	}
+
+	// Stamp it. AppendPitfall may have deduplicated against a similar
+	// existing rule, in which case there is nothing carrying this exact
+	// text to stamp -- and that is not an error: the corpus already says
+	// what this observation would have said.
+	if err := TouchLivePitfall(pitfallsDir, cloud, pitfall.Resource, pitfall.Rule, now); err != nil {
+		return nil
+	}
+	return nil
+}

--- a/internal/generator/pitfalls_retire_test.go
+++ b/internal/generator/pitfalls_retire_test.go
@@ -227,3 +227,61 @@ func TestRetireRefusesACloudNameThatEscapesTheCorpus(t *testing.T) {
 		assert.Error(t, err, "touch must refuse it too: %q", cloud)
 	}
 }
+
+// AppendPitfall's deduplication is deliberately FUZZY: it matches on
+// significant word overlap, which is right for provider diagnostics that
+// vary in phrasing between runs.
+//
+// Live rules are the opposite — generated from a template, so two
+// genuinely different failures on one resource share nearly every word.
+// Routing them through the fuzzy path would keep whichever was observed
+// first and discard the rest, silently.
+func TestAppendLiveKeepsDistinctLessonsForOneResource(t *testing.T) {
+	dir := writeCorpus(t)
+	now := time.Now()
+
+	const preamble = "Observed on a RUNNING deployment, after the apply reported success: "
+	for _, detail := range []string{
+		preamble + "health path returned HTTP 503. Evidence: persistent, across 1 deployment(s).",
+		preamble + "health path is unreachable. Evidence: persistent, across 1 deployment(s).",
+	} {
+		require.NoError(t, AppendLivePitfall(dir, "scaleway",
+			LearnedPitfall{Resource: "scaleway_lb_ip", Rule: detail}, now))
+	}
+
+	entries := readCorpus(t, dir)
+	require.Len(t, entries, 2, "two different failures are two lessons, however alike the wording")
+	for _, e := range entries {
+		assert.Equal(t, LiveSource, e.Source)
+		assert.NotEmpty(t, e.LastSeen, "or it could never be retired")
+	}
+}
+
+// The same lesson twice is one lesson, refreshed.
+func TestAppendLiveRefreshesAnIdenticalLesson(t *testing.T) {
+	dir := writeCorpus(t)
+	learned := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	seen := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	p := LearnedPitfall{Resource: "scaleway_lb_ip", Rule: "the same words exactly"}
+
+	require.NoError(t, AppendLivePitfall(dir, "scaleway", p, learned))
+	require.NoError(t, AppendLivePitfall(dir, "scaleway", p, seen))
+
+	entries := readCorpus(t, dir)
+	require.Len(t, entries, 1)
+	assert.Equal(t, seen.UTC().Format(time.RFC3339), entries[0].LastSeen,
+		"retention means last observed, not first")
+}
+
+// A cloud with no corpus yet must gain one rather than fail: the first
+// live lesson for a provider should not need a file to exist already.
+func TestAppendLiveCreatesACorpusThatDoesNotExistYet(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, AppendLivePitfall(dir, "scaleway",
+		LearnedPitfall{Resource: "scaleway_lb_ip", Rule: "first lesson"}, time.Now()))
+
+	entries := readCorpus(t, dir)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "first lesson", entries[0].Rule)
+}

--- a/internal/generator/pitfalls_retire_test.go
+++ b/internal/generator/pitfalls_retire_test.go
@@ -245,7 +245,7 @@ func TestAppendLiveKeepsDistinctLessonsForOneResource(t *testing.T) {
 		preamble + "health path returned HTTP 503. Evidence: persistent, across 1 deployment(s).",
 		preamble + "health path is unreachable. Evidence: persistent, across 1 deployment(s).",
 	} {
-		require.NoError(t, AppendLivePitfall(dir, "scaleway",
+		require.NoError(t, AppendLivePitfall(dir, "scaleway", detail,
 			LearnedPitfall{Resource: "scaleway_lb_ip", Rule: detail}, now))
 	}
 
@@ -264,8 +264,8 @@ func TestAppendLiveRefreshesAnIdenticalLesson(t *testing.T) {
 	seen := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
 	p := LearnedPitfall{Resource: "scaleway_lb_ip", Rule: "the same words exactly"}
 
-	require.NoError(t, AppendLivePitfall(dir, "scaleway", p, learned))
-	require.NoError(t, AppendLivePitfall(dir, "scaleway", p, seen))
+	require.NoError(t, AppendLivePitfall(dir, "scaleway", "the-key", p, learned))
+	require.NoError(t, AppendLivePitfall(dir, "scaleway", "the-key", p, seen))
 
 	entries := readCorpus(t, dir)
 	require.Len(t, entries, 1)
@@ -278,10 +278,53 @@ func TestAppendLiveRefreshesAnIdenticalLesson(t *testing.T) {
 func TestAppendLiveCreatesACorpusThatDoesNotExistYet(t *testing.T) {
 	dir := t.TempDir()
 
-	require.NoError(t, AppendLivePitfall(dir, "scaleway",
+	require.NoError(t, AppendLivePitfall(dir, "scaleway", "first-key",
 		LearnedPitfall{Resource: "scaleway_lb_ip", Rule: "first lesson"}, time.Now()))
 
 	entries := readCorpus(t, dir)
 	require.Len(t, entries, 1)
 	assert.Equal(t, "first lesson", entries[0].Rule)
+}
+
+// A live rule states its evidence -- how many deployments, how long a
+// run -- and that evidence GROWS as the same failure keeps being
+// observed. Matching on the text would append a new entry every time the
+// counters ticked, so the corpus would grow once per cron tick while
+// looking like it was refreshing.
+func TestAppendLiveRefreshesWhenTheEvidenceChangesButTheFailureDoesNot(t *testing.T) {
+	dir := writeCorpus(t)
+	learned := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	seen := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	const key = "health path returned HTTP 503"
+
+	require.NoError(t, AppendLivePitfall(dir, "scaleway", key, LearnedPitfall{
+		Resource: "scaleway_lb_ip",
+		Rule:     "Observed: HTTP 503. Evidence: persistent, across 1 deployment(s), longest run 3.",
+	}, learned))
+
+	// Same failure, more evidence, so a different rule text.
+	require.NoError(t, AppendLivePitfall(dir, "scaleway", key, LearnedPitfall{
+		Resource: "scaleway_lb_ip",
+		Rule:     "Observed: HTTP 503. Evidence: persistent, across 4 deployment(s), longest run 9.",
+	}, seen))
+
+	entries := readCorpus(t, dir)
+	require.Len(t, entries, 1, "more evidence for one failure is not a second lesson")
+	assert.Contains(t, entries[0].Rule, "across 4 deployment(s)",
+		"and the corpus carries the stronger evidence, not the first written")
+	assert.Equal(t, seen.UTC().Format(time.RFC3339), entries[0].LastSeen)
+}
+
+// Without a key an entry can never be recognised again, so it would
+// duplicate on every pass. Refusing is better than writing something
+// unmaintainable.
+func TestAppendLiveRefusesWithoutAnObservedKey(t *testing.T) {
+	dir := writeCorpus(t)
+
+	err := AppendLivePitfall(dir, "scaleway", "",
+		LearnedPitfall{Resource: "scaleway_lb_ip", Rule: "r"}, time.Now())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "never be recognised again")
+	assert.Empty(t, readCorpus(t, dir))
 }

--- a/internal/harness/real_probe.go
+++ b/internal/harness/real_probe.go
@@ -287,24 +287,46 @@ func loadLiveTerraformState(path string) (terraformState, error) {
 // the live deployment so `live ls` can say where the service actually
 // answers -- an estate you cannot reach is one nobody will check on.
 func LiveEndpoint(workDir, target string) (string, error) {
+	host, _, err := LiveEndpointResource(workDir, target)
+	return host, err
+}
+
+// LiveEndpointResource is LiveEndpoint plus the Terraform resource type
+// the address came from.
+//
+// The type is what makes a live observation attributable. An observation
+// says "the thing at this address returned 503" and names no resource --
+// `ExtractDescriptivePitfall` skips such a detail rather than fabricate
+// one, correctly. But the address was not arbitrary: it was resolved from
+// a specific resource in state, and that resource is what the lesson is
+// legitimately about (S156c).
+//
+// Reporting it here rather than guessing later keeps the attribution at
+// the only point where it is a fact rather than an inference.
+func LiveEndpointResource(workDir, target string) (string, string, error) {
 	state, err := loadLiveTerraformState(filepath.Join(workDir, LiveStateFilename))
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return resolveProbeHost(state, target)
+	return resolveProbeHostResource(state, target)
 }
 
 func resolveProbeHost(state terraformState, target string) (string, error) {
+	host, _, err := resolveProbeHostResource(state, target)
+	return host, err
+}
+
+func resolveProbeHostResource(state terraformState, target string) (string, string, error) {
 	resourceTypes := probeTargetResourceTypes(target)
 	if len(resourceTypes) == 0 {
-		return "", fmt.Errorf("no live endpoint mapping for target %q", target)
+		return "", "", fmt.Errorf("no live endpoint mapping for target %q", target)
 	}
 	for _, resourceType := range resourceTypes {
 		if host := findHostForResourceType(state, resourceType); host != "" {
-			return host, nil
+			return host, resourceType, nil
 		}
 	}
-	return "", fmt.Errorf("could not resolve live endpoint for target %q", target)
+	return "", "", fmt.Errorf("could not resolve live endpoint for target %q", target)
 }
 
 // probeTargetResourceTypes returns the Terraform resource types whose live

--- a/internal/livestore/livestore.go
+++ b/internal/livestore/livestore.go
@@ -79,6 +79,25 @@ type Deployment struct {
 	// configuration. Zero means never.
 	UpgradedAt time.Time `json:"upgraded_at,omitempty"`
 
+	// Cloud is the provider this deployment was applied to, recorded so a
+	// lesson learned from it lands in the right corpus. Taken from the
+	// scenario at deploy time, because that is where it is a fact.
+	Cloud string `json:"cloud,omitempty"`
+
+	// AddressResource is the Terraform resource type the probed address
+	// came from, e.g. `scaleway_lb_ip`.
+	//
+	// It is what makes a live observation attributable. An observation
+	// says "the thing at this address returned 503" and names no
+	// resource, and the corpus is keyed by resource -- so without this a
+	// live signal could only become a pitfall by fabricating one, which
+	// ExtractDescriptivePitfall refuses to do for exactly the right
+	// reason (S156c).
+	//
+	// Recorded at deploy time because that is the only moment it is a
+	// fact rather than an inference.
+	AddressResource string `json:"address_resource,omitempty"`
+
 	// VersionPath, when declared, is probed to check that the service is
 	// running the version this record claims. Snapshotted with the rest.
 	VersionPath string `json:"version_path,omitempty"`

--- a/internal/livestore/promotion.go
+++ b/internal/livestore/promotion.go
@@ -95,6 +95,26 @@ type Candidate struct {
 	Reason PromotionReason
 }
 
+// Key is the candidate's identity, and the identity anything persisting
+// it must use.
+//
+// The gate groups on (status, drift, normalized detail) and deliberately
+// keeps `unhealthy` apart from `unreachable`, and a health failure apart
+// from version drift. A store that keyed on the detail alone would
+// collapse distinctions the gate had just been careful to preserve, and
+// one reproduced failure would overwrite another.
+//
+// Derived here rather than reassembled by callers so the two identities
+// cannot drift apart — the same reason the dry-run and the real
+// retirement share one rule.
+func (c Candidate) Key() string {
+	drift := "health"
+	if c.VersionDrift {
+		drift = "version"
+	}
+	return string(c.Status) + "\x00" + drift + "\x00" + c.Detail
+}
+
 // PromotionReason is why a candidate cleared the gate.
 type PromotionReason string
 


### PR DESCRIPTION
Closes the live-learning loop. `infrafactory live learn` takes the observations
S156b's promotion gate judged reproduced and writes them into the corpus as
`source: live` pitfalls — the first time this system learns from a deployment
that Terraform already reported as successful.

## What it does

- `live learn` (`--consecutive`, `--deployments`, `--dry-run`) runs the promotion
  gate per cloud and appends each promoted candidate.
- Rules are **descriptive only**. They say what was observed and what the evidence
  was, and stop. A descriptive rule that invents a remedy is worse than one that
  admits it has none; the prescriptive form comes from an upgrade diff in S156d.
- An observation whose version was never confirmed says so in its own rule, so
  nothing is blamed on an image tag nobody verified (S155a).

## Two refusals, both deliberate

- **Nothing is written without a resource.** The corpus is keyed by resource and
  the generator steers on it, but a live observation names none — "the thing at
  this address returned 503" is about an endpoint. It uses the resource the
  address was *resolved from*, a fact recorded at deploy time, or it writes
  nothing and says so. Same rule `ExtractDescriptivePitfall` already follows.
- **Nothing is written that cannot later be retired.** Every entry carries
  `last_seen`, so S156a's retirement can act on it. An entry the corpus cannot
  shed steers generation forever.

## Identity, which took three of the four review passes

The corpus needs to recognise a lesson it has already learned. Three answers,
each correct and incomplete:

- **Not the rule text** (pass 77) — a live rule *states its evidence*, and the
  evidence grows. Matching on text appends a fresh entry every time the counters
  tick, so the corpus grows once per cron tick while appearing to refresh.
- **Not the normalized detail alone** (pass 85) — the gate groups on
  *(status, drift, detail)* and keeps `unhealthy` apart from `unreachable`, and a
  health failure apart from a version mismatch. Anything narrower lets one
  reproduced failure overwrite another.
- **The cloud belongs in it too** (pass 86) — the corpus is per-cloud, so
  promotion is partitioned by cloud *before* the gate. Filtering cross-cloud
  candidates afterwards discarded evidence sufficient on its own, and let a
  breadth threshold count deployments across clouds — promoting a coincidence of
  wording that is a fact about neither.

The fix that ended it is structural rather than a better answer:
`Candidate.Key()` is derived by the gate that defines the identity, so nothing
downstream restates it. `cmd/pitfall-merge` keys on it as well — found by
enumerating the readers *before* the next review rather than after, which is
S156a's lesson applied on purpose.

## Review

Codex passes 77, 85, 86, 87 archived under `docs/review-passes/`. Pass 87 clean.
Every finding accepted; none declined.

## Not in this PR

S156d (prescriptive rules from upgrade diffs) and S156e (the validation run: one
live-sourced pitfall that demonstrably prevents a repeat). No real-cloud run is
needed to review this — the tests fake the cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD