### PR TITLE
S157a: reconcile against the API

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,41 @@
 
 Last updated: 2026-08-31
 
+## 2026-09-01 — S157a: reconcile against the API
+
+ADR-0024 called this "the largest remaining hole" in it, and the hole was worse
+than "not built yet". `livestore.go` stated **as fact** that the reaper
+"reconciles against the API rather than trusting this file alone." Nothing did:
+`live reap` calls `store.Reapable()` and never contacts Scaleway. A comment
+asserting a guard that does not exist is worse than no comment, because it makes
+the hole invisible to the next person reading for it.
+
+The failure is quiet and expensive. `.infrafactory/live` sits **inside** the
+working directory — wipe it, switch branches, or run from a fresh clone, and the
+records are gone while the load balancer, the instance and the public IPv4s keep
+running with a TTL nobody will ever enforce. Every signal reports clean, because
+every signal reads the store. That is the shape of D6.
+
+`live reconcile` reports both directions and **never destroys anything**: an
+unrecorded project is by definition something the records cannot explain, and
+destroying what you cannot explain is how a reconciler becomes the incident.
+
+It is precise rather than heuristic because of ADR-0025's stamp, using the *same*
+`IsInfrafactoryRunProject` predicate that guards teardown — one definition of
+ownership rather than one here and another in the guard. Unstamped projects are
+never considered in either direction.
+
+**Three refusals, all the same failure mode.** Missing credentials, an
+unreachable API, and a >50-page estate each render as "nothing unaccounted for"
+if handled the easy way — the false green S139 exists to prevent. All three fail
+instead.
+
+**Verified against real Scaleway, not a fake.** An empty stamped project was
+created, left unregistered, confirmed in `List`, confirmed flagged by `Reconcile`
+against an empty store, and deleted. Cost: nothing, since projects are free.
+The baseline is worth recording — **3 projects in the organization, 0 stamped**,
+so the account holds no leaked run projects and the D6 fix is holding.
+
 ## 2026-09-01 — S160b: real cloud is decided at start time, not on the wire
 
 S160a stopped a page the server did not serve from reaching the API. This closes

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -589,3 +589,59 @@ This matters beyond readability: the promotion gate groups on that detail, so
 without it the most dangerous shape live observation can find — the service and
 the record disagreeing while every other signal reports success — could never
 become a candidate lesson.
+
+## Amendment, 2026-09-01 (S157a): reconcile-against-API, delivered
+
+Rule 3's outstanding promise is kept. `live reconcile` compares the
+organization's projects against the live store and reports both directions:
+stamped projects no record explains, and records naming projects the API says do
+not exist.
+
+**The gap was worse than "not built yet".** `livestore.go` stated, as fact, that
+the reaper "reconciles against the API rather than trusting this file alone."
+Nothing did — `live reap` calls `store.Reapable()` and never contacts Scaleway.
+A comment asserting a guard that does not exist is worse than no comment: it
+makes the hole invisible to the next person who reads for it. That comment now
+describes what is true, and says explicitly that the reaper is store-driven.
+
+### It reports; it never destroys
+
+An unrecorded project is *by definition* something this system's records do not
+explain, and destroying what you cannot explain is how a reconciler becomes the
+incident. The command prints project ids and a human decides.
+
+### Precise rather than heuristic, because of the stamp
+
+Since ADR-0025 every deployment owns a project named `if-run-…` and carrying a
+fixed description. Reconciliation is therefore a set difference over a stamp
+infrafactory itself wrote, using `IsInfrafactoryRunProject` — the *same*
+predicate that guards teardown, so "infrafactory created this" has one definition
+rather than one here and another in the guard. A project without the stamp is
+never considered in either direction.
+
+### Three ways it refuses rather than reporting clean
+
+Every one of these renders as "nothing unaccounted for" if handled the easy way,
+which is the false green S139 exists to prevent:
+
+- **missing credentials** — the cloud would read as empty and every deployment
+  would look accounted for;
+- **an unreachable API** — same, and an error is not an empty organization;
+- **more than 50 pages** — a truncated estate is a partial answer presented as a
+  complete one, so `List` fails instead of returning what it got.
+
+A **released** deployment still accounts for its project. Teardown records the
+release, but this ADR's unreclaimable case is exactly a project that outlives it,
+so ignoring released records would send an operator to investigate something the
+store already explains.
+
+### Verified against real Scaleway
+
+Not against a fake. An empty stamped project was created through the Account API,
+left unregistered, confirmed present in `List` with the stamp read correctly,
+confirmed flagged as unrecorded by `Reconcile` against an empty store, and
+deleted. **Cost: nothing** — Scaleway projects are free; only resources bill.
+
+The baseline that run printed is worth recording: **3 projects in the
+organization, 0 carrying infrafactory's stamp.** The account holds no leaked run
+projects, so the D6 fix is holding.

--- a/docs/review-passes/pass90.md
+++ b/docs/review-passes/pass90.md
@@ -1,0 +1,24 @@
+# Codex review pass 90 — S157a
+
+**Clean.** No correctness regression. It read the new command, the Scaleway
+project listing and the livestore reconciliation as consistent with the stated
+safety goals, and covered by focused tests.
+
+Worth noting what carried more weight than the review here: **the real-cloud
+canary**. The logic was already provably correct against a fake — the fake is
+where the pagination refusal and the released-deployment rule were pinned. What
+the fake could not answer is whether the *stamp* survives a round trip through
+the real Account API: whether `List` returns the description field at all,
+whether it comes back byte-identical to `RunProjectDescription`, and therefore
+whether `IsInfrafactoryRunProject` recognises a project this tool created
+moments earlier.
+
+If it did not, every unrecorded project would be silently invisible and the
+command would report a clean estate forever — the exact failure it exists to
+prevent, and one no unit test would ever show. It does: `stamped=true` on a
+project created and listed against real Scaleway.
+
+That is the same lesson as the Layer 3 canary finding sweep-after-destroy and
+D6's `project_default`: against a mock these things are free to get wrong.
+
+## Nothing declined this pass.

--- a/internal/cli/live_command.go
+++ b/internal/cli/live_command.go
@@ -89,6 +89,16 @@ func newLiveCmd(cfg *rootConfig) *cobra.Command {
 	learn.Flags().Bool("dry-run", false, "Report what would be learned without writing to the corpus")
 	cmd.AddCommand(learn)
 
+	reconcile := &cobra.Command{
+		Use:   "reconcile",
+		Short: "Compare the organization's projects against the live store",
+		Long: "Reports infrafactory projects the cloud holds that no live record explains, and " +
+			"records naming projects that no longer exist. Never destroys anything.",
+		Args: cobra.NoArgs,
+		RunE: cfg.withRuntime("live reconcile", runLiveReconcileCommand),
+	}
+	cmd.AddCommand(reconcile)
+
 	reap := &cobra.Command{
 		Use:   "reap",
 		Short: "Destroy every live deployment whose TTL has run out",

--- a/internal/cli/live_reconcile.go
+++ b/internal/cli/live_reconcile.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/redscaresu/infrafactory/internal/harness"
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+// runLiveReconcileCommand compares the organization's projects against
+// the live store (S157a).
+//
+// # Why this exists
+//
+// ADR-0024 promised it and S153 did not deliver it. `livestore.go` said,
+// as a statement of fact, that the reaper "reconciles against the API
+// rather than trusting this file alone" -- and nothing did. `live reap`
+// calls `store.Reapable()` and never contacts Scaleway.
+//
+// The store lives at `.infrafactory/live`, INSIDE the working directory.
+// Wipe it, switch branches, or run from a fresh clone, and the records
+// are gone while the load balancer, the instance and the public IPv4s
+// keep running with a TTL nobody will ever enforce. Every signal in the
+// system reports clean, because every signal reads the store.
+//
+// That is the shape of D6: a leak whose only symptom is the bill.
+//
+// # Why it never destroys anything
+//
+// An unrecorded project is BY DEFINITION something this system's records
+// do not explain. Destroying what you cannot explain is how a reconciler
+// becomes the incident, and the blast radius here is somebody's running
+// infrastructure. It reports project ids and a human decides.
+func runLiveReconcileCommand(cmd *cobra.Command, _ []string, runtime *CommandRuntime) error {
+	if runtime.Deps.RunProject == nil {
+		return &CLIError{Op: "live reconcile", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+			"no project client is configured, so the cloud cannot be read")}
+	}
+
+	secretKey := strings.TrimSpace(os.Getenv("SCW_SECRET_KEY"))
+	orgID := strings.TrimSpace(os.Getenv("SCW_DEFAULT_ORGANIZATION_ID"))
+	if secretKey == "" || orgID == "" {
+		// Fail rather than report a clean estate. A missing credential
+		// makes every project invisible, which renders as "nothing
+		// unaccounted for" -- the exact false green this command exists
+		// to prevent, and the S139 lesson.
+		return &CLIError{Op: "live reconcile", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+			"reconciliation needs SCW_SECRET_KEY and SCW_DEFAULT_ORGANIZATION_ID; " +
+				"without them the cloud reads as empty and every deployment would look accounted for")}
+	}
+
+	listed, err := runtime.Deps.RunProject.List(cmd.Context(), secretKey, orgID)
+	if err != nil {
+		return &CLIError{Op: "live reconcile", Code: errorCodeCommandFailed, Err: err}
+	}
+
+	store := livestore.NewFilesystemStore(runtime.LiveStoreRoot())
+	deployments, unreadable, err := store.List()
+	if err != nil {
+		return &CLIError{Op: "live reconcile", Code: errorCodeCommandFailed, Err: err}
+	}
+
+	result := livestore.Reconcile(stampedProjects(listed), deployments)
+
+	stages := []StageSummary{{
+		Layer: "live", Stage: "reconcile", Status: StageStatusPass,
+		Detail: reconcileSummary(result, len(listed)),
+	}}
+	var failures []FailureSummary
+
+	for _, p := range result.Unrecorded {
+		// A failure, not a note. Something is running that nothing will
+		// reap, and a summary line an operator can scroll past is how
+		// the D6 leak survived for weeks.
+		failures = append(failures, FailureSummary{
+			Layer: "live", Stage: "reconcile", Check: "unrecorded",
+			Command: "live reconcile",
+			Detail: fmt.Sprintf(
+				"project %s (%s) carries infrafactory's stamp but no live record explains it — "+
+					"it will never expire and nothing will reap it. Nothing was destroyed; inspect it and "+
+					"tear it down deliberately",
+				p.ProjectID, p.Name),
+		})
+	}
+
+	for _, d := range result.Vanished {
+		failures = append(failures, FailureSummary{
+			Layer: "live", Stage: "reconcile", Check: "vanished",
+			Command: "live reconcile",
+			Detail: fmt.Sprintf(
+				"deployment %s (scenario %s) names project %s, which the API says does not exist — "+
+					"the record outlived its infrastructure and `live ls` is reporting something that is gone",
+				d.ID, d.Scenario, d.ProjectID),
+		})
+	}
+
+	for _, u := range unreadable {
+		failures = append(failures, FailureSummary{
+			Layer: "live", Stage: "reconcile", Check: "record",
+			Command: "live reconcile",
+			Detail: fmt.Sprintf(
+				"a live record could not be read, so a project it explains would be reported as unrecorded: %v", u),
+		})
+	}
+
+	status := CommandStatusSuccess
+	if len(failures) > 0 {
+		status = CommandStatusFailed
+	}
+	if err := writeCommandOutput(cmd, OutputResult{
+		Command: "live reconcile", Status: status, Stages: stages, Failures: failures,
+	}); err != nil {
+		return err
+	}
+	if status == CommandStatusFailed {
+		return &CLIError{Op: "live reconcile", Code: errorCodeCommandFailed, Err: fmt.Errorf(
+			"the cloud and the live store disagree in %d place(s)", len(failures))}
+	}
+	return nil
+}
+
+// stampedProjects applies the SAME ownership test that guards teardown,
+// so "infrafactory created this" has one definition rather than one here
+// and another in the guard.
+func stampedProjects(listed []harness.ListedProject) []livestore.StampedProject {
+	out := make([]livestore.StampedProject, 0, len(listed))
+	for _, l := range listed {
+		out = append(out, livestore.StampedProject{
+			ID:   l.ID,
+			Name: l.Name,
+			Ours: l.Provenance().IsInfrafactoryRunProject(),
+		})
+	}
+	return out
+}
+
+// reconcileSummary states what was EXAMINED as well as what was found.
+//
+// "0 unrecorded" out of zero projects and out of forty read identically
+// and mean opposite things, and the first is what a broken credential or
+// a wrong organization looks like.
+func reconcileSummary(r livestore.Reconciliation, projectsSeen int) string {
+	base := fmt.Sprintf("examined %d project(s) in the organization and %d live record(s)",
+		projectsSeen, r.Accounted+len(r.Vanished))
+	if r.Clean() {
+		return base + "; the cloud and the store agree"
+	}
+	return fmt.Sprintf("%s; %d unrecorded project(s), %d record(s) whose project is gone",
+		base, len(r.Unrecorded), len(r.Vanished))
+}

--- a/internal/cli/live_reconcile_test.go
+++ b/internal/cli/live_reconcile_test.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redscaresu/infrafactory/internal/harness"
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+func reconcileRuntime(t *testing.T, fake *fakeRunProject) (*CommandRuntime, *livestore.FilesystemStore) {
+	t.Helper()
+	h := newCommandTestHarness(t)
+	rt := &CommandRuntime{livestoreRoot: h.LivestoreRoot()}
+	rt.Deps.RunProject = fake
+
+	t.Setenv("SCW_SECRET_KEY", "test-secret")
+	t.Setenv("SCW_DEFAULT_ORGANIZATION_ID", "org-1")
+	return rt, livestore.NewFilesystemStore(h.LivestoreRoot())
+}
+
+func runReconcile(t *testing.T, rt *CommandRuntime, out *strings.Builder) error {
+	t.Helper()
+	cmd := &cobra.Command{Use: "reconcile"}
+	cmd.Flags().String("output", string(OutputModeHuman), "")
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetContext(context.Background())
+	return runLiveReconcileCommand(cmd, nil, rt)
+}
+
+func stampedListing(id, name string) harness.ListedProject {
+	return harness.ListedProject{ID: id, Name: name, Description: harness.RunProjectDescription}
+}
+
+func seedReconcileDeployment(t *testing.T, store *livestore.FilesystemStore, id, projectID string) {
+	t.Helper()
+	require.NoError(t, store.Put(livestore.Deployment{
+		ID: id, Scenario: "web-live-paris", Cloud: "scaleway",
+		ProjectID: projectID, State: livestore.StateLive,
+		CreatedAt: time.Now().Add(-time.Hour), ExpiresAt: time.Now().Add(time.Hour),
+	}))
+}
+
+// The whole point: infrastructure the store cannot explain is found, and
+// the command FAILS rather than mentioning it in passing.
+func TestReconcileReportsAStampedProjectNoRecordExplains(t *testing.T) {
+	rt, _ := reconcileRuntime(t, &fakeRunProject{
+		listed: []harness.ListedProject{stampedListing("proj-orphan", "if-run-block-paris-9")},
+	})
+
+	var out strings.Builder
+	err := runReconcile(t, rt, &out)
+
+	require.Error(t, err, "something is running that nothing will reap")
+	assert.Contains(t, out.String(), "proj-orphan")
+	assert.Contains(t, out.String(), "Nothing was destroyed")
+}
+
+// Never destroys. An unrecorded project is by definition something the
+// records do not explain, and destroying what you cannot explain is how a
+// reconciler becomes the incident.
+func TestReconcileDestroysNothing(t *testing.T) {
+	fake := &fakeRunProject{
+		listed: []harness.ListedProject{stampedListing("proj-orphan", "if-run-x")},
+	}
+	rt, _ := reconcileRuntime(t, fake)
+
+	_ = runReconcile(t, rt, &strings.Builder{})
+
+	assert.Zero(t, fake.deletes, "reporting is the whole contract")
+}
+
+// A missing credential makes every project invisible, which renders as
+// "nothing unaccounted for" -- the exact false green this command exists
+// to prevent.
+func TestReconcileRefusesWithoutCredentialsRatherThanReportingClean(t *testing.T) {
+	rt, _ := reconcileRuntime(t, &fakeRunProject{})
+	t.Setenv("SCW_SECRET_KEY", "")
+
+	var out strings.Builder
+	err := runReconcile(t, rt, &out)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "would look accounted for")
+}
+
+// An unreachable API must never read as an empty estate, for the same
+// reason.
+func TestReconcileFailsWhenTheCloudCannotBeRead(t *testing.T) {
+	rt, _ := reconcileRuntime(t, &fakeRunProject{
+		listErr: assertAnError(),
+	})
+
+	require.Error(t, runReconcile(t, rt, &strings.Builder{}))
+}
+
+// infrafactory does not reason about projects it did not create.
+func TestReconcileIgnoresProjectsWithoutTheStamp(t *testing.T) {
+	rt, _ := reconcileRuntime(t, &fakeRunProject{
+		listed: []harness.ListedProject{
+			{ID: "openclaw-prod", Name: "openclaw", Description: "our real project"},
+		},
+	})
+
+	var out strings.Builder
+	require.NoError(t, runReconcile(t, rt, &out))
+	assert.NotContains(t, out.String(), "openclaw")
+}
+
+// The clean answer states what was EXAMINED. "0 unrecorded" out of zero
+// projects and out of forty read identically and mean opposite things.
+func TestReconcileCleanAnswerSaysWhatItLookedAt(t *testing.T) {
+	fake := &fakeRunProject{
+		listed: []harness.ListedProject{stampedListing("proj-a", "if-run-a")},
+	}
+	rt, store := reconcileRuntime(t, fake)
+	seedReconcileDeployment(t, store, "dep-a", "proj-a")
+
+	var out strings.Builder
+	require.NoError(t, runReconcile(t, rt, &out))
+
+	assert.Contains(t, out.String(), "examined 1 project(s)")
+	assert.Contains(t, out.String(), "agree")
+	assert.Equal(t, "org-1", fake.lastOrg)
+}
+
+// A record naming a project the API does not have makes `live ls` report
+// something that is gone.
+func TestReconcileReportsARecordWhoseProjectIsGone(t *testing.T) {
+	rt, store := reconcileRuntime(t, &fakeRunProject{})
+	seedReconcileDeployment(t, store, "dep-ghost", "proj-vanished")
+
+	var out strings.Builder
+	err := runReconcile(t, rt, &out)
+
+	require.Error(t, err)
+	assert.Contains(t, out.String(), "dep-ghost")
+	assert.Contains(t, out.String(), "does not exist")
+}

--- a/internal/cli/run_project_lifecycle_test.go
+++ b/internal/cli/run_project_lifecycle_test.go
@@ -30,6 +30,9 @@ type fakeRunProject struct {
 	lastOrg           string
 	lastScen          string
 	deletedID         string
+	lists             int
+	listed            []harness.ListedProject
+	listErr           error
 }
 
 func (f *fakeRunProject) Create(_ context.Context, _, organizationID, scenario, _ string) (harness.RunProject, error) {
@@ -439,4 +442,10 @@ func TestEnsureRunProjectCreatesDespiteACancelledContext(t *testing.T) {
 	marker, err := harness.ReadRunProjectMarker(workDir)
 	require.NoError(t, err)
 	assert.Equal(t, "proj-1", marker.ProjectID)
+}
+
+func (f *fakeRunProject) List(_ context.Context, _, organizationID string) ([]harness.ListedProject, error) {
+	f.lists++
+	f.lastOrg = organizationID
+	return f.listed, f.listErr
 }

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -52,6 +52,12 @@ type RunProjectManager interface {
 	Create(ctx context.Context, secretKey, organizationID, scenario, stamp string) (harness.RunProject, error)
 	Describe(ctx context.Context, secretKey, projectID string) (harness.ProjectProvenance, error)
 	Delete(ctx context.Context, secretKey, projectID string) error
+
+	// List enumerates the organization's projects, which is the only way
+	// to find infrastructure no record explains (S157a). Describe cannot
+	// do it: it can only confirm a project id somebody already knew to
+	// ask about, and the missing ids are the whole problem.
+	List(ctx context.Context, secretKey, organizationID string) ([]harness.ListedProject, error)
 }
 
 // ServiceProbeRunner checks a live deployment's health path. Separate

--- a/internal/harness/run_project.go
+++ b/internal/harness/run_project.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -236,4 +237,112 @@ func (p *ScalewayRunProject) Delete(ctx context.Context, secretKey, projectID st
 	}
 
 	return nil
+}
+
+// ListedProject is one project the API knows about, with the fields the
+// provenance stamp is read from.
+type ListedProject struct {
+	ID          string
+	Name        string
+	Description string
+}
+
+// Provenance re-reads the stamp from a listed project, so a caller uses
+// one rule for "is this ours" whether it listed the project or described
+// it.
+func (l ListedProject) Provenance() ProjectProvenance {
+	return ProjectProvenance{Exists: true, Name: l.Name, Description: l.Description}
+}
+
+// maxProjectListPages bounds the pagination walk.
+//
+// Not a tuning knob: it is the difference between "this account has more
+// projects than expected" and an unbounded loop against a paid API if it
+// ever returns a page that does not shrink. At 100 per page it allows
+// 5,000 projects, far past anything this tool creates.
+const maxProjectListPages = 50
+
+const projectListPageSize = 100
+
+// List returns every project in the organization.
+//
+// It does NOT filter to infrafactory's own. The caller decides what is
+// theirs, using the same `IsInfrafactoryRunProject` stamp that guards
+// teardown, so there is one definition of ownership rather than one here
+// and another there.
+//
+// Reading the whole organization is deliberate and is the only way to
+// answer the question reconciliation asks -- *what is running that
+// nothing knows about?* A list filtered by the API could only return
+// projects matching something we already knew to ask for, which is the
+// assumption being checked.
+func (p *ScalewayRunProject) List(ctx context.Context, secretKey, organizationID string) ([]ListedProject, error) {
+	if strings.TrimSpace(secretKey) == "" {
+		return nil, fmt.Errorf("list projects: no secret key")
+	}
+	if strings.TrimSpace(organizationID) == "" {
+		return nil, fmt.Errorf("list projects: no organization id")
+	}
+
+	var out []ListedProject
+	for page := 1; page <= maxProjectListPages; page++ {
+		listed, err := p.listPage(ctx, secretKey, organizationID, page)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, listed...)
+		if len(listed) < projectListPageSize {
+			// A short page is the last page. Stopping on an EMPTY page
+			// instead would spend one extra request per call, every
+			// call, against an API that charges for nothing else here
+			// but is rate limited.
+			return out, nil
+		}
+	}
+	// Fail rather than return a truncated list. A caller comparing this
+	// against the live store would read missing projects as "nothing
+	// unaccounted for", which is the precise falsehood reconciliation
+	// exists to prevent.
+	return nil, fmt.Errorf("list projects: more than %d pages in organization %s; refusing to report a partial estate",
+		maxProjectListPages, organizationID)
+}
+
+func (p *ScalewayRunProject) listPage(ctx context.Context, secretKey, organizationID string, page int) ([]ListedProject, error) {
+	endpoint := fmt.Sprintf("%s/account/v3/projects?organization_id=%s&page=%d&page_size=%d",
+		p.apiBase, url.QueryEscape(organizationID), page, projectListPageSize)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build list-projects request: %w", err)
+	}
+	req.Header.Set("X-Auth-Token", secretKey)
+
+	resp, err := p.doer(req)
+	if err != nil {
+		return nil, fmt.Errorf("list projects (page %d): %w", page, err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("list projects (page %d): http %d: %s",
+			page, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var decoded struct {
+		Projects []struct {
+			ID          string `json:"id"`
+			Name        string `json:"name"`
+			Description string `json:"description"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, fmt.Errorf("decode list-projects response: %w", err)
+	}
+
+	out := make([]ListedProject, 0, len(decoded.Projects))
+	for _, pr := range decoded.Projects {
+		out = append(out, ListedProject{ID: pr.ID, Name: pr.Name, Description: pr.Description})
+	}
+	return out, nil
 }

--- a/internal/harness/run_project_test.go
+++ b/internal/harness/run_project_test.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -144,4 +145,99 @@ func TestDeleteRefusesWithoutCredentialsOrProject(t *testing.T) {
 
 	require.Error(t, client.Delete(context.Background(), "", "proj-1"))
 	require.Error(t, client.Delete(context.Background(), "secret", ""))
+}
+
+func listResponse(projects string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"projects":[` + projects + `]}`)),
+	}
+}
+
+func project(id, name, description string) string {
+	return `{"id":"` + id + `","name":"` + name + `","description":"` + description + `"}`
+}
+
+// List returns the whole organization, unfiltered. Filtering here would
+// only return projects matching something we already knew to ask for,
+// which is the assumption reconciliation exists to check.
+func TestListReturnsEveryProjectIncludingOnesNotOurs(t *testing.T) {
+	var gotURL string
+	client := NewScalewayRunProjectWithDoer("https://api.example", func(r *http.Request) (*http.Response, error) {
+		gotURL = r.URL.String()
+		return listResponse(
+			project("p1", "if-run-a", RunProjectDescription) + "," +
+				project("p2", "openclaw", "our real project")), nil
+	})
+
+	got, err := client.List(context.Background(), "secret", "org-1")
+	require.NoError(t, err)
+
+	require.Len(t, got, 2)
+	assert.True(t, got[0].Provenance().IsInfrafactoryRunProject())
+	assert.False(t, got[1].Provenance().IsInfrafactoryRunProject(),
+		"the caller decides what is ours, using the stamp that guards teardown")
+	assert.Contains(t, gotURL, "organization_id=org-1")
+}
+
+// A short page is the last page. Stopping on an empty one instead would
+// spend an extra request against a rate-limited API on every call.
+func TestListStopsOnAShortPage(t *testing.T) {
+	pages := 0
+	client := NewScalewayRunProjectWithDoer("https://api.example", func(*http.Request) (*http.Response, error) {
+		pages++
+		return listResponse(project("p1", "if-run-a", RunProjectDescription)), nil
+	})
+
+	got, err := client.List(context.Background(), "secret", "org-1")
+	require.NoError(t, err)
+
+	assert.Len(t, got, 1)
+	assert.Equal(t, 1, pages)
+}
+
+// Refusing beats truncating. A caller comparing a partial list against
+// the live store would read the missing projects as "nothing
+// unaccounted for" -- the precise falsehood reconciliation prevents.
+func TestListRefusesToReportAPartialEstate(t *testing.T) {
+	full := make([]string, 0, projectListPageSize)
+	for i := 0; i < projectListPageSize; i++ {
+		full = append(full, project(fmt.Sprintf("p%d", i), "if-run-a", RunProjectDescription))
+	}
+	body := strings.Join(full, ",")
+
+	client := NewScalewayRunProjectWithDoer("https://api.example", func(*http.Request) (*http.Response, error) {
+		return listResponse(body), nil
+	})
+
+	_, err := client.List(context.Background(), "secret", "org-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to report a partial estate")
+}
+
+// An unreachable API is an error, never an empty organization.
+func TestListFailsRatherThanReportingAnEmptyOrganization(t *testing.T) {
+	client := NewScalewayRunProjectWithDoer("https://api.example", func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       io.NopCloser(strings.NewReader(`{"message":"denied"}`)),
+		}, nil
+	})
+
+	_, err := client.List(context.Background(), "secret", "org-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "403")
+}
+
+func TestListRefusesWithoutCredentials(t *testing.T) {
+	client := NewScalewayRunProjectWithDoer("https://api.example", func(*http.Request) (*http.Response, error) {
+		t.Fatal("must not reach the API without credentials")
+		return nil, nil
+	})
+
+	_, err := client.List(context.Background(), "", "org-1")
+	require.Error(t, err)
+
+	_, err = client.List(context.Background(), "secret", "")
+	require.Error(t, err)
 }

--- a/internal/livestore/livestore.go
+++ b/internal/livestore/livestore.go
@@ -29,8 +29,14 @@ import (
 )
 
 // DefaultRoot sits beside .infrafactory/runs so both stores share a fate:
-// wiping the working directory loses the record, which is why the reaper
-// reconciles against the API rather than trusting this file alone.
+// wiping the working directory loses the record while the cloud keeps the
+// resources.
+//
+// `live reconcile` is what detects that (S157a). The REAPER does not: it
+// reads this store and nothing else, so a deployment whose record is gone
+// is a deployment it will never expire. This comment previously claimed
+// the reaper reconciled against the API, which was never true and made
+// the hole invisible to anyone reading for it.
 const DefaultRoot = ".infrafactory/live"
 
 const DeploymentSchemaVersion = "infrafactory.live.deployment.v1"

--- a/internal/livestore/reconcile.go
+++ b/internal/livestore/reconcile.go
@@ -1,0 +1,115 @@
+package livestore
+
+import "sort"
+
+// Reconciliation is the difference between what the cloud holds and what
+// this store believes (S157a).
+//
+// ADR-0024 promised this and S153 did not deliver it: the reaper trusts
+// the store to know every deployment. `.infrafactory/live` sits INSIDE
+// the working directory, so wiping the directory, switching branches, or
+// running from a fresh clone loses the records while the load balancer,
+// the instance and the public IPv4s keep running -- with a TTL nobody
+// will ever enforce.
+//
+// Every other signal reports clean, because every other signal reads this
+// store. That is the shape of D6: a leak whose only symptom is the bill.
+type Reconciliation struct {
+	// Unrecorded are projects the cloud holds that bear infrafactory's
+	// stamp and that no record explains. The expensive case: something is
+	// running and nothing is going to reap it.
+	Unrecorded []UnrecordedProject
+
+	// Vanished are records naming projects the API says do not exist.
+	// Harmless to the bill, and not harmless: they make `live ls` a lie,
+	// and a teardown against one can only fail.
+	Vanished []Deployment
+
+	// Accounted is how many records matched a project that exists. Worth
+	// reporting rather than implying, because "0 unrecorded" out of zero
+	// projects examined and out of forty are different results and read
+	// identically.
+	Accounted int
+}
+
+// UnrecordedProject is a stamped project with no record behind it.
+type UnrecordedProject struct {
+	ProjectID string
+	Name      string
+}
+
+// StampedProject is one project the cloud holds, narrowed to what
+// reconciliation needs. Declared here rather than importing the harness
+// so this package keeps its deliberately small dependency set --
+// the same reason PromotionRule takes an injected Normalize.
+type StampedProject struct {
+	ID   string
+	Name string
+
+	// Ours is the CALLER's verdict, taken with the same stamp that guards
+	// teardown. Passing the verdict rather than the description keeps one
+	// definition of "infrafactory created this" in the codebase, instead
+	// of one here and another in the guard.
+	Ours bool
+}
+
+// Reconcile compares the cloud's projects against the store's records.
+//
+// Two rules, and each is a way this could be wrong rather than merely
+// incomplete:
+//
+//   - **A project without the stamp is never considered**, in either
+//     direction. infrafactory does not reason about projects it did not
+//     create, and an unstamped project appearing in this report would
+//     invite someone to delete it.
+//   - **A released deployment still accounts for its project.** Teardown
+//     records the release but the project can outlive it -- ADR-0024's
+//     unreclaimable case is exactly that. Ignoring released records would
+//     report those projects as unrecorded, sending an operator to
+//     investigate something the store already explains.
+func Reconcile(projects []StampedProject, deployments []Deployment) Reconciliation {
+	known := map[string]bool{}
+	for _, d := range deployments {
+		if d.ProjectID != "" {
+			known[d.ProjectID] = true
+		}
+	}
+
+	live := map[string]bool{}
+	for _, p := range projects {
+		live[p.ID] = true
+	}
+
+	out := Reconciliation{}
+	for _, p := range projects {
+		if !p.Ours || known[p.ID] {
+			continue
+		}
+		out.Unrecorded = append(out.Unrecorded, UnrecordedProject{ProjectID: p.ID, Name: p.Name})
+	}
+	sort.Slice(out.Unrecorded, func(i, j int) bool {
+		return out.Unrecorded[i].ProjectID < out.Unrecorded[j].ProjectID
+	})
+
+	for _, d := range deployments {
+		if d.ProjectID == "" {
+			// A record with no project id cannot be reconciled either
+			// way. ADR-0024 already reports it as reapable-but-damaged,
+			// so it is not this command's to re-report.
+			continue
+		}
+		if live[d.ProjectID] {
+			out.Accounted++
+			continue
+		}
+		out.Vanished = append(out.Vanished, d)
+	}
+	sort.Slice(out.Vanished, func(i, j int) bool { return out.Vanished[i].ID < out.Vanished[j].ID })
+
+	return out
+}
+
+// Clean reports whether the store and the cloud agree.
+func (r Reconciliation) Clean() bool {
+	return len(r.Unrecorded) == 0 && len(r.Vanished) == 0
+}

--- a/internal/livestore/reconcile_test.go
+++ b/internal/livestore/reconcile_test.go
@@ -1,0 +1,108 @@
+package livestore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func reconcileDeployment(id, projectID string, state State) Deployment {
+	return Deployment{
+		ID: id, Scenario: "web-live-paris", Cloud: "scaleway",
+		ProjectID: projectID, State: state,
+		CreatedAt: time.Now().Add(-time.Hour), ExpiresAt: time.Now().Add(time.Hour),
+	}
+}
+
+// The expensive case, and the reason this exists: the store was wiped and
+// the infrastructure was not.
+func TestReconcileFindsAStampedProjectNoRecordExplains(t *testing.T) {
+	projects := []StampedProject{
+		{ID: "proj-a", Name: "if-run-block-paris-1", Ours: true},
+	}
+
+	got := Reconcile(projects, nil)
+
+	require.Len(t, got.Unrecorded, 1)
+	assert.Equal(t, "proj-a", got.Unrecorded[0].ProjectID)
+	assert.False(t, got.Clean())
+}
+
+// infrafactory does not reason about projects it did not create. An
+// unstamped project in this report would invite somebody to delete it.
+func TestReconcileNeverConsidersAProjectWithoutTheStamp(t *testing.T) {
+	projects := []StampedProject{
+		{ID: "openclaw-prod", Name: "openclaw", Ours: false},
+		{ID: "someone-elses", Name: "production", Ours: false},
+	}
+
+	got := Reconcile(projects, nil)
+
+	assert.Empty(t, got.Unrecorded, "these are not ours to report on, let alone to delete")
+	assert.True(t, got.Clean())
+}
+
+// A record naming a project the API does not have is not a leak, but it
+// makes `live ls` report something that is gone.
+func TestReconcileFindsARecordWhoseProjectIsGone(t *testing.T) {
+	deployments := []Deployment{reconcileDeployment("dep-1", "proj-vanished", StateLive)}
+
+	got := Reconcile(nil, deployments)
+
+	require.Len(t, got.Vanished, 1)
+	assert.Equal(t, "dep-1", got.Vanished[0].ID)
+	assert.Zero(t, got.Accounted)
+}
+
+// A released deployment still ACCOUNTS for its project. Teardown records
+// the release, but ADR-0024's unreclaimable case is exactly a project
+// that outlives it -- so ignoring released records would send an operator
+// to investigate something the store already explains.
+func TestReconcileLetsAReleasedRecordAccountForItsProject(t *testing.T) {
+	projects := []StampedProject{{ID: "proj-a", Name: "if-run-x", Ours: true}}
+	deployments := []Deployment{reconcileDeployment("dep-1", "proj-a", StateReleased)}
+
+	got := Reconcile(projects, deployments)
+
+	assert.Empty(t, got.Unrecorded, "the store explains this project; it is not unaccounted for")
+	assert.Equal(t, 1, got.Accounted)
+	assert.True(t, got.Clean())
+}
+
+// A record with no project id is reported elsewhere (ADR-0024 calls it
+// reapable-but-damaged) and cannot be reconciled in either direction.
+func TestReconcileIgnoresARecordWithNoProjectID(t *testing.T) {
+	deployments := []Deployment{reconcileDeployment("dep-broken", "", StateLive)}
+
+	got := Reconcile(nil, deployments)
+
+	assert.Empty(t, got.Vanished)
+	assert.Zero(t, got.Accounted)
+	assert.True(t, got.Clean())
+}
+
+// The mixed case an operator actually meets, and the ordering that makes
+// two runs comparable.
+func TestReconcileReportsBothDirectionsInAStableOrder(t *testing.T) {
+	projects := []StampedProject{
+		{ID: "proj-z", Name: "if-run-z", Ours: true},
+		{ID: "proj-a", Name: "if-run-a", Ours: true},
+		{ID: "proj-known", Name: "if-run-known", Ours: true},
+		{ID: "not-ours", Name: "production", Ours: false},
+	}
+	deployments := []Deployment{
+		reconcileDeployment("dep-known", "proj-known", StateLive),
+		reconcileDeployment("dep-z", "gone-2", StateLive),
+		reconcileDeployment("dep-a", "gone-1", StateLive),
+	}
+
+	got := Reconcile(projects, deployments)
+
+	assert.Equal(t, []string{"proj-a", "proj-z"},
+		[]string{got.Unrecorded[0].ProjectID, got.Unrecorded[1].ProjectID})
+	assert.Equal(t, []string{"dep-a", "dep-z"},
+		[]string{got.Vanished[0].ID, got.Vanished[1].ID})
+	assert.Equal(t, 1, got.Accounted)
+}


### PR DESCRIPTION
ADR-0024 called this *"the largest remaining hole"* in it. The hole was worse
than "not built yet".

`internal/livestore/livestore.go:33` stated, **as a fact**, that the reaper
*"reconciles against the API rather than trusting this file alone."* Nothing did.
`runLiveReapCommand` calls `store.Reapable()` and never contacts Scaleway. A
comment asserting a guard that does not exist is worse than no comment: it makes
the hole invisible to the next person who reads for it.

## The failure it closes

`.infrafactory/live` sits **inside** the working directory. Wipe it, switch
branches, or run from a fresh clone, and the records are gone while the load
balancer, the instance and the two public IPv4s keep running — with a TTL nobody
will ever enforce. **Every signal in the system reports clean, because every
signal reads the store.** That is the shape of D6: a leak whose only symptom is
the bill.

## It reports; it never destroys

An unrecorded project is *by definition* something this system's records do not
explain, and destroying what you cannot explain is how a reconciler becomes the
incident. `live reconcile` prints project ids and a human decides.
`TestReconcileDestroysNothing` pins it.

## Precise rather than heuristic

Since ADR-0025 every deployment owns an `if-run-…` project with a fixed
description, so reconciliation is a set difference over a stamp infrafactory
itself wrote — read with the **same** `IsInfrafactoryRunProject` predicate that
guards teardown, so "infrafactory created this" has one definition rather than
one here and another in the guard. A project without the stamp is never
considered in either direction.

A **released** deployment still accounts for its project: ADR-0024's
unreclaimable case is exactly a project that outlives its release, so ignoring
released records would send an operator to investigate something the store
already explains.

## Three refusals, all the same failure mode

Each of these renders as "nothing unaccounted for" if handled the easy way —
the false green S139 exists to prevent:

- **missing credentials** — the cloud reads as empty and every deployment looks
  accounted for;
- **an unreachable API** — an error is not an empty organization;
- **an estate over 50 pages** — `List` fails rather than returning a truncated
  answer that would read as complete.

## Verified against real Scaleway, not a fake

An empty stamped project was created through the Account API, left unregistered,
confirmed present in `List` with the stamp read correctly, confirmed flagged as
unrecorded by `Reconcile` against an empty store, and deleted. **Cost: nothing** —
projects are free, only resources bill.

That mattered more than it sounds. The fake proves the *logic*; it cannot prove
the **stamp survives a round trip through the real API** — that `List` returns
the description at all, byte-identical to `RunProjectDescription`. If it did not,
every unrecorded project would be invisible and this command would report a clean
estate forever, and no unit test would ever show it.

Baseline that run printed, worth recording: **3 projects in the organization, 0
carrying infrafactory's stamp.** No leaked run projects — the D6 fix is holding.

ADR-0024 amended; the false comment in `livestore.go` now says what is true and
states explicitly that the reaper is store-driven. Codex pass 90 clean on the
first review; archived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD