### PR TITLE
S156d: prescriptive rules from upgrade diffs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,58 @@
 
 Last updated: 2026-08-31
 
+## 2026-09-01 — S156d: prescriptive rules from upgrade diffs
+
+S156c writes descriptive rules only — what was observed, nothing about what to do.
+ADR-0019 calls that the weakest useful class, and it is all a single live failure
+can support: there is no "next iteration that fixed it" to diff against.
+
+An upgrade supplies one, which is why S155b stashes `.infrafactory-previous/`.
+
+**The planned risk was real, and the resolution was to change what does the
+discriminating.** An upgrade diffs two configurations that *both applied
+successfully*, so the apply cannot tell a fix from a routine version bump. The
+observations can: `livestore.Repairs` promotes an upgrade only when the service
+was observed failing **before** and healthy **after** — precisely "this failed,
+then this passed", measured against the running service rather than terraform,
+which reported success both times.
+
+Healthy-but-on-the-wrong-version does not count as "after": a service answering
+fine while running something other than what was deployed is close to evidence
+the upgrade never took. One healthy probe does not count either.
+
+**Attribution turned out to be the hard part, and the first answer was wrong.**
+A run-loop failure names a resource address; a live probe says `health path
+http://… returned HTTP 503` and names nothing. `AddressResource` looked like the
+substitute and is not — it is where the probe *pointed* (a load balancer IP), not
+where the fault was (a backend block), so narrowing the diff to its type skips
+exactly the upgrades worth learning from. Review caught it, and caught that the
+test only passed because it seeded a synthetic detail containing a Terraform
+address. Attribution now comes from the diff: use the change only when **exactly
+one** resource differs.
+
+**Eight findings across five review passes, and every one the same shape**: a rule
+the surrounding code already enforced that the new path did not inherit — the
+ambiguity gate (deletions uncounted), per-cloud handling, failure-must-persist,
+attribution-from-detail, "an absent input is not an empty input", and the
+apply-window boundary. S156a's lesson was that a change lands in every place that
+reads it; this is its mirror, and the sharper one, because none of those rules are
+written where a new path can see them.
+
+The worst was subtle: `upgraded_at` is written *after* the apply returns, so a
+concurrent `live observe` — which S158's journey test performs — records the
+upgrade's **own downtime** as the failure being repaired. Records now carry
+`upgrade_started_at`, probes inside the window are discarded rather than assigned
+to either side, and a record without the boundary is declined rather than guessed
+at.
+
+Remedies stay `source: live`, not `fix`. `fix` is permanent; `live` is retirable.
+A rule extracted from a running deployment is prescriptive in shape and live in
+provenance, and what is true of a running service stops being true — tagging it
+`fix` would make it immortal and break S156c's rule that nothing is written which
+cannot later be retired. ADR-0019 amended: the source tag is about provenance and
+retention, the rule text is about shape, and they are separate axes.
+
 ## 2026-09-01 — S157a: reconcile against the API
 
 ADR-0024 called this "the largest remaining hole" in it, and the hole was worse

--- a/docs/decisions/0019-learning-system-vocabulary.md
+++ b/docs/decisions/0019-learning-system-vocabulary.md
@@ -178,3 +178,73 @@ filter would discard evidence that was sufficient on its own merely because
 another cloud observed the same words, and — in the other direction — would let a
 breadth threshold count deployments across clouds, promoting a coincidence of
 wording that is a fact about neither.
+
+## Amendment, 2026-09-01 (S156d): a live entry may be prescriptive
+
+`source: live` says where a lesson came from and how long it may live. It does
+**not** say what shape the rule takes.
+
+S156c could only write descriptive rules, because a single live failure has no
+"next iteration that fixed it" to diff against. An **upgrade** supplies one:
+S155b keeps the previous configuration in `.infrafactory-previous/`, and
+`ExtractFixPitfall` turns a before/after pair into a rule that says what to do.
+
+Such an entry stays `source: live` rather than becoming `fix`, and the reason is
+retention. `fix` entries are permanent; `live` entries are retirable by S156a.
+A rule extracted from a running deployment is prescriptive in **shape** and live
+in **provenance** — it describes a service that is running now, and what is true
+of a running service stops being true. Tagging it `fix` would make it immortal
+and break S156c's rule that nothing is written which cannot later be retired.
+
+So the source tag is about **provenance and retention**, and the rule text is
+about shape. They are separate axes, and this is where that becomes visible.
+
+### The apply cannot tell a fix from a version bump; the observations can
+
+The risk this slice was planned against was that an upgrade diffs two
+configurations that **both applied successfully**, which is not the shape
+`ExtractFixPitfall` was built for.
+
+That is true, and the resolution is that the apply is not the discriminator.
+`livestore.Repairs` promotes an upgrade only when the service was observed
+failing **before** it and healthy **after** — which is precisely "this failed,
+then this passed", measured against the running service rather than against
+terraform. Terraform reported success both times, which is the entire reason live
+observation exists.
+
+Healthy-but-on-the-wrong-version does not count as "after". A service answering
+fine while running something other than what was deployed is close to evidence
+the upgrade did not take at all.
+
+### Attribution comes from the diff, because a live failure names nothing
+
+A run-loop failure names a resource address. A live health probe says
+`health path http://… returned HTTP 503` and names nothing at all.
+
+The deployment record's `AddressResource` looks like the answer and is not: it is
+where the probe **pointed** — a load balancer IP — not where the fault was, which
+is typically a backend block. Narrowing the diff to its type skips exactly the
+upgrades worth learning from.
+
+So the live path attributes from the diff itself, under the rule the extractor
+already applies to ambiguity: use the change only when **exactly one** resource
+differs between the two configurations. Several is an ordinary upgrade and simply
+carries no attributable remedy; the diff cannot say which change cleared the
+failure, and picking one would be a guess presented as a finding.
+
+### Both prescriptive shapes are tried, and one of them barely fits
+
+A repair is not always an addition: removing something is as much a fix, which is
+what `avoid` entries are for. The live path tries `ExtractFixPitfall` and then
+`ExtractAvoidPitfall`.
+
+The avoid path will rarely fire on a live signal, and the reason is worth
+recording rather than rediscovering. `ExtractAvoidPitfall` attributes strictly —
+the removed attribute's name **must appear in the failure detail**, a rule added
+after a false positive in S63. A provider error names the offending attribute; a
+health probe reporting `returned HTTP 503` names nothing at all.
+
+Loosening that attribution to suit live signals would weaken a guard the **run
+loop** depends on, in service of a different caller. That is not a trade a
+live-learning slice is entitled to make, so the limit stands and is pinned by a
+test rather than left as a surprise.

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -645,3 +645,22 @@ deleted. **Cost: nothing** — Scaleway projects are free; only resources bill.
 The baseline that run printed is worth recording: **3 projects in the
 organization, 0 carrying infrafactory's stamp.** The account holds no leaked run
 projects, so the D6 fix is holding.
+
+## Amendment, 2026-09-01 (S156d): an upgrade records when its apply began
+
+A deployment record now carries `upgrade_started_at` alongside `upgraded_at`. The
+pair brackets the window in which the service is expected to be disrupted.
+
+Without it, an upgrade's **own downtime is indistinguishable from the failure it
+was meant to fix**. `live observe` can run during an apply that takes minutes —
+S158's journey test does precisely that — and those probes are stamped *before*
+`upgraded_at`, because `upgraded_at` is written after the apply returns. A
+`connection refused` from mid-apply then reads as the pre-existing failure, and
+S156d would write a prescriptive rule teaching a remedy for an outage this tool
+caused.
+
+Probes landing inside the window are **discarded**, not assigned to either side:
+they describe neither the old configuration nor the new one, only the changeover.
+A record with no `upgrade_started_at` is declined for repair-learning rather than
+guessed at — fail-closed, and it costs only records written before this field
+existed.

--- a/docs/review-passes/pass91.md
+++ b/docs/review-passes/pass91.md
@@ -1,0 +1,47 @@
+# Codex review pass 91 — S156d
+
+Two findings, both accepted. The first is the more serious, because **the test
+was written in a way that hid it.**
+
+## [P2] `AddressResource` is the probe target, not the fault site
+
+A run-loop failure names a resource address. A real `live observe` failure says
+`health path http://51.15.0.1/healthz returned HTTP 503` and names nothing at all.
+
+I passed the deployment's `AddressResource` to `ExtractFixPitfall` as the
+attribution hint. It is where the probe **pointed** — a load balancer IP — not
+where the fault was, which is typically a backend block. So the diff was narrowed
+to the wrong resource type and every upgrade worth learning from was skipped as
+"no attributable change".
+
+**My test passed only because it seeded a synthetic detail containing
+`scaleway_lb_backend.app`.** A real deployment would have learned nothing, and the
+suite would have gone on reporting that it worked. The test now uses the detail a
+real `ServiceProbe` produces.
+
+Attribution comes from the diff instead, under the rule the extractor already
+applies to ambiguity: use the change only when **exactly one** resource differs.
+Several is an ordinary upgrade that carries no attributable remedy — the diff
+cannot say which change cleared the failure.
+
+## [P2] A failure that had already recovered was credited to the upgrade
+
+`lastAdverse` searched the entire pre-upgrade history, so a service that broke,
+recovered on its own, and was later upgraded produced a "repair" — attaching a
+remedy to a failure the new configuration never addressed.
+
+The rule is now the mirror of the one on the other side: `after` must be entirely
+healthy, so `before` must **end** unhealthy. Anything looser lets an unrelated
+diff inherit somebody else's failure.
+
+## Reverted in the same pass, deliberately
+
+While chasing the first finding I had taught `ExtractFixPitfall` to accept a bare
+resource type as a hint, fixing a real silent no-op — the argument had been
+falling through `splitAddress` and returning nothing.
+
+With attribution moved to the diff it was unused, and it changes the behaviour of
+the **run loop** (`run_command.go` passes `cleared.Resource`) as a side effect of
+a live-learning slice. No evidence says any caller passes a bare type today, so
+it is speculative as well as out of scope. Reverted. If it is worth fixing it is
+worth its own slice with its own evidence.

--- a/docs/review-passes/pass92.md
+++ b/docs/review-passes/pass92.md
@@ -1,0 +1,35 @@
+# Codex review pass 92 — S156d
+
+Two findings, both accepted, and both are the *same shape as pass 91's* — a rule
+stated in a comment that the code did not actually enforce.
+
+## [P2] A deletion is a change, and was not being counted
+
+`ChangedResourceAddresses` walked only the passing side, so a resource **removed**
+between the two configurations did not register. An upgrade that deleted one
+resource and modified another therefore reported "exactly one changed" and
+sailed through the ambiguity gate the previous pass had just installed.
+
+Worse than a miscount: the deletion may be what cleared the failure.
+Deletion-as-fix is a real shape — it is why ADR-0019 has `avoid` entries at all —
+so the remedy would have been attributed to whichever resource happened to
+survive.
+
+## [P2] One partial record could fail the whole command
+
+The descriptive path partitions by cloud and reports records that name none. The
+repair path iterated every deployment and would reach `AppendLivePitfall` with an
+empty cloud, where `assertCloudName` fails — taking the entire `live learn`
+command down over one incomplete record. `Cloud` is optional on the schema, so
+these exist.
+
+It skips and reports now, the same way the path beside it already did.
+
+## The pattern across passes 91 and 92
+
+Four findings in this slice, and every one is a case where **a second code path
+did not inherit a rule the first one had already established**: the ambiguity
+gate, the per-cloud handling, the failure-must-persist rule, the attribution
+source. The S156a lesson is that a change lands in every place that reads it —
+this is the same lesson from the other direction, where adding a path means
+inheriting every rule the existing paths enforce.

--- a/docs/review-passes/pass93.md
+++ b/docs/review-passes/pass93.md
@@ -1,0 +1,26 @@
+# Codex review pass 93 — S156d
+
+One finding: *"the repair path misses deletion-as-fix upgrades even though the
+project already has an extractor for that shape."*
+
+**Accepted in substance, and the answer is more interesting than the fix.**
+
+`ExtractAvoidPitfall` is now tried when `ExtractFixPitfall` finds nothing, which
+is eight lines and cheaper than arguing about scope. But it will rarely fire on a
+live signal, and the reason is structural rather than incidental.
+
+That extractor attributes **strictly**: the removed attribute's name must appear
+in the failure detail, a rule added after a false positive on `aws_subnet` in the
+S63 sweep. A provider error names the offending attribute. A health probe
+reporting `returned HTTP 503` names nothing at all — which is the same
+attribution gap pass 91 found, appearing again one layer down.
+
+Loosening that attribution to suit live signals would weaken a guard the **run
+loop** depends on, in service of a different caller. **Declined**, and the limit
+is pinned by `TestLearnCannotAttributeARemovalTheProbeDidNotName` rather than
+left to be rediscovered.
+
+The finding did surface a real defect alongside it: the skip message said "no
+single attributable change was found" even when exactly one change *was* found
+and simply could not be turned into a rule. Two different situations calling for
+two different responses, reported as one. They now read differently.

--- a/docs/review-passes/pass94.md
+++ b/docs/review-passes/pass94.md
@@ -1,0 +1,34 @@
+# Codex review pass 94 — S156d
+
+One finding, accepted, and the most dangerous of the slice.
+
+## [P2] An absent "before" is not an empty one
+
+`loadResourceBlocks` returns an empty map for a directory that does not exist —
+sensible on its own, and load-bearing in the wrong direction here.
+
+If `.infrafactory-previous/` is missing, every resource in the current
+configuration reads as newly **added**. With a single resource in the file,
+`singleChangedResource` returns it and the extractor emits the whole body as "the
+fix" — so the corpus gains a rule asserting that the entire configuration was the
+remedy for a failure whose before-state was never seen.
+
+That is corpus corruption, and it is silent: the entry looks exactly like a
+correct one.
+
+A record reaches that state for ordinary reasons — it predates S155b, or the
+working directory was cleaned since the upgrade — so `Repairs` checking
+`WorkDir != ""` was never enough. The stash must exist.
+
+## Five findings, one shape
+
+Every finding in this slice is the same: **a rule the surrounding code already
+enforced, which the new path did not inherit.** The ambiguity gate (deletions
+uncounted), the per-cloud handling, failure-must-persist, attribution-from-detail,
+and now "an absent input is not an empty input" — which the D6 purge, the orphan
+sweep and `live reconcile` all state in their own words as *never let missing data
+read as clean data*.
+
+S156a's lesson was that a change lands in every place that reads it. This is its
+mirror: a new path inherits every rule the existing paths enforce, and none of
+them are written down where the new path can see them.

--- a/docs/review-passes/pass95.md
+++ b/docs/review-passes/pass95.md
@@ -1,0 +1,33 @@
+# Codex review pass 95 — S156d
+
+Two findings, both accepted. The first is the subtlest defect in the slice.
+
+## [P2] The upgrade's own downtime read as the failure it fixed
+
+`upgraded_at` is written **after** the apply returns. `live observe` can run
+during an apply that takes minutes — S158's journey test does exactly that — so
+those probes are stamped *before* `upgraded_at` and landed in the "before" bucket.
+
+The last one wins under pass 91's failure-must-persist rule. So a
+`connection refused` captured mid-changeover became "the failure the upgrade
+repaired", and the corpus would have gained a prescriptive rule **teaching a
+remedy for an outage this tool caused**.
+
+Every ingredient was already in the codebase and none of them pointed at it:
+S155b knew the apply is long, S158 deliberately observes during one, and pass 91
+had just tightened the "before" side in a way that made the most recent
+observation decisive.
+
+Records now carry `upgrade_started_at`, stamped before the apply. Probes inside
+`[started, finished)` are **discarded** rather than assigned to either side —
+they describe neither configuration, only the changeover. A record without the
+boundary is declined rather than guessed at.
+
+## [P3] The rule overstated its own evidence
+
+`ObservationsBefore` was `len(before)` — the whole pre-upgrade history. So
+healthy → healthy → 503 wrote "3 probe(s) had reported" when one did.
+
+Accepted despite the P3, because the corpus is read as **guidance**: an inflated
+confidence is a small lie that survives, and this rule's whole value is that it
+states what is known. It counts the trailing adverse run now.

--- a/docs/review-passes/pass96.md
+++ b/docs/review-passes/pass96.md
@@ -1,0 +1,39 @@
+# Codex review pass 96 — S156d
+
+One finding, accepted after checking it rather than taking it on trust — six
+passes in, a plausible-sounding finding deserves verification before another
+round of changes.
+
+## [P2] An upgrade having happened is not an upgrade having worked
+
+`applyRan()` returns true for a **failed** apply, provided it got past init and
+plan. That is deliberate and correct: a failed apply may still have created
+resources, and a record that ignored it would describe infrastructure that no
+longer exists. So `live upgrade` sets `UpgradedAt` on a partial upgrade too.
+
+`Repairs` read `UpgradedAt` as "the new configuration is what is running". After a
+partial apply it is not — the running infrastructure is some mixture of the two,
+so diffing previous against current describes a change **that was never fully
+made**. Pair that with two healthy probes and the corpus gains a remedy crediting
+the recovery to HCL that was never applied.
+
+Verified before accepting: `applyRan` at `live_upgrade.go:505` returns true for
+any `SandboxDeployError` whose stage is neither `init` nor `plan`.
+
+Records now carry `upgrade_succeeded`, set only when the apply returned no error.
+False by default, so records written before it existed are declined — the
+intended direction.
+
+## Six passes is the finding
+
+Nine accepted findings. Not one was a coding slip; every one was a rule the
+surrounding system already enforced that this path did not inherit. That is what
+a slice too large for one question looks like, and S156d had at least four
+questions in it: when is an upgrade a repair, what does the diff attribute to,
+which observations count, and what counts as an upgrade at all.
+
+The plan for S156 already learned this once — S155b's seven passes were what
+split S156 into five slices. The split was not fine enough, and the signal was
+available before the code was written: this slice's plan entry names *"is the
+before/after pair a usable diff?"* as its one question, and the pair turned out
+not to be the hard part at all.

--- a/docs/review-passes/pass97.md
+++ b/docs/review-passes/pass97.md
@@ -1,0 +1,32 @@
+# Codex review pass 97 — S156d
+
+One finding, accepted. **It is pass 85's finding again, in a new place.**
+
+## [P2] The remedy was not part of the remedy's identity
+
+`repairKey` was `repair + cloud + symptom`. Two upgrades can clear the same
+normalized `HTTP 503` on the same resource by different changes — one adds a
+health check, another corrects a port — and those are two lessons. Keyed on the
+symptom alone, the second silently refreshed over the first and the corpus kept
+whichever happened to be learned last.
+
+Pass 85 said the same thing about descriptive entries: *the persisted identity
+was narrower than the thing it identifies.* S156c ended by making
+`Candidate.Key()` derive identity from the gate that defines it, precisely so
+this could not recur — and it recurred one slice later, in a key written by hand
+in a different file.
+
+The remedy now enters the key as a digest of the **extractor's** rule, taken
+before the evidence wrapper goes on: the extracted text is derived
+deterministically from the two configurations, while the wrapped text states
+counts that grow. The changed address stays in the clear so a human reading the
+YAML can see what the digest refers to.
+
+## The test was wrong, not the code
+
+`TestLearnKeepsTwoDifferentRemediesForTheSameSymptom` first asserted two corpus
+entries and got three. The third was correct: both deployments reported the same
+symptom, so the **descriptive** path promoted it on breadth as it should. The
+assertion now counts remedies specifically.
+
+Worth noting because the reflex on a red test is to change the code.

--- a/docs/review-passes/pass98.md
+++ b/docs/review-passes/pass98.md
@@ -1,0 +1,41 @@
+# Codex review pass 98 — S156d
+
+**Clean.** No discrete correctness issue. It did go and check that a NUL byte
+survives a YAML round trip, which is what the observed-key separator relies on —
+it does.
+
+## Seven passes, ten accepted findings, one declined
+
+That is the most any slice in this project has needed, and the count is the
+finding.
+
+Not one was a coding slip. Every one was **a rule the surrounding system already
+enforced that this new path did not inherit**:
+
+| pass | the rule that was not inherited |
+|---|---|
+| 91 | attribution comes from the failure, and `AddressResource` is not it |
+| 91 | a failure must still be present at the moment of the fix |
+| 92 | a deletion is a change (the ambiguity gate) |
+| 92 | a partial record skips, it does not fail the command |
+| 93 | both prescriptive shapes exist, not only additions |
+| 94 | an absent input is not an empty input |
+| 95 | the tool's own disruption is not a signal about the service |
+| 95 | evidence is what was observed, not what was available |
+| 96 | an operation having run is not an operation having worked |
+| 97 | identity must be as wide as the thing it identifies |
+
+Several of those are stated, in those words, elsewhere in this codebase. None of
+them are stated anywhere a new path can see.
+
+## The slice was too big, and the evidence was there beforehand
+
+S156 was split into five slices *because* S155b took seven passes. The split was
+by dependency, not by question, and S156d had at least four questions in it: when
+is an upgrade a repair, what does the diff attribute to, which observations count,
+and what counts as an upgrade at all.
+
+The plan entry names its one question as *"is the before/after pair a usable
+diff?"* — and the pair was never the hard part. **The question a slice is planned
+around should be the one that turns out to be hard, and being wrong about which
+one that is looks exactly like this.**

--- a/internal/cli/live_learn.go
+++ b/internal/cli/live_learn.go
@@ -92,6 +92,15 @@ func runLiveLearnCommand(cmd *cobra.Command, _ []string, runtime *CommandRuntime
 		}
 	}
 
+	// The PRESCRIPTIVE half (S156d). Runs over every deployment rather
+	// than per cloud: a repair names its own cloud on the record, so
+	// there is no grouping to get wrong.
+	repairStages, repairFailures, repaired, repairsSeen := learnRepairs(runtime, deployments, dryRun, now)
+	stages = append(stages, repairStages...)
+	failures = append(failures, repairFailures...)
+	written += repaired
+	considered += repairsSeen
+
 	if uncloudedCount > 0 {
 		// Said out loud. The corpus is per-cloud, so a record that names
 		// none cannot be filed anywhere -- but whatever it observed was

--- a/internal/cli/live_learn_repair.go
+++ b/internal/cli/live_learn_repair.go
@@ -1,0 +1,282 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/redscaresu/infrafactory/internal/feedback"
+	"github.com/redscaresu/infrafactory/internal/generator"
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+// learnRepairs turns upgrades that demonstrably fixed something into
+// PRESCRIPTIVE corpus entries (S156d).
+//
+// S156c writes descriptive rules: what was observed, and nothing about
+// what to do. ADR-0019 calls that the weakest useful class, and it is all
+// a single live failure can support -- there is no "next iteration that
+// fixed it" to diff against.
+//
+// An upgrade supplies one. S155b keeps the configuration a deployment was
+// running into `.infrafactory-previous/` for exactly this, and
+// `ExtractFixPitfall` turns a before/after HCL pair into a rule that says
+// what to DO.
+//
+// The gate is `livestore.Repairs`, and the whole difficulty is there
+// rather than here: an upgrade is a diff between two configurations that
+// both applied successfully, so the apply cannot tell a fix from a
+// routine version bump. The observations can.
+func learnRepairs(runtime *CommandRuntime, deployments []livestore.Deployment, dryRun bool, now time.Time) (stages []StageSummary, failures []FailureSummary, written, considered int) {
+	repairs := livestore.Repairs(deployments, feedback.NormalizeDetail)
+	considered = len(repairs)
+
+	for _, r := range repairs {
+		d := r.Deployment
+		if d.Cloud == "" {
+			// The corpus is per-cloud, so a record naming none cannot
+			// be filed anywhere. `live learn` already reports these on
+			// the descriptive path; this path must SKIP them the same
+			// way rather than reaching AppendLivePitfall, whose
+			// cloud-name guard would fail the whole command over one
+			// partial record. `Cloud` is optional on the schema, so
+			// older records really do lack it.
+			stages = append(stages, StageSummary{
+				Layer: "live", Stage: "learn", Status: StageStatusSkip,
+				Detail: fmt.Sprintf(
+					"%s repaired a failure but names no cloud, so the remedy cannot be filed", d.ID),
+			})
+			continue
+		}
+		previous := filepath.Join(d.WorkDir, PreviousHCLDirname)
+		if info, err := os.Stat(previous); err != nil || !info.IsDir() {
+			// Without the stash there is no "before", and an ABSENT
+			// before is not an empty one. `loadResourceBlocks` returns
+			// an empty map for a missing directory, so every resource in
+			// the current configuration would look newly added: with one
+			// resource in the file, the extractor would emit the whole
+			// body as "the fix" and the corpus would carry a rule
+			// claiming the entire configuration was the remedy.
+			//
+			// A record can reach here without one -- it predates S155b,
+			// or the working directory was cleaned since the upgrade --
+			// so this is a real state, not a defensive impossibility.
+			stages = append(stages, StageSummary{
+				Layer: "live", Stage: "learn", Status: StageStatusSkip,
+				Detail: fmt.Sprintf(
+					"%s repaired a failure but the configuration it was running is no longer in %s, "+
+						"so there is nothing to compare against", d.ID, PreviousHCLDirname),
+			})
+			continue
+		}
+
+		// Attribution is the hard part of a live repair, and the
+		// record's `AddressResource` is NOT the answer.
+		//
+		// A run-loop failure names a resource address. A live health
+		// probe says `health path http://… returned HTTP 503` and names
+		// nothing. `AddressResource` is where the probe POINTED -- a
+		// load balancer IP -- not where the fault was, which is
+		// typically a backend block. Handing it to the extractor as a
+		// hint narrows the diff to the wrong resource type and skips
+		// precisely the upgrades worth learning from.
+		//
+		// So attribution comes from the diff itself, under the rule the
+		// extractor already applies to ambiguity: use it only when
+		// exactly ONE resource changed. Several means the diff cannot
+		// say which cleared the failure.
+		address, attributionErr := singleChangedResource(previous, d.WorkDir)
+		if attributionErr != nil {
+			failures = append(failures, FailureSummary{
+				Layer: "live", Stage: "learn", Check: "diff",
+				Command: "live learn",
+				Detail: fmt.Sprintf(
+					"deployment %s repaired a failure but its configurations could not be read: %v",
+					d.ID, attributionErr),
+			})
+			continue
+		}
+
+		pitfall, err := extractRepairPitfall(
+			previous, d.WorkDir, r.Example, address, d.Cloud, d.Scenario,
+			now.UTC().Format(time.RFC3339))
+		if err != nil {
+			failures = append(failures, FailureSummary{
+				Layer: "live", Stage: "learn", Check: "diff",
+				Command: "live learn",
+				Detail: fmt.Sprintf(
+					"deployment %s repaired a failure but its configurations could not be diffed: %v", d.ID, err),
+			})
+			continue
+		}
+		if pitfall == nil {
+			// The extractor found no productive diff it could attribute.
+			// Said out loud rather than dropped: a repair nobody can
+			// explain is a real signal this system cannot yet use, and
+			// silence would make the corpus look like it had learned
+			// everything available.
+			//
+			// S156c will still have written the DESCRIPTIVE form of the
+			// same failure if it reproduced, so the observation is not
+			// lost -- only the remedy is.
+			stages = append(stages, StageSummary{
+				Layer: "live", Stage: "learn", Status: StageStatusSkip,
+				Detail: fmt.Sprintf(
+					"%s: an upgrade cleared %q but %s, so no remedy can be written",
+					d.ID, truncateRule(strings.TrimSpace(r.Example)), unattributableReason(address)),
+			})
+			continue
+		}
+
+		// Kept as `source: live`, NOT `fix`, and that is deliberate.
+		//
+		// ADR-0019's source tag carries two things at once: how the
+		// knowledge was extracted, and how long it may live. `fix`
+		// entries are permanent; `live` entries are retirable by S156a.
+		// This rule is prescriptive in SHAPE and live in PROVENANCE --
+		// it describes a running service, and what is true of a running
+		// service stops being true. Tagging it `fix` would make it
+		// immortal, breaking S156c's rule that nothing is written which
+		// cannot later be retired.
+		pitfall.Source = generator.LiveSource
+		// Captured before the evidence wrapper goes on: the extractor's
+		// rule is derived deterministically from the two configurations,
+		// so it is stable identity. The wrapped text is not -- it states
+		// counts that grow (pass 77).
+		extracted := pitfall.Rule
+		pitfall.Rule = repairRuleText(r, pitfall.Rule)
+		pitfall.DiscoveredFrom = d.Scenario
+
+		if dryRun {
+			stages = append(stages, StageSummary{
+				Layer: "live", Stage: "learn", Status: StageStatusSkip,
+				Detail: fmt.Sprintf("--dry-run: would learn a REMEDY for %s/%s — %s",
+					d.Cloud, pitfall.Resource, truncateRule(pitfall.Rule)),
+			})
+			continue
+		}
+
+		if err := generator.AppendLivePitfall(
+			runtime.Config.Paths.Pitfalls, d.Cloud, repairKey(r, address, extracted), *pitfall, now); err != nil {
+			failures = append(failures, FailureSummary{
+				Layer: "live", Stage: "learn", Check: "append",
+				Command: "live learn",
+				Detail:  fmt.Sprintf("could not record the remedy for %s: %v", pitfall.Resource, err),
+			})
+			continue
+		}
+		written++
+		stages = append(stages, StageSummary{
+			Layer: "live", Stage: "learn", Status: StageStatusPass,
+			Detail: fmt.Sprintf("%s/%s (remedy): %s", d.Cloud, pitfall.Resource, truncateRule(pitfall.Rule)),
+		})
+	}
+
+	return stages, failures, written, considered
+}
+
+// repairKey identifies a prescriptive live entry.
+//
+// Deliberately distinct from a descriptive candidate's key, even for the
+// same failure: "this is what went wrong" and "this is what fixed it" are
+// two entries the corpus should hold at once, and keying them together
+// would let the weaker one overwrite the stronger.
+//
+// It also carries the REMEDY, not only the symptom. Two upgrades can
+// clear the same normalized `HTTP 503` on the same resource by different
+// changes -- one adds a health check, another corrects a port -- and
+// those are two lessons. Keyed on the symptom alone the second would
+// silently refresh over the first, and the corpus would quietly hold
+// whichever happened to be learned last.
+//
+// The remedy enters as a digest rather than in full: a snippet runs to
+// hundreds of bytes of HCL and identity has to be exact, so the digest
+// does the identifying while the address stays in the clear for a human
+// reading the file.
+func repairKey(r livestore.Repair, address, extracted string) string {
+	sum := sha256.Sum256([]byte(extracted))
+	return "repair\x00" + r.Deployment.Cloud + "\x00" + r.Detail +
+		"\x00" + address + "\x00" + hex.EncodeToString(sum[:8])
+}
+
+// repairRuleText states the evidence alongside the remedy.
+//
+// The extractor's rule says what to write. It cannot say how anyone knows
+// it works, and for a live-sourced rule that is the load-bearing part: a
+// remedy is only a remedy because a running service was observed failing
+// before it and healthy after.
+func repairRuleText(r livestore.Repair, extracted string) string {
+	return fmt.Sprintf(
+		"%s Observed on a RUNNING deployment: this configuration change cleared %q, "+
+			"which %d probe(s) had reported before the upgrade and %d probe(s) confirmed gone after it. "+
+			"The apply reported success both before and after, so only the running service showed the difference.",
+		strings.TrimSpace(extracted), strings.TrimSpace(r.Example),
+		r.ObservationsBefore, r.ObservationsAfter)
+}
+
+// extractRepairPitfall turns the before/after pair into a rule, trying
+// both prescriptive shapes.
+//
+// A repair is not always an addition. An upgrade that REMOVES something
+// is just as much a fix, and the corpus already has a vocabulary for it:
+// ADR-0019's `avoid` entries, of the shape "do NOT use X; it causes Y".
+// Trying only `ExtractFixPitfall` would report a deletion-as-fix as
+// unattributable, which is both wrong and misleading -- there was a
+// single attributable change, it simply was not an addition.
+//
+// Fix first because addition is the commoner shape and its rule is more
+// directly actionable. They read opposite sides of the same diff.
+//
+// A LIMIT worth stating rather than discovering: `ExtractAvoidPitfall`
+// attributes strictly -- the removed attribute's name must appear in the
+// failure detail, a rule added after a false positive in S63. Provider
+// errors name the offending attribute; a health probe reporting
+// `returned HTTP 503` names nothing at all. So the avoid path fires for a
+// live signal only when the detail happens to carry the attribute name,
+// and most live details will not. Loosening that attribution to suit the
+// live path would weaken a guard the RUN LOOP depends on, which is not a
+// trade this slice is entitled to make.
+func extractRepairPitfall(previousDir, currentDir, detail, address, cloud, scenario, timestamp string) (*generator.LearnedPitfall, error) {
+	fix, err := generator.ExtractFixPitfall(previousDir, currentDir, detail, address, cloud, scenario, timestamp)
+	if err != nil {
+		return nil, err
+	}
+	if fix != nil {
+		return fix, nil
+	}
+	return generator.ExtractAvoidPitfall(previousDir, currentDir, detail, address, cloud, scenario, timestamp)
+}
+
+// singleChangedResource returns the one resource that differs between
+// the configurations, or "" when zero or several do.
+//
+// Returning "" rather than an error for the ambiguous case is
+// deliberate: several changed resources is a perfectly ordinary upgrade,
+// not a fault. It simply carries no attributable remedy, and the caller
+// reports that.
+func singleChangedResource(previousDir, currentDir string) (string, error) {
+	changed, err := generator.ChangedResourceAddresses(previousDir, currentDir)
+	if err != nil {
+		return "", err
+	}
+	if len(changed) != 1 {
+		return "", nil
+	}
+	return changed[0], nil
+}
+
+// unattributableReason distinguishes the two ways a repair fails to
+// produce a rule, because they call for different responses and reading
+// them as one hides which happened.
+func unattributableReason(address string) string {
+	if address == "" {
+		return "no single attributable change was found between the configurations"
+	}
+	return fmt.Sprintf(
+		"the change to %s could not be turned into a rule (a removal whose attribute the "+
+			"failure never named, most likely)", address)
+}

--- a/internal/cli/live_learn_repair_test.go
+++ b/internal/cli/live_learn_repair_test.go
@@ -1,0 +1,343 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+// repairWorkDir lays out the before/after pair S155b leaves behind: the
+// configuration that was running, stashed under .infrafactory-previous,
+// and the one that replaced it.
+func repairWorkDir(t *testing.T, before, after string) string {
+	t.Helper()
+	work := t.TempDir()
+	previous := filepath.Join(work, PreviousHCLDirname)
+	require.NoError(t, os.MkdirAll(previous, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(previous, "main.tf"), []byte(before), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(work, "main.tf"), []byte(after), 0o644))
+	return work
+}
+
+func seedRepair(t *testing.T, store *livestore.FilesystemStore, workDir string, healthyAfter int) {
+	t.Helper()
+	// The detail a REAL ServiceProbe produces: it names no Terraform
+	// address and no attribute, which is the whole attribution problem.
+	seedRepairWithDetail(t, store, workDir, healthyAfter,
+		"health path http://51.15.0.1/healthz returned HTTP 503")
+}
+
+func seedRepairWithDetail(t *testing.T, store *livestore.FilesystemStore, workDir string, healthyAfter int, detail string) {
+	t.Helper()
+	base := time.Now().Add(-time.Hour)
+	d := livestore.Deployment{
+		ID: "dep-repair", Scenario: "web-live-paris", Cloud: "scaleway",
+		ProjectID: "proj-1", WorkDir: workDir,
+		AddressResource: "scaleway_lb_ip",
+		State:           livestore.StateLive,
+		CreatedAt:       base.Add(-time.Hour), ExpiresAt: time.Now().Add(time.Hour),
+		UpgradedAt:       base,
+		UpgradeStartedAt: base.Add(-30 * time.Second),
+		UpgradeSucceeded: true,
+	}
+	d.Observations = append(d.Observations, livestore.Observation{
+		At: base.Add(-time.Minute), Status: livestore.ObservationUnhealthy, Detail: detail,
+	})
+	for i := 1; i <= healthyAfter; i++ {
+		d.Observations = append(d.Observations, livestore.Observation{
+			At: base.Add(time.Duration(i) * time.Minute), Status: livestore.ObservationHealthy,
+			Version: livestore.VersionConfirmed,
+		})
+	}
+	require.NoError(t, store.Put(d))
+}
+
+const backendBefore = `resource "scaleway_lb_backend" "app" {
+  name             = "app"
+  forward_protocol = "http"
+  forward_port     = 80
+}
+`
+
+const backendAfter = `resource "scaleway_lb_backend" "app" {
+  name             = "app"
+  forward_protocol = "http"
+  forward_port     = 80
+  health_check_http {
+    uri = "/healthz"
+  }
+}
+`
+
+// The point of the slice: an upgrade that demonstrably fixed something
+// becomes a rule that says what to DO, not merely what went wrong.
+func TestLearnWritesARemedyWhenAnUpgradeClearedAFailure(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedRepair(t, store, repairWorkDir(t, backendBefore, backendAfter), 2)
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out))
+
+	entries := corpus(t, pitfalls)
+	require.NotEmpty(t, entries)
+
+	var remedy string
+	for _, e := range entries {
+		if strings.Contains(e.Rule, "health_check_http") {
+			remedy = e.Rule
+		}
+	}
+	require.NotEmpty(t, remedy, "the rule must carry the configuration that fixed it: %+v", entries)
+	assert.Contains(t, remedy, "cleared", "and the evidence that it did")
+	assert.Contains(t, out.String(), "remedy")
+}
+
+// Retirable, not immortal. ADR-0019's `fix` entries are permanent; this
+// describes a RUNNING service, and what is true of one stops being true.
+func TestLearnedRemediesStayRetirable(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedRepair(t, store, repairWorkDir(t, backendBefore, backendAfter), 2)
+
+	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
+
+	for _, e := range corpus(t, pitfalls) {
+		assert.Equal(t, "live", e.Source,
+			"a remedy tagged `fix` could never be retired, breaking S156c's rule")
+		assert.NotEmpty(t, e.LastSeen, "retirement acts on last_seen")
+		assert.NotEmpty(t, e.ObservedKey)
+	}
+}
+
+// One healthy probe is a lucky sample. The remedy waits.
+func TestLearnWritesNoRemedyOnASingleHealthyProbe(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedRepair(t, store, repairWorkDir(t, backendBefore, backendAfter), 1)
+
+	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
+	assert.Empty(t, corpus(t, pitfalls))
+}
+
+// A repair whose configurations cannot be told apart yields no remedy,
+// and says so rather than going quiet.
+func TestLearnSaysSoWhenARepairCannotBeAttributed(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedRepair(t, store, repairWorkDir(t, backendBefore, backendBefore), 2)
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out))
+
+	assert.Empty(t, corpus(t, pitfalls))
+	assert.Contains(t, out.String(), "no single attributable change was found")
+}
+
+// Several resources changing is an ordinary upgrade, not a fault -- but
+// the diff cannot say which one cleared the failure, and picking one
+// would be a guess presented as a finding.
+func TestLearnWritesNoRemedyWhenSeveralResourcesChanged(t *testing.T) {
+	before := backendBefore + `
+resource "scaleway_lb_frontend" "app" {
+  inbound_port = 80
+}
+`
+	after := backendAfter + `
+resource "scaleway_lb_frontend" "app" {
+  inbound_port = 443
+}
+`
+	rt, store, pitfalls := learnRuntime(t)
+	seedRepair(t, store, repairWorkDir(t, before, after), 2)
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out))
+
+	assert.Empty(t, corpus(t, pitfalls))
+	assert.Contains(t, out.String(), "no single attributable change was found")
+}
+
+// --dry-run must not write a remedy either. Writing to the corpus is the
+// one irreversible act in this arc.
+func TestLearnDryRunWritesNoRemedy(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedRepair(t, store, repairWorkDir(t, backendBefore, backendAfter), 2)
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out, "--dry-run"))
+
+	assert.Empty(t, corpus(t, pitfalls))
+	assert.Contains(t, out.String(), "would learn a REMEDY")
+}
+
+// A deletion is a change. An upgrade that removes one resource and
+// modifies another is not "exactly one changed", and attributing the fix
+// to whichever survived would be a guess -- deletion-as-fix is a real
+// shape, which is why ADR-0019 has `avoid` entries at all.
+func TestLearnWritesNoRemedyWhenAnUpgradeAlsoDeletedAResource(t *testing.T) {
+	before := backendBefore + `
+resource "scaleway_lb_frontend" "legacy" {
+  inbound_port = 8080
+}
+`
+	rt, store, pitfalls := learnRuntime(t)
+	seedRepair(t, store, repairWorkDir(t, before, backendAfter), 2)
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out))
+
+	assert.Empty(t, corpus(t, pitfalls),
+		"the deletion may be what cleared the failure; the diff cannot say")
+	assert.Contains(t, out.String(), "no single attributable change was found")
+}
+
+// A record naming no cloud cannot be filed anywhere. It must skip the
+// way the descriptive path does, not fail the whole command over one
+// partial record -- `Cloud` is optional on the schema and older records
+// really do lack it.
+func TestLearnSkipsARepairedRecordWithNoCloud(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+	seedRepair(t, store, repairWorkDir(t, backendBefore, backendAfter), 2)
+
+	d, err := store.Get("dep-repair")
+	require.NoError(t, err)
+	d.Cloud = ""
+	require.NoError(t, store.Put(d))
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out), "one partial record must not fail the command")
+
+	assert.Empty(t, corpus(t, pitfalls))
+	assert.Contains(t, out.String(), "names no cloud")
+}
+
+// A repair is not always an addition. An upgrade that REMOVES something
+// is just as much a fix, and ADR-0019 has a vocabulary for it.
+//
+// The avoid extractor attributes strictly -- the removed attribute must
+// be NAMED in the failure detail, a rule added after a false positive in
+// S63 -- so this fires only when the detail carries it.
+func TestLearnWritesARemedyWhenTheFixWasARemovalTheFailureNamed(t *testing.T) {
+	before := `resource "scaleway_lb_backend" "app" {
+  forward_port     = 80
+  sticky_sessions  = "cookie"
+}
+`
+	after := `resource "scaleway_lb_backend" "app" {
+  forward_port = 80
+}
+`
+	rt, store, pitfalls := learnRuntime(t)
+	seedRepairWithDetail(t, store, repairWorkDir(t, before, after), 2,
+		"backend rejected requests: sticky_sessions requires a cookie name")
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out))
+
+	entries := corpus(t, pitfalls)
+	require.NotEmpty(t, entries, "a removal that cleared a live failure is a lesson")
+	assert.Contains(t, entries[0].Rule, "sticky_sessions")
+	assert.Equal(t, "live", entries[0].Source, "still retirable, like every live entry")
+}
+
+// And the limit, stated as a test rather than left to be discovered: a
+// health probe says `returned HTTP 503` and names no attribute, so the
+// avoid extractor's strict attribution cannot fire. The run loop depends
+// on that strictness, so loosening it to suit the live path is not a
+// trade this slice is entitled to make.
+func TestLearnCannotAttributeARemovalTheProbeDidNotName(t *testing.T) {
+	before := `resource "scaleway_lb_backend" "app" {
+  forward_port    = 80
+  sticky_sessions = "cookie"
+}
+`
+	after := `resource "scaleway_lb_backend" "app" {
+  forward_port = 80
+}
+`
+	rt, store, pitfalls := learnRuntime(t)
+	seedRepair(t, store, repairWorkDir(t, before, after), 2)
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out))
+
+	assert.Empty(t, corpus(t, pitfalls))
+	assert.Contains(t, out.String(), "could not be turned into a rule")
+}
+
+// An ABSENT "before" is not an empty one. `loadResourceBlocks` returns an
+// empty map for a missing directory, so without this check every resource
+// in the current configuration looks newly added and the corpus gains a
+// rule claiming the whole configuration was the remedy.
+func TestLearnWritesNoRemedyWithoutTheStashedPreviousConfiguration(t *testing.T) {
+	work := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(work, "main.tf"), []byte(backendAfter), 0o644))
+
+	rt, store, pitfalls := learnRuntime(t)
+	seedRepair(t, store, work, 2)
+
+	var out strings.Builder
+	require.NoError(t, runLearn(t, rt, &out))
+
+	assert.Empty(t, corpus(t, pitfalls),
+		"a rule claiming the entire configuration was the fix is corpus corruption")
+	assert.Contains(t, out.String(), "nothing to compare against")
+}
+
+// Two upgrades can clear the same symptom by different changes, and
+// those are two lessons. Keyed on the symptom alone the second would
+// silently refresh over the first.
+func TestLearnKeepsTwoDifferentRemediesForTheSameSymptom(t *testing.T) {
+	rt, store, pitfalls := learnRuntime(t)
+
+	base := time.Now().Add(-time.Hour)
+	for i, spec := range []struct{ before, after string }{
+		{backendBefore, backendAfter},
+		{backendBefore, `resource "scaleway_lb_backend" "app" {
+  name             = "app"
+  forward_protocol = "http"
+  forward_port     = 8080
+}
+`},
+	} {
+		work := repairWorkDir(t, spec.before, spec.after)
+		d := livestore.Deployment{
+			ID: fmt.Sprintf("dep-%d", i), Scenario: "web-live-paris", Cloud: "scaleway",
+			ProjectID: "proj-1", WorkDir: work, AddressResource: "scaleway_lb_ip",
+			State:     livestore.StateLive,
+			CreatedAt: base.Add(-time.Hour), ExpiresAt: time.Now().Add(time.Hour),
+			UpgradedAt: base, UpgradeStartedAt: base.Add(-30 * time.Second),
+			UpgradeSucceeded: true,
+		}
+		d.Observations = append(d.Observations, livestore.Observation{
+			At: base.Add(-time.Minute), Status: livestore.ObservationUnhealthy,
+			Detail: "health path http://51.15.0.1/healthz returned HTTP 503",
+		})
+		for n := 1; n <= 2; n++ {
+			d.Observations = append(d.Observations, livestore.Observation{
+				At: base.Add(time.Duration(n) * time.Minute), Status: livestore.ObservationHealthy,
+				Version: livestore.VersionConfirmed,
+			})
+		}
+		require.NoError(t, store.Put(d))
+	}
+
+	require.NoError(t, runLearn(t, rt, &strings.Builder{}))
+
+	// Three entries, not two: both deployments reported the same symptom,
+	// so the DESCRIPTIVE path correctly promotes it on breadth as well.
+	// Count the remedies specifically.
+	remedies := 0
+	for _, e := range corpus(t, pitfalls) {
+		if strings.Contains(e.Rule, "this configuration change cleared") {
+			remedies++
+		}
+	}
+	assert.Equal(t, 2, remedies,
+		"one symptom, two remedies, and neither may overwrite the other")
+}

--- a/internal/cli/live_upgrade.go
+++ b/internal/cli/live_upgrade.go
@@ -170,6 +170,12 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 
 	_, _ = fmt.Fprintf(progress, "Upgrading %s in project %s\n", d.ID, d.ProjectID)
 
+	// Stamped BEFORE the apply, so the pair (start, finish) brackets the
+	// window in which this service is expected to be disrupted. Without
+	// it, a probe taken mid-apply is indistinguishable from the failure
+	// the upgrade was meant to fix -- see UpgradeStartedAt.
+	upgradeStartedAt := time.Now()
+
 	if err := stashPreviousHCL(d.WorkDir); err != nil {
 		return &CLIError{Op: "live upgrade", Code: errorCodeCommandFailed, Err: err}
 	}
@@ -227,7 +233,12 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 			d.Tag = trimmed
 			tagChanged = true
 		}
+		d.UpgradeStartedAt = upgradeStartedAt
 		d.UpgradedAt = time.Now()
+		// applyRan() is true for a FAILED apply past plan -- deliberately,
+		// since resources may exist and the record must say so. Only a
+		// clean apply means the running configuration is the new one.
+		d.UpgradeSucceeded = applyErr == nil
 
 		// The address can move: replacement HCL may recreate the load
 		// balancer. Verifying against the address captured at first
@@ -629,11 +640,13 @@ func assertRunProjectOurs(ctx context.Context, runtime *CommandRuntime, projectI
 // losing them does not corrupt the record -- it quietly weakens the
 // learning signal, which is harder to notice.
 //
-// An allow-list of the four fields an upgrade owns, not a blanket copy:
+// An allow-list of the fields an upgrade owns, not a blanket copy:
 // anything else belongs to whoever wrote it last.
 func mergeUpgradeOntoFresh(fresh, upgraded livestore.Deployment) livestore.Deployment {
 	fresh.Tag = upgraded.Tag
 	fresh.UpgradedAt = upgraded.UpgradedAt
+	fresh.UpgradeStartedAt = upgraded.UpgradeStartedAt
+	fresh.UpgradeSucceeded = upgraded.UpgradeSucceeded
 	fresh.Address = upgraded.Address
 	fresh.AddressResource = upgraded.AddressResource
 	return fresh

--- a/internal/generator/prescriptive_extractor.go
+++ b/internal/generator/prescriptive_extractor.go
@@ -787,3 +787,53 @@ func firstSentence(detail string) string {
 	}
 	return ""
 }
+
+// ChangedResourceAddresses returns every resource address that differs
+// between two configuration directories: added, modified, or REMOVED.
+//
+// Exported for the live path (S156d), which has an attribution problem
+// the run loop does not. A run-loop failure names a resource address; a
+// live health probe says `health path http://… returned HTTP 503` and
+// names nothing at all. The deployment record's `AddressResource` is not
+// a substitute -- it is where the probe POINTED (a load balancer IP), not
+// where the fault was (a backend block), so narrowing the diff to its
+// type skips exactly the upgrades worth learning from.
+//
+// The caller's rule is the one this file already uses for ambiguity: use
+// the change only when there is exactly one. Several changed resources
+// mean the diff cannot say which cleared the failure, and picking one
+// would be a guess presented as a finding.
+func ChangedResourceAddresses(failedDir, passingDir string) ([]string, error) {
+	failed, err := loadResourceBlocks(failedDir)
+	if err != nil {
+		return nil, fmt.Errorf("read failed dir %q: %w", failedDir, err)
+	}
+	passing, err := loadResourceBlocks(passingDir)
+	if err != nil {
+		return nil, fmt.Errorf("read passing dir %q: %w", passingDir, err)
+	}
+
+	var out []string
+	for addr, p := range passing {
+		f, ok := failed[addr]
+		if !ok || normalizeBody(f.Body) != normalizeBody(p.Body) {
+			out = append(out, addr)
+		}
+	}
+	// Deletions count. An upgrade that REMOVES a resource has changed
+	// the configuration just as much as one that adds a block, and the
+	// removal may well be what cleared the failure -- ADR-0019's `avoid`
+	// entries exist precisely because deletion-as-fix is a real shape.
+	//
+	// Walking only the passing side would report "exactly one changed"
+	// for an upgrade that deleted one resource and modified another,
+	// defeating the caller's ambiguity gate and attributing the fix to
+	// whichever one happened to survive.
+	for addr := range failed {
+		if _, ok := passing[addr]; !ok {
+			out = append(out, addr)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/generator/prescriptive_extractor_test.go
+++ b/internal/generator/prescriptive_extractor_test.go
@@ -531,3 +531,36 @@ func writeTF(t *testing.T, dir, name, content string) {
 func repeat(s string, n int) string {
 	return strings.Repeat(s, n)
 }
+
+// A removed resource is a changed resource. Walking only the passing
+// side reports "exactly one changed" for an upgrade that deleted one
+// thing and modified another, defeating the caller's ambiguity gate.
+func TestChangedResourceAddressesCountsDeletions(t *testing.T) {
+	before := `resource "scaleway_lb_backend" "app" {
+  forward_port = 80
+}
+resource "scaleway_lb_frontend" "legacy" {
+  inbound_port = 8080
+}
+`
+	after := `resource "scaleway_lb_backend" "app" {
+  forward_port = 443
+}
+`
+	d1, d2 := t.TempDir(), t.TempDir()
+	if err := os.WriteFile(filepath.Join(d1, "main.tf"), []byte(before), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(d2, "main.tf"), []byte(after), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := ChangedResourceAddresses(d1, d2)
+	if err != nil {
+		t.Fatalf("changed: %v", err)
+	}
+	want := []string{"scaleway_lb_backend.app", "scaleway_lb_frontend.legacy"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("expected the deletion to count as a change: got %v, want %v", got, want)
+	}
+}

--- a/internal/livestore/livestore.go
+++ b/internal/livestore/livestore.go
@@ -85,6 +85,39 @@ type Deployment struct {
 	// configuration. Zero means never.
 	UpgradedAt time.Time `json:"upgraded_at,omitempty"`
 
+	// UpgradeStartedAt is when that upgrade's apply BEGAN.
+	//
+	// The pair brackets a window in which the service is expected to be
+	// disrupted, and without it an upgrade's own downtime is
+	// indistinguishable from the failure it was meant to fix. `live
+	// observe` can run during an apply that takes minutes -- S158's
+	// journey test does exactly that -- and those probes are stamped
+	// before UpgradedAt, because UpgradedAt is written after the apply
+	// returns. Treating a `connection refused` from mid-apply as the
+	// pre-existing failure would teach a remedy for the outage the
+	// upgrade CAUSED (S156d).
+	UpgradeStartedAt time.Time `json:"upgrade_started_at,omitempty"`
+
+	// UpgradeSucceeded records whether that apply COMPLETED, as opposed
+	// to merely having run.
+	//
+	// `live upgrade` updates this record whenever the apply got past
+	// plan, because a failed apply may still have created resources and
+	// a record that ignored it would describe infrastructure that no
+	// longer exists. So `UpgradedAt` being set does not mean the upgrade
+	// worked.
+	//
+	// The distinction matters for S156d. After a partial apply the
+	// running infrastructure is some mixture of the old and new
+	// configurations, so diffing one against the other describes a
+	// change that was never fully made -- and pairing that with "the
+	// service is healthy now" would attribute the recovery to HCL that
+	// was never applied.
+	//
+	// False by default, which declines records written before this
+	// existed. That is the intended direction.
+	UpgradeSucceeded bool `json:"upgrade_succeeded,omitempty"`
+
 	// Cloud is the provider this deployment was applied to, recorded so a
 	// lesson learned from it lands in the right corpus. Taken from the
 	// scenario at deploy time, because that is where it is a fact.

--- a/internal/livestore/repair.go
+++ b/internal/livestore/repair.go
@@ -1,0 +1,211 @@
+package livestore
+
+import "time"
+
+// Repair is an upgrade that DEMONSTRABLY fixed something (S156d).
+//
+// # Why this type exists rather than "the deployment was upgraded"
+//
+// S155b keeps the previous configuration in `.infrafactory-previous/`
+// precisely so a live failure can reach `ExtractFixPitfall`, which turns
+// a before/after HCL pair into a PRESCRIPTIVE rule -- one that says what
+// to do, not merely what went wrong. That is the strongest class of entry
+// the corpus holds, and S156c can only produce the weakest.
+//
+// The plan's stated risk was that an upgrade is a diff between two
+// configurations that BOTH applied successfully, which is not obviously
+// the same shape as "this failed, then this passed".
+//
+// The risk is real and the resolution is that **the apply is not the
+// discriminator; the observations are.** An upgrade qualifies only when
+// the service was observed failing BEFORE it and observed healthy AFTER.
+// That is exactly "this failed, then this passed", measured against the
+// running service rather than against terraform -- which is the whole
+// point of live observation, since terraform reported success both times.
+//
+// An upgrade with no failure before it fixed nothing. An upgrade still
+// failing after it fixed nothing. Neither is a lesson, and writing either
+// one would teach a remedy that was never shown to work.
+type Repair struct {
+	Deployment Deployment
+
+	// Detail is the failure the upgrade cleared, as observed before it.
+	Detail string
+
+	// Example is one raw pre-upgrade detail, for a human.
+	Example string
+
+	// ObservationsBefore is how many consecutive probes reported THIS
+	// failure immediately before the upgrade -- not the size of the
+	// pre-upgrade history.
+	//
+	// A rule that says "3 probes reported it" when one did, and two
+	// earlier probes were healthy, overstates its own evidence. The
+	// corpus is read as guidance, so an inflated confidence is a small
+	// lie that survives.
+	ObservationsBefore int
+
+	// ObservationsAfter is how many probes confirmed it gone.
+	ObservationsAfter int
+}
+
+// MinHealthyAfterUpgrade is how many consecutive healthy observations
+// must follow an upgrade before it counts as a repair.
+//
+// One is not enough: a service that is briefly up during a restart, or
+// probed once in a window it happens to survive, would promote a remedy
+// on the strength of a single lucky sample. This is the same reasoning as
+// PromotionRule.ConsecutiveProbes, and the same admission -- the number is
+// a guess, held here so it can be raised when there is evidence to tune it
+// against.
+const MinHealthyAfterUpgrade = 2
+
+// Repairs returns the upgrades that demonstrably fixed something.
+//
+// normalize collapses cosmetic variation in failure details, as in
+// PromotionCandidates; nil means identity.
+func Repairs(deployments []Deployment, normalize func(string) string) []Repair {
+	if normalize == nil {
+		normalize = func(s string) string { return s }
+	}
+
+	var out []Repair
+	for _, d := range deployments {
+		if d.UpgradedAt.IsZero() || d.WorkDir == "" {
+			continue
+		}
+
+		if !d.UpgradeSucceeded {
+			// The apply ran but did not complete, so the running
+			// infrastructure is a mixture of the two configurations.
+			// Diffing them describes a change that was never fully
+			// made, and pairing that with "healthy now" would credit
+			// the recovery to HCL that was never applied.
+			continue
+		}
+		if d.UpgradeStartedAt.IsZero() {
+			// Without the start of the apply there is no way to tell the
+			// upgrade's OWN downtime from the failure it was meant to
+			// fix: `live observe` can run during an apply that takes
+			// minutes, and those probes are stamped before UpgradedAt.
+			//
+			// Declining is fail-closed and costs only older records.
+			// Guessing a boundary would teach remedies for outages the
+			// upgrade caused.
+			continue
+		}
+
+		before, after := splitAtUpgrade(d)
+		if len(after) < MinHealthyAfterUpgrade {
+			// Not yet enough evidence. Deliberately not an error and
+			// not a rejection -- observing it more may still qualify
+			// it, and saying "no" now would be as wrong as saying yes.
+			continue
+		}
+		if !allHealthy(after) {
+			continue
+		}
+
+		detail, example, run := failureAtUpgrade(before)
+		if detail == "" {
+			// The service was not failing when it was upgraded. Either
+			// it was healthy throughout -- a version bump, a fine thing
+			// to have done that teaches no remedy -- or it had already
+			// recovered on its own, in which case crediting the new
+			// configuration would attach a remedy to a failure it never
+			// addressed.
+			continue
+		}
+
+		out = append(out, Repair{
+			Deployment:         d,
+			Detail:             normalize(detail),
+			Example:            example,
+			ObservationsBefore: run,
+			ObservationsAfter:  len(after),
+		})
+	}
+	return out
+}
+
+// splitAtUpgrade divides a deployment's observations either side of its
+// most recent upgrade, DISCARDING those taken during the apply.
+//
+// Three regions, not two. `[UpgradeStartedAt, UpgradedAt)` is the window
+// in which the service is expected to be disrupted, and a probe landing
+// there describes neither the old configuration nor the new one -- it
+// describes the changeover. Counting such a probe as "before" would make
+// the upgrade's own downtime look like the failure it was meant to fix,
+// and the corpus would gain a remedy for an outage this tool caused.
+//
+// Observations AT the finish instant count as after: a probe stamped at
+// the moment the upgrade completed describes the new configuration, and
+// counting it as evidence of the old failure would attribute the fault to
+// the thing that fixed it.
+func splitAtUpgrade(d Deployment) (before, after []Observation) {
+	for _, o := range d.Observations {
+		if o.At.Before(d.UpgradeStartedAt) {
+			before = append(before, o)
+			continue
+		}
+		if o.At.Before(d.UpgradedAt) {
+			// In flight. Discarded rather than assigned to either side.
+			continue
+		}
+		after = append(after, o)
+	}
+	return before, after
+}
+
+func allHealthy(observations []Observation) bool {
+	for _, o := range observations {
+		// adverse() rather than !Healthy(): a service answering fine
+		// while running a version other than the one deployed is NOT
+		// evidence that an upgrade worked. It is close to evidence of
+		// the opposite -- the apply reported success and the running
+		// service did not move.
+		if adverse(o) {
+			return false
+		}
+	}
+	return len(observations) > 0
+}
+
+// failureAtUpgrade returns the failure the service was exhibiting when it
+// was upgraded, or "" if it was not exhibiting one.
+//
+// The LAST observation before the upgrade, not the last adverse one
+// anywhere in the history. A service that broke on Monday, recovered on
+// Tuesday, and was upgraded on Wednesday was not fixed by that upgrade --
+// it had already recovered, and crediting the new configuration would
+// attach a remedy to a failure it never addressed.
+//
+// This is the mirror of the rule on the other side: `after` must be
+// entirely healthy, so `before` must end unhealthy. Anything looser lets
+// an unrelated diff inherit somebody else's failure.
+// It also returns how many consecutive probes reported that same
+// failure, which is the evidence the rule may claim -- the trailing run,
+// not the whole history. Two healthy probes followed by one 503 is one
+// probe's worth of evidence, not three.
+func failureAtUpgrade(before []Observation) (detail, example string, run int) {
+	if len(before) == 0 {
+		return "", "", 0
+	}
+	last := before[len(before)-1]
+	if !adverse(last) || last.Detail == "" {
+		return "", "", 0
+	}
+
+	for i := len(before) - 1; i >= 0; i-- {
+		o := before[i]
+		if !adverse(o) || o.Detail != last.Detail {
+			break
+		}
+		run++
+	}
+	return last.Detail, last.Detail, run
+}
+
+// UpgradedAtOrZero is a small accessor so callers outside this package
+// can order events against the upgrade without reaching into the record.
+func (r Repair) UpgradedAt() time.Time { return r.Deployment.UpgradedAt }

--- a/internal/livestore/repair_test.go
+++ b/internal/livestore/repair_test.go
@@ -1,0 +1,251 @@
+package livestore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type obsSpec struct {
+	offset time.Duration
+	status ObservationStatus
+	detail string
+	drift  bool
+}
+
+func repairDeployment(upgradeOffset time.Duration, specs ...obsSpec) Deployment {
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	d := Deployment{
+		ID: "dep-1", Scenario: "web-live-paris", Cloud: "scaleway",
+		ProjectID: "proj-1", WorkDir: "/tmp/work",
+		AddressResource: "scaleway_lb_ip",
+		State:           StateLive,
+		CreatedAt:       base.Add(-time.Hour), ExpiresAt: base.Add(time.Hour),
+		UpgradedAt:       base.Add(upgradeOffset),
+		UpgradeStartedAt: base.Add(upgradeOffset - 30*time.Second),
+		UpgradeSucceeded: true,
+	}
+	for _, s := range specs {
+		o := Observation{At: base.Add(s.offset), Status: s.status, Detail: s.detail}
+		if s.drift {
+			o.Version = VersionUnconfirmed
+		} else if s.status == ObservationHealthy {
+			o.Version = VersionConfirmed
+		}
+		d.Observations = append(d.Observations, o)
+	}
+	return d
+}
+
+// The shape S156d exists for: failing, upgraded, healthy. Terraform
+// reported success both times, so only the observations can tell these
+// apart.
+func TestRepairsFindsAnUpgradeThatClearedAFailure(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -2 * time.Minute, status: ObservationUnhealthy, detail: "HTTP 503 from /healthz"},
+		obsSpec{offset: -time.Minute, status: ObservationUnhealthy, detail: "HTTP 503 from /healthz"},
+		obsSpec{offset: time.Minute, status: ObservationHealthy},
+		obsSpec{offset: 2 * time.Minute, status: ObservationHealthy},
+	)
+
+	got := Repairs([]Deployment{d}, nil)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "HTTP 503 from /healthz", got[0].Detail)
+	assert.Equal(t, 2, got[0].ObservationsBefore)
+	assert.Equal(t, 2, got[0].ObservationsAfter)
+}
+
+// An upgrade with nothing wrong before it fixed nothing. Rolling a
+// version forward is a fine thing to have done and teaches no remedy.
+func TestRepairsIgnoresAnUpgradeThatFixedNothing(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -time.Minute, status: ObservationHealthy},
+		obsSpec{offset: time.Minute, status: ObservationHealthy},
+		obsSpec{offset: 2 * time.Minute, status: ObservationHealthy},
+	)
+
+	assert.Empty(t, Repairs([]Deployment{d}, nil),
+		"there was no failure for the upgrade to have fixed")
+}
+
+// Still broken afterwards is not a fix, and writing it as one would
+// teach a remedy that was demonstrably not one.
+func TestRepairsIgnoresAnUpgradeThatDidNotHelp(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -time.Minute, status: ObservationUnhealthy, detail: "HTTP 503"},
+		obsSpec{offset: time.Minute, status: ObservationHealthy},
+		obsSpec{offset: 2 * time.Minute, status: ObservationUnhealthy, detail: "HTTP 503"},
+	)
+
+	assert.Empty(t, Repairs([]Deployment{d}, nil))
+}
+
+// One healthy probe is a lucky sample, not evidence.
+func TestRepairsWaitsForMoreThanOneHealthyProbe(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -time.Minute, status: ObservationUnhealthy, detail: "HTTP 503"},
+		obsSpec{offset: time.Minute, status: ObservationHealthy},
+	)
+
+	assert.Empty(t, Repairs([]Deployment{d}, nil),
+		"observing it more may still qualify it; saying yes now would be as wrong as saying no")
+}
+
+// The most dangerous case, and the one every other signal calls healthy.
+// A service answering fine while running a version other than the one
+// deployed is close to evidence the upgrade did NOT take.
+func TestRepairsRefusesWhenTheServiceIsHealthyButOnTheWrongVersion(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -time.Minute, status: ObservationUnhealthy, detail: "HTTP 503"},
+		obsSpec{offset: time.Minute, status: ObservationHealthy, drift: true},
+		obsSpec{offset: 2 * time.Minute, status: ObservationHealthy, drift: true},
+	)
+
+	assert.Empty(t, Repairs([]Deployment{d}, nil),
+		"the apply reported success and the running service did not move")
+}
+
+// A probe stamped at the upgrade instant describes the NEW
+// configuration. Counting it as evidence of the old failure would
+// attribute the fault to the thing that fixed it.
+func TestRepairsCountsAProbeAtTheUpgradeInstantAsAfter(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -time.Minute, status: ObservationUnhealthy, detail: "HTTP 503"},
+		obsSpec{offset: 0, status: ObservationHealthy},
+		obsSpec{offset: time.Minute, status: ObservationHealthy},
+	)
+
+	got := Repairs([]Deployment{d}, nil)
+	require.Len(t, got, 1)
+	assert.Equal(t, 1, got[0].ObservationsBefore)
+	assert.Equal(t, 2, got[0].ObservationsAfter)
+}
+
+// The failure the service was exhibiting AT the upgrade, which is the
+// one the new configuration was written against.
+func TestRepairsTakesTheFailureTheUpgradeWasWrittenAgainst(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -3 * time.Minute, status: ObservationUnhealthy, detail: "an older problem"},
+		obsSpec{offset: -2 * time.Minute, status: ObservationUnhealthy, detail: "an older problem"},
+		obsSpec{offset: -time.Minute, status: ObservationUnreachable, detail: "connection refused"},
+		obsSpec{offset: time.Minute, status: ObservationHealthy},
+		obsSpec{offset: 2 * time.Minute, status: ObservationHealthy},
+	)
+
+	got := Repairs([]Deployment{d}, nil)
+	require.Len(t, got, 1)
+	assert.Equal(t, "connection refused", got[0].Detail)
+}
+
+// A deployment that was never upgraded has no before/after pair at all.
+func TestRepairsIgnoresADeploymentThatWasNeverUpgraded(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -time.Minute, status: ObservationUnhealthy, detail: "HTTP 503"},
+		obsSpec{offset: time.Minute, status: ObservationHealthy},
+		obsSpec{offset: 2 * time.Minute, status: ObservationHealthy},
+	)
+	d.UpgradedAt = time.Time{}
+
+	assert.Empty(t, Repairs([]Deployment{d}, nil))
+}
+
+// Without a working directory there is no previous HCL to diff against,
+// so there is nothing prescriptive to extract.
+func TestRepairsIgnoresADeploymentWithNoWorkDir(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -time.Minute, status: ObservationUnhealthy, detail: "HTTP 503"},
+		obsSpec{offset: time.Minute, status: ObservationHealthy},
+		obsSpec{offset: 2 * time.Minute, status: ObservationHealthy},
+	)
+	d.WorkDir = ""
+
+	assert.Empty(t, Repairs([]Deployment{d}, nil))
+}
+
+// A service that broke, recovered on its own, and was then upgraded was
+// not fixed by that upgrade. Crediting the new configuration would
+// attach a remedy to a failure it never addressed.
+func TestRepairsIgnoresAFailureThatHadAlreadyRecovered(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -3 * time.Minute, status: ObservationUnhealthy, detail: "HTTP 503"},
+		obsSpec{offset: -2 * time.Minute, status: ObservationHealthy},
+		obsSpec{offset: -time.Minute, status: ObservationHealthy},
+		obsSpec{offset: time.Minute, status: ObservationHealthy},
+		obsSpec{offset: 2 * time.Minute, status: ObservationHealthy},
+	)
+
+	assert.Empty(t, Repairs([]Deployment{d}, nil),
+		"it had already recovered; the upgrade cleared nothing")
+}
+
+// The upgrade's OWN downtime must not be learned as the failure it was
+// meant to fix. `live observe` can run during an apply that takes
+// minutes, and those probes are stamped before UpgradedAt because that
+// is written after the apply returns.
+func TestRepairsDiscardsProbesTakenDuringTheApply(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -time.Minute, status: ObservationUnhealthy, detail: "HTTP 503 from /healthz"},
+		// Mid-apply: after UpgradeStartedAt (-30s), before UpgradedAt.
+		obsSpec{offset: -15 * time.Second, status: ObservationUnreachable, detail: "connection refused"},
+		obsSpec{offset: time.Minute, status: ObservationHealthy},
+		obsSpec{offset: 2 * time.Minute, status: ObservationHealthy},
+	)
+
+	got := Repairs([]Deployment{d}, nil)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, "HTTP 503 from /healthz", got[0].Detail,
+		"the changeover describes neither configuration")
+	assert.Equal(t, 1, got[0].ObservationsBefore)
+}
+
+// Without the boundary there is no way to tell the two apart, so the
+// record is declined rather than guessed at.
+func TestRepairsDeclinesWhenTheApplyWindowIsUnknown(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -time.Minute, status: ObservationUnhealthy, detail: "HTTP 503"},
+		obsSpec{offset: time.Minute, status: ObservationHealthy},
+		obsSpec{offset: 2 * time.Minute, status: ObservationHealthy},
+	)
+	d.UpgradeStartedAt = time.Time{}
+
+	assert.Empty(t, Repairs([]Deployment{d}, nil),
+		"guessing a boundary would teach remedies for outages the upgrade caused")
+}
+
+// A rule claiming three probes reported a failure when one did overstates
+// its own evidence, and the corpus is read as guidance.
+func TestRepairsCountsOnlyTheProbesThatReportedTheFailure(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -4 * time.Minute, status: ObservationHealthy},
+		obsSpec{offset: -3 * time.Minute, status: ObservationHealthy},
+		obsSpec{offset: -2 * time.Minute, status: ObservationUnhealthy, detail: "HTTP 503"},
+		obsSpec{offset: -time.Minute, status: ObservationUnhealthy, detail: "HTTP 503"},
+		obsSpec{offset: time.Minute, status: ObservationHealthy},
+		obsSpec{offset: 2 * time.Minute, status: ObservationHealthy},
+	)
+
+	got := Repairs([]Deployment{d}, nil)
+	require.Len(t, got, 1)
+	assert.Equal(t, 2, got[0].ObservationsBefore, "two reported it, not four")
+}
+
+// `live upgrade` updates the record whenever the apply got past plan,
+// because a failed apply may still have created resources. So an upgrade
+// having HAPPENED is not an upgrade having worked -- and after a partial
+// apply the running infrastructure is a mixture of the two
+// configurations, so the diff describes a change that was never made.
+func TestRepairsDeclinesAnUpgradeThatDidNotComplete(t *testing.T) {
+	d := repairDeployment(0,
+		obsSpec{offset: -time.Minute, status: ObservationUnhealthy, detail: "HTTP 503"},
+		obsSpec{offset: time.Minute, status: ObservationHealthy},
+		obsSpec{offset: 2 * time.Minute, status: ObservationHealthy},
+	)
+	d.UpgradeSucceeded = false
+
+	assert.Empty(t, Repairs([]Deployment{d}, nil),
+		"crediting recovery to HCL that was never applied is a false remedy")
+}


### PR DESCRIPTION
S156c writes **descriptive** rules only — what was observed, nothing about what to
do. That is all a single live failure can support: there is no "next iteration
that fixed it" to diff against. An upgrade supplies one, which is why S155b
stashes `.infrafactory-previous/`.

## The planned risk was real, and the fix was to change what discriminates

An upgrade diffs two configurations that **both applied successfully**, so the
apply cannot tell a fix from a routine version bump.

The observations can. `livestore.Repairs` promotes an upgrade only when the
service was observed failing **before** it and healthy **after** — precisely
"this failed, then this passed", measured against the running service rather than
terraform, which reported success both times. That is the entire reason live
observation exists.

Healthy-but-on-the-wrong-version does not count as "after": a service answering
fine while running something other than what was deployed is close to evidence
the upgrade never took.

## Ten findings over seven review passes, and none was a coding slip

Every one was **a rule the surrounding system already enforced that this new path
did not inherit**. Worth reading as a list, because the pattern is the point:

| the rule | what went wrong |
|---|---|
| attribution comes from the failure | `AddressResource` is where the probe *pointed* (an LB IP), not where the fault was (a backend block) — so the diff was narrowed to the wrong type and **the test only passed because it seeded a synthetic Terraform address into the detail** |
| a failure must persist to the moment of the fix | a service that broke, recovered, and was later upgraded was credited as repaired |
| a deletion is a change | the ambiguity gate let a two-change upgrade through as one, and the deletion may be what fixed it |
| a partial record skips | a record with no cloud failed the entire `live learn` command |
| both prescriptive shapes exist | only additions were tried, never removals |
| an absent input is not an empty input | without the stash, every resource reads as newly added — the corpus gains a rule claiming **the entire configuration** was the remedy |
| the tool's own disruption is not a signal | `upgraded_at` is written *after* the apply, so a concurrent `live observe` (which S158's journey test performs) recorded **upgrade downtime** as the failure being repaired |
| evidence is what was observed | `healthy → healthy → 503` claimed "3 probes reported it" |
| an operation having run ≠ having worked | `applyRan()` is true for a *failed* apply past plan, so a partial upgrade set `upgraded_at` and the diff described a change never fully made |
| identity must be as wide as its subject | two upgrades clearing one symptom by different changes — the second silently overwrote the first |

Several of those are stated in those words elsewhere in this codebase. None are
stated anywhere a new path can see.

## Schema

Records gain `upgrade_started_at` and `upgrade_succeeded`. Probes inside the apply
window are **discarded** rather than assigned to either side, and a record lacking
either field is declined for repair-learning rather than guessed at.

## Vocabulary

Remedies stay `source: live`, not `fix`. `fix` is permanent; `live` is retirable
by S156a, and what is true of a running service stops being true. ADR-0019
amended: the source tag is about **provenance and retention**, the rule text is
about **shape**, and they are separate axes.

## Declined, with a reason

Loosening `ExtractAvoidPitfall`'s strict attribution so removals can attribute
from live details. That strictness exists because of an `aws_subnet` false
positive in S63 and the **run loop** depends on it; weakening it to serve a
different caller is not a trade this slice is entitled to make. The limit is
pinned by a test rather than left to be rediscovered.

Also reverted mid-slice: a fix making `ExtractFixPitfall` accept a bare resource
type. Real latent no-op, but unused once attribution moved to the diff, and it
changes the **run loop's** behaviour as a side effect of a live-learning slice.

Codex passes 91–98 archived; 98 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD