### PR TITLE
S159a: the live estate, read-only, over the API

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,46 @@
 
 Last updated: 2026-08-31
 
+## 2026-09-01 — S159a: the live estate, read-only, over the API
+
+S159 as planned bundles a read path, five mutating endpoints and a seam
+extraction. Split, applying S156d's lesson: the read path carries no guards and
+the mutating ones carry all of them, so shipping the read first lets the estate
+page be built against something real without any of those guards being
+reimplemented in a hurry.
+
+`GET /api/deployments` serves the estate. It refuses every mutating method, and
+says so when no live store is configured rather than answering with an empty list
+that reads as "nothing is running" — the same rule `live reconcile` applies.
+
+**The health summary moved onto the record.** `live ls` and this listing must
+agree about what silence means, and two implementations of "the last observation,
+unless there are none" is how one of them eventually renders `unobserved` as
+healthy — silently, and only in the UI, where it is least likely to be noticed.
+`healthLabel` now defers to `Deployment.Health()`.
+
+**`unchecked` is spelled out, and finding that was the point of the slice.**
+`VersionUnchecked` is the empty string on the stored record, which is right there
+— `omitempty` keeps the file terse. In a *view* it is a falsehood: a UI rendering
+`""` shows a blank cell beside a `confirmed` one and invites the reader to read
+nothing-was-checked as nothing-is-wrong. The UI arc plan warns about exactly this
+and the zero value would have delivered it. `HealthSummary.Version` is a string
+that always says the word.
+
+**The same defect turned up three times, and the third fix is the one that
+matters.** `omitempty` does nothing on a `time.Time` — it is a struct, so the tag
+has nothing to act on — and `VersionUnchecked` is the empty string. So the
+version label would have rendered blank, the observation timestamp as
+`0001-01-01`, and the embedded record's upgrade timestamps the same. Pass 99's
+own note says that *checking the field I was thinking about and not its
+neighbours* caused it; pass 100 was me doing that again. It is closed as a class
+now: a test marshals a deployment with every optional field unset and asserts
+`0001-01-01` appears nowhere, so the next optional time inherits a failing test
+rather than the defect.
+
+Records the store could not decode travel in the payload. `live ls` exits
+non-zero for those; a GET cannot, so the count has to reach the page.
+
 ## 2026-09-01 — S156d: prescriptive rules from upgrade diffs
 
 S156c writes descriptive rules only — what was observed, nothing about what to do.

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -664,3 +664,20 @@ they describe neither the old configuration nor the new one, only the changeover
 A record with no `upgrade_started_at` is declined for repair-learning rather than
 guessed at — fail-closed, and it costs only records written before this field
 existed.
+
+## Amendment, 2026-09-01 (S159a): what a view of a deployment must say out loud
+
+The record is terse on purpose: `VersionUnchecked` is the empty string and
+`omitempty` keeps it out of the file entirely. A **view** of the record may not
+be.
+
+`unobserved` and `unchecked` are the load-bearing states of this ADR's three-state
+design, and both are the zero value. Rendered as a blank cell beside a
+`confirmed` one, they invite the reader to read *nothing was checked* as *nothing
+is wrong* — rebuilding the falsehood the design exists to prevent, in the one
+place it is least likely to be noticed.
+
+So `Deployment.Health()` always spells them out, and lives on the record rather
+than being assembled by each caller. `live ls` and `GET /api/deployments` must
+agree about what silence means; two implementations of "the last observation,
+unless there are none" is how one of them eventually gets it wrong.

--- a/docs/review-passes/pass100.md
+++ b/docs/review-passes/pass100.md
@@ -1,0 +1,33 @@
+# Codex review pass 100 — S159a
+
+One finding, accepted, and **the third instance of the same defect in this
+slice.**
+
+## [P2] The embedded record leaked year-1 upgrade timestamps
+
+`deploymentJSON` embeds `livestore.Deployment`, whose `UpgradedAt` and
+`UpgradeStartedAt` are `time.Time` with `omitempty` — a tag that does nothing on
+a struct. A deployment that was never upgraded arrived carrying an upgrade date
+in the year 1.
+
+## Three findings, one defect, and I wrote the lesson down between two of them
+
+- the **version label** would have rendered as `""` — the reason this slice
+  exists;
+- the **observation timestamp** as `0001-01-01` — pass 99;
+- the **upgrade timestamps** as `0001-01-01` — this one.
+
+Pass 99's note says, in as many words, that *"checking the field I was thinking
+about and not its neighbours"* caused it. I then fixed the field I was thinking
+about and not its neighbours.
+
+## So it is closed as a class, not a field
+
+`TestDeploymentPayloadNeverCarriesAYearOneTimestamp` marshals a deployment with
+**every optional field unset** and asserts the string `0001-01-01` appears
+nowhere in the payload. The next optional time added to the record would inherit
+the defect silently; now it fails a test instead.
+
+That is the narrow-audit lesson applied to a serialisation
+bug: three fields fixed one at a time is a snapshot, and the class is what the
+next person needs closed.

--- a/docs/review-passes/pass101.md
+++ b/docs/review-passes/pass101.md
@@ -1,0 +1,17 @@
+# Codex review pass 101 — S159a
+
+**Clean.** No correctness regression; the new tests cover the serialisation and
+method-handling behaviour.
+
+Three passes, three findings, and all three were one defect: **the zero value is
+a lie in a view.** `""` for a version that was never checked, `0001-01-01` for a
+moment that never happened, twice.
+
+The slice was planned around exactly that — the UI arc plan warns that rendering
+`unobserved` and `unchecked` as blank cells rebuilds the falsehood the three-state
+design exists to prevent. Knowing the defect by name did not stop me shipping it
+twice more in fields adjacent to the one I had just fixed.
+
+What ended it was not a third careful fix but a test that asserts the *class*:
+marshal a deployment with every optional field unset, and fail if `0001-01-01`
+appears anywhere in the payload.

--- a/docs/review-passes/pass99.md
+++ b/docs/review-passes/pass99.md
@@ -1,0 +1,29 @@
+# Codex review pass 99 — S159a
+
+One finding, accepted. **It is the slice's own bug, one field over.**
+
+## [P2] A never-observed deployment reported being observed in the year 1
+
+`omitempty` does not omit a zero `time.Time`. It is a struct, so the tag has no
+effect and it marshals as `0001-01-01T00:00:00Z`. `GET /api/deployments` therefore
+gave every never-probed deployment an apparent last-observed timestamp.
+
+Worse than a blank cell, because it looks like data. A page would render a date
+next to `unobserved`, and a reader trusts a date.
+
+This slice exists *because* the zero value lies in a view: `VersionUnchecked` is
+the empty string and would have rendered as a blank cell, so `HealthSummary.Version`
+became a string that always says the word. I wrote that comment, then left the
+field directly beneath it with the same defect in a different disguise — a struct
+whose zero value serialises rather than disappearing.
+
+`At` is a `*time.Time` now, nil when nobody looked.
+
+## The generalisation
+
+"The zero value is a lie in a view" is not a fact about one field. It is a
+property of every optional field in a payload a human reads, and each type
+expresses it differently: `""` for a string, `0001-01-01` for a time, `0` for a
+count, `false` for a flag. Checking the field I was thinking about and not its
+neighbours is what made a one-finding pass out of a slice whose whole subject was
+that defect.

--- a/internal/api/handlers_deployments.go
+++ b/internal/api/handlers_deployments.go
@@ -1,0 +1,136 @@
+package api
+
+import (
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+// DeploymentLister reads the live estate.
+//
+// An interface rather than a concrete store because the API package does
+// not own where the estate lives -- `internal/cli` resolves the live
+// store root from configuration and flags -- and the same seam already
+// carries RunStarter.
+type DeploymentLister interface {
+	List() ([]livestore.Deployment, []error, error)
+}
+
+// deploymentJSON is one deployment as the UI needs it.
+//
+// The health summary comes from `Deployment.Health()` rather than being
+// assembled here, so this listing and `live ls` cannot disagree about
+// what silence means (S159a).
+type deploymentJSON struct {
+	livestore.Deployment
+
+	// Unreadable is re-exported because the embedded field is
+	// `json:"-"`. Without it a consumer sees a phantom deployment with
+	// no scenario, project or state and no way to tell it from a real
+	// record -- the same reason `live ls` re-exports it.
+	Unreadable bool                    `json:"unreadable"`
+	Health     livestore.HealthSummary `json:"health"`
+	Expired    bool                    `json:"expired"`
+	TTLSeconds int64                   `json:"time_to_live_seconds"`
+	Upgraded   bool                    `json:"upgraded"`
+
+	// These SHADOW the embedded record's fields of the same name, for a
+	// reason that is a property of the language rather than of this
+	// record: `omitempty` does not omit a zero `time.Time`. It is a
+	// struct, so the tag has nothing to act on and the field marshals
+	// as `0001-01-01T00:00:00Z`.
+	//
+	// A deployment that was never upgraded would arrive carrying an
+	// upgrade date in the year 1 -- worse than a missing field, because
+	// a page renders it and a reader trusts a date.
+	//
+	// Every optional time in a view has this defect by default, which is
+	// why TestDeploymentPayloadNeverCarriesAYearOneTimestamp checks the
+	// whole payload rather than these two fields: the next optional time
+	// added to the record inherits it silently.
+	UpgradedAt       *time.Time `json:"upgraded_at"`
+	UpgradeStartedAt *time.Time `json:"upgrade_started_at"`
+}
+
+// optionalTime is nil for the zero time, so an absent moment serialises
+// as `null` rather than as the year 1.
+func optionalTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
+type deploymentsResponse struct {
+	Schema      string           `json:"schema"`
+	Deployments []deploymentJSON `json:"deployments"`
+
+	// Unreadable carries records the store could not decode.
+	//
+	// Reported rather than omitted, and the count is what the UI must
+	// show: a record that will not decode may describe running,
+	// billing infrastructure, so a listing that silently dropped it
+	// would make "we could not check" look like "nothing is running".
+	// `live ls` exits non-zero for this; a GET cannot, so the payload
+	// has to carry it where a page will see it.
+	Unreadable []string `json:"unreadable"`
+}
+
+// deploymentsHandler serves the live estate, read-only.
+//
+// Deliberately read-only. Deploying, tearing down and reaping all carry
+// guards that live in `internal/cli` and are not reachable from here
+// without a seam that does not exist yet; shipping the read first lets
+// the estate page be built against something real without any of those
+// guards being reimplemented in a hurry.
+func deploymentsHandler(state *serverState) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		if state.deployments == nil {
+			writeJSONError(w, http.StatusNotImplemented, "live deployments are not configured")
+			return
+		}
+
+		deployments, unreadable, err := state.deployments.List()
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		now := time.Now()
+		payload := deploymentsResponse{
+			Schema:      "infrafactory.api.deployments.v1",
+			Deployments: make([]deploymentJSON, 0, len(deployments)),
+			Unreadable:  make([]string, 0, len(unreadable)),
+		}
+		for _, d := range deployments {
+			payload.Deployments = append(payload.Deployments, deploymentJSON{
+				Deployment: d,
+				Unreadable: d.Undecodable,
+				Health:     d.Health(),
+				Expired:    d.Expired(now),
+				TTLSeconds: int64(d.TimeToLive(now).Seconds()),
+				Upgraded:   !d.UpgradedAt.IsZero(),
+
+				UpgradedAt:       optionalTime(d.UpgradedAt),
+				UpgradeStartedAt: optionalTime(d.UpgradeStartedAt),
+			})
+		}
+		for _, e := range unreadable {
+			payload.Unreadable = append(payload.Unreadable, e.Error())
+		}
+
+		// Soonest to expire first: the estate page's job is to show what
+		// needs attention, and what is about to vanish needs it most.
+		sort.SliceStable(payload.Deployments, func(i, j int) bool {
+			return payload.Deployments[i].TTLSeconds < payload.Deployments[j].TTLSeconds
+		})
+
+		writeJSON(w, http.StatusOK, payload)
+	}
+}

--- a/internal/api/handlers_deployments_test.go
+++ b/internal/api/handlers_deployments_test.go
@@ -1,0 +1,173 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redscaresu/infrafactory/internal/config"
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+type fakeDeployments struct {
+	deployments []livestore.Deployment
+	unreadable  []error
+	err         error
+}
+
+func (f *fakeDeployments) List() ([]livestore.Deployment, []error, error) {
+	return f.deployments, f.unreadable, f.err
+}
+
+func getDeployments(t *testing.T, lister DeploymentLister) (*httptest.ResponseRecorder, deploymentsResponse) {
+	t.Helper()
+	srv := NewServer(ServerConfig{Config: config.Default(), Deployments: lister})
+	req := httptest.NewRequest(http.MethodGet, "/api/deployments", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	var payload deploymentsResponse
+	if rec.Code == http.StatusOK {
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	}
+	return rec, payload
+}
+
+func liveDeployment(id string, ttl time.Duration, observations ...livestore.Observation) livestore.Deployment {
+	return livestore.Deployment{
+		ID: id, Scenario: "web-live-paris", Cloud: "scaleway",
+		ProjectID: "proj-1", State: livestore.StateLive,
+		CreatedAt: time.Now().Add(-time.Hour), ExpiresAt: time.Now().Add(ttl),
+		Observations: observations,
+	}
+}
+
+// The load-bearing case for the estate page. A deployment nobody probed
+// must arrive saying so, in words, on both axes -- a blank cell beside a
+// `confirmed` one invites the reader to read silence as health.
+func TestDeploymentsReportUnobservedAndUncheckedInWords(t *testing.T) {
+	_, payload := getDeployments(t, &fakeDeployments{
+		deployments: []livestore.Deployment{liveDeployment("dep-1", time.Hour)},
+	})
+
+	require.Len(t, payload.Deployments, 1)
+	assert.Equal(t, livestore.HealthUnobserved, payload.Deployments[0].Health.Status)
+	assert.Equal(t, "unchecked", payload.Deployments[0].Health.Version)
+}
+
+// A record that will not decode may describe running, billing
+// infrastructure. `live ls` exits non-zero for this; a GET cannot, so the
+// payload has to carry it where a page will see it.
+func TestDeploymentsCarryRecordsTheStoreCouldNotRead(t *testing.T) {
+	_, payload := getDeployments(t, &fakeDeployments{
+		unreadable: []error{errors.New("dep-broken.json: unexpected end of JSON input")},
+	})
+
+	require.Len(t, payload.Unreadable, 1)
+	assert.Contains(t, payload.Unreadable[0], "dep-broken.json")
+}
+
+// Healthy-but-on-the-wrong-version is the most dangerous state the system
+// can be in, and the one every other signal calls fine.
+func TestDeploymentsKeepVersionDriftVisible(t *testing.T) {
+	_, payload := getDeployments(t, &fakeDeployments{
+		deployments: []livestore.Deployment{liveDeployment("dep-1", time.Hour, livestore.Observation{
+			At: time.Now(), Status: livestore.ObservationHealthy, Version: livestore.VersionUnconfirmed,
+		})},
+	})
+
+	require.Len(t, payload.Deployments, 1)
+	assert.Equal(t, "healthy", payload.Deployments[0].Health.Status)
+	assert.Equal(t, "unconfirmed", payload.Deployments[0].Health.Version)
+}
+
+// What is about to vanish needs attention most.
+func TestDeploymentsAreOrderedBySoonestToExpire(t *testing.T) {
+	_, payload := getDeployments(t, &fakeDeployments{deployments: []livestore.Deployment{
+		liveDeployment("dep-late", 4*time.Hour),
+		liveDeployment("dep-soon", time.Minute),
+		liveDeployment("dep-mid", time.Hour),
+	}})
+
+	require.Len(t, payload.Deployments, 3)
+	assert.Equal(t, []string{"dep-soon", "dep-mid", "dep-late"}, []string{
+		payload.Deployments[0].ID, payload.Deployments[1].ID, payload.Deployments[2].ID,
+	})
+}
+
+// An upgraded deployment is a different thing from one that never moved.
+func TestDeploymentsMarkOnesThatWereUpgraded(t *testing.T) {
+	d := liveDeployment("dep-1", time.Hour)
+	d.UpgradedAt = time.Now()
+
+	_, payload := getDeployments(t, &fakeDeployments{deployments: []livestore.Deployment{d}})
+
+	require.Len(t, payload.Deployments, 1)
+	assert.True(t, payload.Deployments[0].Upgraded)
+}
+
+// Read-only, deliberately: deploy, teardown and reap carry guards that
+// live in internal/cli and are not reachable from here.
+func TestDeploymentsRefuseEveryMutatingMethod(t *testing.T) {
+	srv := NewServer(ServerConfig{Config: config.Default(), Deployments: &fakeDeployments{}})
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+		req := httptest.NewRequest(method, "/api/deployments", nil)
+		rec := httptest.NewRecorder()
+		srv.Handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, rec.Code, "%s must not be served", method)
+	}
+}
+
+// A store that cannot be read is an error, never an empty estate: the
+// same rule live reconcile applies, for the same reason.
+func TestDeploymentsFailRatherThanReportingAnEmptyEstate(t *testing.T) {
+	rec, _ := getDeployments(t, &fakeDeployments{err: errors.New("permission denied")})
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// A server with no live store configured says so, rather than answering
+// with an empty list that reads as "nothing is running".
+func TestDeploymentsSayWhenTheyAreNotConfigured(t *testing.T) {
+	srv := NewServer(ServerConfig{Config: config.Default()})
+	req := httptest.NewRequest(http.MethodGet, "/api/deployments", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotImplemented, rec.Code)
+}
+
+// The class, closed once rather than field by field.
+//
+// `omitempty` does not omit a zero `time.Time` -- it is a struct, so the
+// tag has nothing to act on and the field marshals as year 1. Every
+// optional time in this payload has that defect by default, and the next
+// one added to the record inherits it silently.
+//
+// Three review findings in this slice were instances of it: the version
+// label, the observation timestamp, and the upgrade timestamps. Checking
+// the field in front of me and not its neighbours produced all three, so
+// this checks the whole payload instead.
+func TestDeploymentPayloadNeverCarriesAYearOneTimestamp(t *testing.T) {
+	// Deliberately a record with every optional field unset: never
+	// upgraded, never observed, no address, no image.
+	rec, _ := getDeployments(t, &fakeDeployments{
+		deployments: []livestore.Deployment{{
+			ID: "dep-bare", Scenario: "web-live-paris", Cloud: "scaleway",
+			ProjectID: "proj-1", State: livestore.StateLive,
+			CreatedAt: time.Now(), ExpiresAt: time.Now().Add(time.Hour),
+		}},
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "0001-01-01",
+		"an absent moment must serialise as null; a page renders a date and a reader trusts it")
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -30,6 +30,7 @@ type ServerConfig struct {
 	Hub           *Hub
 	SchemaPath    string
 	RunStarter    RunStarter
+	Deployments   DeploymentLister
 	RuntimeErrors chan error
 }
 
@@ -67,6 +68,7 @@ func NewServer(cfg ServerConfig) *http.Server {
 		hub:          cfg.Hub,
 		schemaPath:   cfg.SchemaPath,
 		runStarter:   cfg.RunStarter,
+		deployments:  cfg.Deployments,
 		sessionID:    fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UTC().UnixNano()),
 		startedAt:    time.Now().UTC(),
 	}
@@ -101,6 +103,7 @@ func NewServer(cfg ServerConfig) *http.Server {
 	mux.HandleFunc("/api/output/", outputHandler(state))
 	mux.HandleFunc("/api/pitfalls", pitfallsHandler(state))
 	mux.HandleFunc("/api/pitfalls/", pitfallsHandler(state))
+	mux.HandleFunc("/api/deployments", deploymentsHandler(state))
 	mux.HandleFunc("/api/ws", websocketHandler(state))
 
 	mux.HandleFunc("/api", notImplementedAPIHandler)
@@ -129,6 +132,7 @@ type serverState struct {
 	hub          *Hub
 	schemaPath   string
 	runStarter   RunStarter
+	deployments  DeploymentLister
 	sessionID    string
 	startedAt    time.Time
 }

--- a/internal/cli/live_command.go
+++ b/internal/cli/live_command.go
@@ -187,11 +187,12 @@ func renderLiveTable(out io.Writer, deployments []livestore.Deployment, unreadab
 // without this the only way to learn a live service is failing is to
 // read the JSON record by hand, and nobody does that until after they
 // already know.
+// healthLabel defers to the record so this table and the API's listing
+// cannot disagree about what silence means. Two implementations of "the
+// last observation, unless there are none" is how one of them eventually
+// renders `unobserved` as healthy.
 func healthLabel(d livestore.Deployment) string {
-	if len(d.Observations) == 0 {
-		return "unobserved"
-	}
-	return string(d.Observations[len(d.Observations)-1].Status)
+	return d.Health().Status
 }
 
 // liveListJSON is a listing, not a staged run, so it does not pretend to

--- a/internal/cli/ui_command.go
+++ b/internal/cli/ui_command.go
@@ -18,6 +18,7 @@ import (
 	"github.com/redscaresu/infrafactory/internal/api"
 	"github.com/redscaresu/infrafactory/internal/config"
 	"github.com/redscaresu/infrafactory/internal/generator"
+	"github.com/redscaresu/infrafactory/internal/livestore"
 	"github.com/redscaresu/infrafactory/internal/runstore"
 	"github.com/spf13/cobra"
 )
@@ -69,6 +70,10 @@ func newUICmd(assets fs.FS) *cobra.Command {
 				Store:      runstore.NewFilesystemStore(resolveRunStoreRoot()),
 				Hub:        hub,
 				RunStarter: starter,
+				// Read-only. Deploy, teardown and reap carry guards that
+				// live in this package and are not reachable from the API
+				// without a seam that does not exist yet (S159a).
+				Deployments: livestore.NewFilesystemStore(resolveLiveStoreRoot()),
 			})
 
 			errCh := make(chan error, 1)

--- a/internal/livestore/health.go
+++ b/internal/livestore/health.go
@@ -1,0 +1,94 @@
+package livestore
+
+import "time"
+
+// HealthUnobserved is the state of a deployment nobody has probed.
+//
+// Deliberately NOT an ObservationStatus: it is the absence of one, and
+// giving it the same type would let it be compared with, defaulted to, or
+// mistaken for a probe result. It exists because the alternative -- an
+// empty string, or a blank cell -- reads as "fine", and rebuilding that
+// falsehood is what the three-state design exists to prevent.
+const HealthUnobserved = "unobserved"
+
+// HealthSummary is what a reader needs to know about whether a live
+// deployment is actually serving.
+//
+// It lives here, on the record, rather than being assembled by each
+// caller. The CLI's `live ls` and the API's deployments listing must
+// agree about what silence means, and two implementations of "take the
+// last observation, unless there are none" is how one of them eventually
+// renders `unobserved` as healthy -- silently, and only in the UI, where
+// it is least likely to be noticed.
+type HealthSummary struct {
+	// Status is a probe status, or HealthUnobserved when there is none.
+	Status string `json:"status"`
+
+	// Version is `confirmed`, `unconfirmed`, or `unchecked`, ALWAYS
+	// spelled out.
+	//
+	// A string rather than a VersionCheck, and that is the whole point:
+	// `VersionUnchecked` is the empty string on the stored record, which
+	// is fine there -- `omitempty` keeps the file terse -- and is a
+	// falsehood in a view. A UI rendering `""` shows a blank cell beside
+	// a `confirmed` one and invites the reader to read nothing-was-checked
+	// as nothing-is-wrong. This is a view, so it says the word.
+	//
+	// Carried separately from Status because they answer different
+	// questions, and the dangerous state is where they disagree: a
+	// service answering perfectly while running something other than
+	// what the record claims looks healthy to every other signal.
+	Version string `json:"version"`
+
+	// At is when the deployment was last observed, or nil when never.
+	//
+	// A POINTER, because `omitempty` does not omit a zero time.Time --
+	// it is a struct, so the tag has no effect and it marshals as
+	// `0001-01-01T00:00:00Z`. A page would then show a never-probed
+	// deployment as last observed in the year 1: worse than a blank
+	// cell, because it looks like data.
+	//
+	// The same defect the Version field above exists to avoid, one line
+	// down and in a different disguise.
+	At *time.Time `json:"at"`
+
+	// Detail is the reason, when there is one.
+	Detail string `json:"detail,omitempty"`
+
+	// Observations is how many probes this record holds, so a reader can
+	// tell one lucky sample from a settled picture.
+	Observations int `json:"observations"`
+}
+
+// Observed reports whether anybody has ever probed this deployment.
+func (h HealthSummary) Observed() bool { return h.Status != HealthUnobserved }
+
+// Health summarises the most recent observation.
+func (d Deployment) Health() HealthSummary {
+	if len(d.Observations) == 0 {
+		// Nobody looked, so nothing is known about the running version
+		// either.
+		return HealthSummary{Status: HealthUnobserved, Version: VersionLabelUnchecked}
+	}
+
+	last := d.Observations[len(d.Observations)-1]
+	at := last.At
+	return HealthSummary{
+		Status:       string(last.Status),
+		Version:      versionLabel(last.Version),
+		At:           &at,
+		Detail:       last.Detail,
+		Observations: len(d.Observations),
+	}
+}
+
+// VersionLabelUnchecked is what `VersionUnchecked` is called in a view.
+const VersionLabelUnchecked = "unchecked"
+
+// versionLabel spells out a VersionCheck, including the empty one.
+func versionLabel(v VersionCheck) string {
+	if v == VersionUnchecked {
+		return VersionLabelUnchecked
+	}
+	return string(v)
+}

--- a/internal/livestore/health_test.go
+++ b/internal/livestore/health_test.go
@@ -1,0 +1,80 @@
+package livestore
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Silence is not health. A deployment nobody probed must say so, in a
+// word, rather than reading as fine.
+func TestHealthOfAnUnobservedDeploymentSaysUnobserved(t *testing.T) {
+	got := Deployment{ID: "dep-1"}.Health()
+
+	assert.Equal(t, HealthUnobserved, got.Status)
+	assert.False(t, got.Observed())
+	assert.Zero(t, got.Observations)
+	assert.Nil(t, got.At, "there is no time at which nobody looked")
+}
+
+// `omitempty` does not omit a zero time.Time -- it is a struct, so the
+// tag has no effect and it marshals as year 1. A page showing a
+// never-probed deployment as "last observed 0001-01-01" is worse than a
+// blank cell, because it looks like data.
+func TestHealthNeverSerialisesAYearOneTimestamp(t *testing.T) {
+	payload, err := json.Marshal(Deployment{ID: "dep-1"}.Health())
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(payload), "0001-01-01")
+	assert.Contains(t, string(payload), `"at":null`)
+}
+
+// The load-bearing case for the UI. `VersionUnchecked` is the empty
+// string on the record -- correct there, and a falsehood in a view: a
+// blank cell beside a `confirmed` one invites the reader to read
+// nothing-was-checked as nothing-is-wrong.
+func TestHealthNeverSerialisesAVersionAsAnEmptyString(t *testing.T) {
+	for name, d := range map[string]Deployment{
+		"never observed": {ID: "dep-1"},
+		"observed with no version path": {ID: "dep-2", Observations: []Observation{
+			{At: time.Now(), Status: ObservationHealthy, Version: VersionUnchecked},
+		}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			payload, err := json.Marshal(d.Health())
+			require.NoError(t, err)
+			assert.Contains(t, string(payload), `"version":"unchecked"`)
+		})
+	}
+}
+
+// The most dangerous state this system can be in, and the one every
+// other signal calls healthy.
+func TestHealthKeepsVersionDriftVisibleBesideAHealthyStatus(t *testing.T) {
+	got := Deployment{Observations: []Observation{
+		{At: time.Now(), Status: ObservationHealthy, Version: VersionUnconfirmed},
+	}}.Health()
+
+	assert.Equal(t, string(ObservationHealthy), got.Status)
+	assert.Equal(t, string(VersionUnconfirmed), got.Version,
+		"a reader must be able to see the two disagree")
+}
+
+// The LAST observation, and the count, so one lucky sample is
+// distinguishable from a settled picture.
+func TestHealthReportsTheLatestObservationAndHowManyThereWere(t *testing.T) {
+	base := time.Now()
+	got := Deployment{Observations: []Observation{
+		{At: base.Add(-time.Minute), Status: ObservationUnhealthy, Detail: "old"},
+		{At: base, Status: ObservationUnreachable, Detail: "connection refused"},
+	}}.Health()
+
+	assert.Equal(t, string(ObservationUnreachable), got.Status)
+	assert.Equal(t, "connection refused", got.Detail)
+	assert.Equal(t, 2, got.Observations)
+	require.NotNil(t, got.At)
+	assert.Equal(t, base, *got.At)
+}


### PR DESCRIPTION
First slice of the UI arc — and a split of the planned S159, which bundles a read
path, five mutating endpoints and a seam extraction. The read path carries no
guards; the mutating ones carry all of them. Shipping the read first lets the
estate page (S161) be built against something real without any of those guards
being reimplemented in a hurry.

`GET /api/deployments` serves the estate. It refuses every mutating method, and
says so when no live store is configured rather than answering with an empty list
that reads as *"nothing is running"* — the rule `live reconcile` already applies.

## The health summary moved onto the record

`live ls` and this listing must agree about what silence means. Two
implementations of *"the last observation, unless there are none"* is how one of
them eventually renders `unobserved` as healthy — silently, and only in the UI,
where it is least likely to be noticed. `healthLabel` now defers to
`Deployment.Health()`.

## The zero value is a lie in a view, and it took three findings to close

The UI arc plan warns that rendering `unobserved` and `unchecked` as blank cells
rebuilds the falsehood the three-state design exists to prevent. Knowing that by
name did not stop me shipping it twice more:

- **`VersionUnchecked` is the empty string.** Right on the stored record —
  `omitempty` keeps the file terse. In a view it renders as a blank cell beside a
  `confirmed` one. `HealthSummary.Version` is a string that always says the word.
- **`omitempty` does nothing on a `time.Time`.** It is a struct, so the tag has
  nothing to act on: a never-observed deployment reported being observed at
  `0001-01-01T00:00:00Z`. Worse than a blank cell, because a page renders a date
  and a reader trusts it.
- **The embedded record's `upgraded_at` / `upgrade_started_at`** had the identical
  defect.

Pass 99's own note says that *"checking the field I was thinking about and not
its neighbours"* caused it. Pass 100 was me doing exactly that again.

**So it is closed as a class**: `TestDeploymentPayloadNeverCarriesAYearOneTimestamp`
marshals a deployment with every optional field unset and fails if `0001-01-01`
appears anywhere in the payload. The next optional time added to the record
inherits a failing test rather than the defect.

## Also carried

Records the store could not decode travel in the payload. `live ls` exits
non-zero for those; a GET cannot, so the count has to reach the page — otherwise
"we could not check" looks like "nothing is running".

ADR-0024 amended with what a *view* of a deployment must say out loud. Codex
passes 99–101 archived; 101 clean.

## Not in this PR

S159b: the mutating endpoints, which need `runDeployCommand` to become callable
without a `*cobra.Command`. That extraction is the largest part of the original
S159 and belongs with the guards it has to preserve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD