### PR TITLE
S159b: teardown and reap over the API

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,31 @@
 
 Last updated: 2026-08-31
 
+## 2026-09-02 — S159b: teardown and reap over the API
+
+The mutating half of the deployments endpoint, and the seam turned out to be much
+thinner than the plan expected: `tearDownDeployment` already took a context, a
+runtime and a store, so `LiveActions` translates its staged output and does
+nothing else. **None of the guards are restated at the seam** — teardown still
+refuses unless a run-owned marker and the API's own provenance both say the
+project is infrafactory's, because a second implementation of a guard is a second
+thing that can be wrong.
+
+**Deploy is deliberately not here.** Teardown and reap reduce cost; deploy
+creates it, and the deploy button still needs its safety model.
+
+**The capability does not exist without `--allow-teardown`.** Nil actor, 404
+routes — not "exists and refuses", so a request cannot talk this server into
+destroying infrastructure even if the origin guard has a bug. Same rule as
+`--allow-layer3`, applied to the other direction of harm: teardown is not safe
+merely because it removes rather than creates. It is irreversible.
+
+404 rather than 501, because announcing "not implemented" advertises a capability
+the operator declined. And if `--allow-teardown` IS given and the runtime cannot
+be built, the server refuses to start rather than coming up silently without it.
+
+A teardown that cannot prove the account clean answers **409**, not 200.
+
 ## 2026-09-02 — S161: the estate page
 
 `/deployments` renders what is running, built on S159a's read endpoint. It reads;

--- a/STATUS.md
+++ b/STATUS.md
@@ -27,6 +27,11 @@ be built, the server refuses to start rather than coming up silently without it.
 
 A teardown that cannot prove the account clean answers **409**, not 200.
 
+Both review findings were rules **already written in this codebase, next to the
+code that follows them** — `withRuntimeNoGenerator` on requiring the LLM for
+housekeeping, and `ensureRunProject` on not letting a caller cancel a change to
+real infrastructure. That is four findings in two days of the same shape.
+
 ## 2026-09-02 — S161: the estate page
 
 `/deployments` renders what is running, built on S159a's read endpoint. It reads;

--- a/docs/decisions/0026-the-ui-api-answers-only-loopback-origins.md
+++ b/docs/decisions/0026-the-ui-api-answers-only-loopback-origins.md
@@ -140,3 +140,55 @@ used the checkbox now gets no real-cloud apply until they restart with
 `--allow-layer3`. That is the intended behaviour change and the whole point of
 the slice: it makes the moment of authorisation explicit and attributable to a
 person, rather than implicit in a file.
+
+## Amendment, 2026-09-02 (S159b): destructive actions are start-time too
+
+`DELETE /api/deployments/{id}` and `POST /api/deployments/reap` exist only when
+the server was started with `infrafactory ui --allow-teardown`. Without it the
+actor is nil and the routes answer **404** — the capability does not exist, so
+there is nothing to bypass.
+
+That is the same rule as `--allow-layer3`, applied to the other direction of
+harm. Teardown is not safe merely because it removes rather than creates: it is
+irreversible, it acts on real infrastructure, and a demo torn down mid-talk costs
+something even though the bill goes down.
+
+**404, not 501.** Announcing "not implemented" would advertise a capability the
+operator declined.
+
+**And it fails loudly when asked for.** If `--allow-teardown` is given and the
+teardown runtime cannot be built, the server refuses to start rather than coming
+up without it. A UI silently missing a capability the operator requested is a
+guard that stops without saying why (ADR-0023).
+
+### The guards are not re-expressed at the seam
+
+`LiveActions` calls `tearDownDeployment` — the same function the CLI calls — and
+does nothing but translate its staged output. Teardown refuses unless a run-owned
+marker *and* the API's own provenance both say the project is infrafactory's, and
+it declines to mark a deployment released when its state has vanished, because
+that would retire the only record saying its resources may still exist. None of
+that is restated here. **A second implementation of a guard is a second thing
+that can be wrong.**
+
+### A partial teardown is a 409
+
+ADR-0024's rule is that a teardown which cannot *prove* the account clean must
+not report success. `ActionResult.Clean` is its own field rather than "no
+failures", and a result carrying failures answers 409 — a page rendering a green
+tick over *"the state file has vanished and the resources may still be running"*
+is exactly the false green this project exists to avoid.
+
+### A destroy is not cancellable by the caller
+
+`r.Context()` is cancelled when the client disconnects — closing the tab,
+navigating away, a flaky wifi hop. A teardown cancelled halfway has already
+deleted some resources and not others, and the live record then describes neither
+the old state nor the new one.
+
+So the destructive handlers run on a context detached from the request, with a
+generous timeout as a backstop against a hung provider call rather than as a
+deadline. This is the same rule `ensureRunProject` applies to creating a run's
+project: **once an operation begins changing real infrastructure, the caller
+going away must not stop it.** Whoever asked can leave; the destroy finishes and
+the record ends up describing what is actually there.

--- a/docs/review-passes/pass107.md
+++ b/docs/review-passes/pass107.md
@@ -1,0 +1,32 @@
+# Codex review pass 107 — S159b
+
+One finding, accepted, and it is a good one because the consequence is the
+opposite of the intent.
+
+## [P2] Teardown required LLM credentials to start
+
+`teardownActor` called `buildRuntime` with the default options, which construct
+the Claude transport. That construction fails on a missing `claude` binary or an
+unreadable prompts directory.
+
+So `--allow-teardown` would refuse to start on a machine with no LLM configured —
+**making the recovery capability unavailable in exactly the situation that needs
+it**: real infrastructure running, and a machine that was never set up to
+generate anything.
+
+The pattern already existed and I did not reach for it. `withRuntimeNoGenerator`
+exists for `pitfalls retire`, with a comment saying almost this: *"making corpus
+maintenance impossible because the LLM is not configured is a dependency nobody
+asked for, and it would bite hardest on exactly the machine doing housekeeping
+rather than generation."* The same sentence applies to teardown with a stronger
+consequence, because the housekeeping here is billable.
+
+The actor now builds with a refusing generator stub — loud if ever called, absent
+as a dependency.
+
+## Worth noting
+
+This is the fourth time in two days a finding has been *"the rule is already
+stated somewhere in this codebase, in almost these words, and the new path did
+not inherit it."* The rules are written next to the code that follows them, which
+is exactly where a new path cannot see them.

--- a/docs/review-passes/pass108.md
+++ b/docs/review-passes/pass108.md
@@ -1,0 +1,37 @@
+# Codex review pass 108 — S159b
+
+One finding, accepted.
+
+## [P2] Closing the browser tab could cancel a destroy mid-flight
+
+The handlers passed `r.Context()` straight through. That context is cancelled
+when the client disconnects, so navigating away during a teardown would abort a
+destroy that had already removed some resources and not others — leaving the live
+record describing neither the old state nor the new one.
+
+The rule is already in this codebase, in `ensureRunProject`: *"The create is NOT
+cancellable by the caller's context."* Once an operation begins changing real
+infrastructure, the caller going away must not stop it.
+
+Destructive handlers now run on `context.WithoutCancel` plus a 30-minute
+backstop — generous rather than tight, because a real destroy-plus-sweep-plus-
+project-delete has taken minutes against Scaleway and cutting one short is the
+failure this timeout exists to *avoid*, not to cause.
+
+## The first test failed against correct code
+
+It captured the context and asserted on it after `ServeHTTP` returned — by which
+time the handler's own `defer cancel()` had fired. It was measuring the cleanup,
+not the disconnect.
+
+Worth recording because the instinct on a red test is to change the code, and the
+code was right. The test now records `ctx.Err()` *during* the call.
+
+## Two passes, two findings, both the same
+
+Pass 107: teardown required LLM credentials, and `withRuntimeNoGenerator` already
+existed with a comment explaining why that is wrong. Pass 108: teardown was
+cancellable, and `ensureRunProject` already says why that is wrong.
+
+Both rules live next to the code that follows them — which is exactly where a new
+path cannot see them.

--- a/docs/review-passes/pass109.md
+++ b/docs/review-passes/pass109.md
@@ -1,0 +1,9 @@
+# Codex review pass 109 — S159b
+
+**Clean.** No correctness issue. It confirmed the routing, the failure status, the
+origin guarding and the cancellation behaviour are covered, and that the seam
+reuses the existing CLI teardown path rather than reimplementing it.
+
+Run after a quota exhaustion interrupted pass 108's confirmation — the slice sat
+unmerged rather than being merged on two fixed findings and an assumption, since
+one clean pass is the merge precondition.

--- a/internal/api/deployment_actions.go
+++ b/internal/api/deployment_actions.go
@@ -1,0 +1,44 @@
+package api
+
+import "context"
+
+// ActionStep is one thing an action did, in the shape a page can render.
+//
+// Deliberately not the CLI's StageSummary: this package does not import
+// `internal/cli`, and a neutral shape at the seam is what keeps the
+// dependency pointing one way -- the same arrangement RunStarter uses.
+type ActionStep struct {
+	Stage  string `json:"stage"`
+	Status string `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// ActionResult is what happened, reported whether or not it worked.
+//
+// `Clean` is a separate field from the absence of failures because they
+// are different claims. ADR-0024's rule is that a teardown which cannot
+// PROVE the account is clean must not report success -- a deployment
+// whose state has vanished is not released, because marking it released
+// would retire the only record saying its resources may still exist.
+type ActionResult struct {
+	Clean bool         `json:"clean"`
+	Steps []ActionStep `json:"steps"`
+
+	// Failures are the reasons it is not clean. Carried separately so a
+	// page cannot render a partial success as a success.
+	Failures []ActionStep `json:"failures"`
+}
+
+// DeploymentActor performs the destructive half of live management.
+//
+// Separate from DeploymentLister on purpose. Reading the estate is safe
+// and always available; destroying infrastructure is neither, and a
+// server that can only read cannot be talked into more than reading
+// (S159b).
+type DeploymentActor interface {
+	// Teardown destroys one deployment's infrastructure.
+	Teardown(ctx context.Context, id string) (ActionResult, error)
+
+	// Reap destroys every deployment whose TTL has run out.
+	Reap(ctx context.Context) (ActionResult, error)
+}

--- a/internal/api/handlers_deployment_actions_test.go
+++ b/internal/api/handlers_deployment_actions_test.go
@@ -1,0 +1,241 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redscaresu/infrafactory/internal/config"
+)
+
+type fakeActor struct {
+	result    ActionResult
+	err       error
+	teardowns []string
+	reaps     int
+	notExist  bool
+}
+
+func (f *fakeActor) Teardown(_ context.Context, id string) (ActionResult, error) {
+	f.teardowns = append(f.teardowns, id)
+	if f.notExist {
+		return ActionResult{}, os.ErrNotExist
+	}
+	return f.result, f.err
+}
+
+func (f *fakeActor) Reap(context.Context) (ActionResult, error) {
+	f.reaps++
+	return f.result, f.err
+}
+
+func actionServer(t *testing.T, actor DeploymentActor) *http.Server {
+	t.Helper()
+	return NewServer(ServerConfig{
+		Config: config.Default(), Deployments: &fakeDeployments{}, DeploymentActor: actor,
+	})
+}
+
+func do(t *testing.T, srv *http.Server, method, path string) (*httptest.ResponseRecorder, ActionResult) {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	var result ActionResult
+	if rec.Code == http.StatusOK || rec.Code == http.StatusConflict {
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &result))
+	}
+	return rec, result
+}
+
+// The capability does not EXIST unless the operator asked for it in the
+// shell. Not "exists and refuses": a request must not be able to talk
+// this server into destroying infrastructure, and that property survives
+// a bug in the origin guard.
+func TestTeardownEndpointsDoNotExistWithoutTheFlag(t *testing.T) {
+	srv := actionServer(t, nil)
+
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodDelete, "/api/deployments/dep-1"},
+		{http.MethodPost, "/api/deployments/reap"},
+	} {
+		rec, _ := do(t, srv, tc.method, tc.path)
+		assert.Equal(t, http.StatusNotFound, rec.Code, "%s %s", tc.method, tc.path)
+		assert.Contains(t, rec.Body.String(), "--allow-teardown")
+	}
+}
+
+func TestTeardownDestroysTheNamedDeployment(t *testing.T) {
+	actor := &fakeActor{result: ActionResult{Clean: true, Steps: []ActionStep{
+		{Stage: "teardown", Status: "pass", Detail: "destroyed"},
+	}}}
+	srv := actionServer(t, actor)
+
+	rec, result := do(t, srv, http.MethodDelete, "/api/deployments/dep-1")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, result.Clean)
+	assert.Equal(t, []string{"dep-1"}, actor.teardowns)
+}
+
+// ADR-0024: a teardown that cannot PROVE the account clean must not
+// report success. A page rendering a green tick over "the state file has
+// vanished and the resources may still be running" is the false green
+// this project exists to avoid.
+func TestTeardownThatCannotProveCleanIsNotASuccess(t *testing.T) {
+	srv := actionServer(t, &fakeActor{result: ActionResult{
+		Clean: false,
+		Failures: []ActionStep{{
+			Stage: "teardown", Status: "fail",
+			Detail: "state file has vanished; resources may still be running",
+		}},
+	}})
+
+	rec, result := do(t, srv, http.MethodDelete, "/api/deployments/dep-1")
+
+	assert.Equal(t, http.StatusConflict, rec.Code, "a partial teardown is not a 200")
+	assert.False(t, result.Clean)
+	require.Len(t, result.Failures, 1)
+	assert.Contains(t, result.Failures[0].Detail, "may still be running")
+}
+
+func TestReapDestroysEverythingExpired(t *testing.T) {
+	actor := &fakeActor{result: ActionResult{Clean: true}}
+	srv := actionServer(t, actor)
+
+	rec, _ := do(t, srv, http.MethodPost, "/api/deployments/reap")
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, actor.reaps)
+}
+
+// A deployment id addresses a file in the live store. Anything that
+// could climb out of it is refused BEFORE the store is asked, so a
+// traversal attempt is never a lookup.
+func TestTeardownRefusesIdsThatCouldEscapeTheStore(t *testing.T) {
+	actor := &fakeActor{result: ActionResult{Clean: true}}
+	srv := actionServer(t, actor)
+
+	for _, id := range []string{"..", "../etc/passwd", "a/b", "a.json", ""} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodDelete, "/api/deployments/"+id, nil)
+		srv.Handler.ServeHTTP(rec, req)
+
+		assert.NotEqual(t, http.StatusOK, rec.Code, "id %q must not be served", id)
+	}
+	assert.Empty(t, actor.teardowns, "the store must never be asked about these")
+}
+
+func TestTeardownOfAnUnknownDeploymentIsNotFound(t *testing.T) {
+	srv := actionServer(t, &fakeActor{notExist: true})
+
+	rec, _ := do(t, srv, http.MethodDelete, "/api/deployments/dep-missing")
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// GET must not destroy, and neither must anything else that is not the
+// one verb each action is spelled with.
+func TestDeploymentActionsRefuseTheWrongVerb(t *testing.T) {
+	actor := &fakeActor{result: ActionResult{Clean: true}}
+	srv := actionServer(t, actor)
+
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodGet, "/api/deployments/dep-1"},
+		{http.MethodPost, "/api/deployments/dep-1"},
+		{http.MethodGet, "/api/deployments/reap"},
+		{http.MethodDelete, "/api/deployments/reap"},
+	} {
+		rec := httptest.NewRecorder()
+		srv.Handler.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, nil))
+		assert.Equal(t, http.StatusMethodNotAllowed, rec.Code, "%s %s", tc.method, tc.path)
+	}
+	assert.Empty(t, actor.teardowns)
+	assert.Zero(t, actor.reaps)
+}
+
+// The origin guard covers these too, by position rather than by anyone
+// remembering (S160a).
+func TestDeploymentActionsAreBehindTheOriginGuard(t *testing.T) {
+	srv := actionServer(t, &fakeActor{result: ActionResult{Clean: true}})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/deployments/dep-1", nil)
+	req.Host = "127.0.0.1:4173"
+	req.Header.Set("Origin", "https://evil.example")
+
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// A teardown cancelled halfway has deleted some resources and not
+// others, and the live record then describes neither the old state nor
+// the new one. Closing a browser tab must not do that.
+//
+// The same rule ensureRunProject applies to creating a run's project.
+func TestTeardownSurvivesTheClientDisconnecting(t *testing.T) {
+	actor := &contextCapturingActor{result: ActionResult{Clean: true}}
+	srv := actionServer(t, actor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodDelete, "/api/deployments/dep-1", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	// The client goes away before the handler runs.
+	cancel()
+	srv.Handler.ServeHTTP(rec, req)
+
+	// Recorded DURING the call. Checking the context afterwards would
+	// measure the handler's own `defer cancel()`, not the client's
+	// disconnect -- a distinction that made an earlier version of this
+	// test fail against correct code.
+	assert.NoError(t, actor.errDuringCall, "the destroy must still be running after the caller left")
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	require.True(t, actor.hadDeadline, "a detached destroy still needs a backstop against a hung provider call")
+	assert.True(t, actor.deadline.After(time.Now().Add(20*time.Minute)),
+		"the backstop must not cut a real destroy short")
+}
+
+func TestReapSurvivesTheClientDisconnecting(t *testing.T) {
+	actor := &contextCapturingActor{result: ActionResult{Clean: true}}
+	srv := actionServer(t, actor)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/api/deployments/reap", nil).WithContext(ctx)
+	cancel()
+	srv.Handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.NoError(t, actor.errDuringCall)
+}
+
+type contextCapturingActor struct {
+	result        ActionResult
+	errDuringCall error
+	deadline      time.Time
+	hadDeadline   bool
+}
+
+func (c *contextCapturingActor) observe(ctx context.Context) {
+	c.errDuringCall = ctx.Err()
+	c.deadline, c.hadDeadline = ctx.Deadline()
+}
+
+func (c *contextCapturingActor) Teardown(ctx context.Context, _ string) (ActionResult, error) {
+	c.observe(ctx)
+	return c.result, nil
+}
+
+func (c *contextCapturingActor) Reap(ctx context.Context) (ActionResult, error) {
+	c.observe(ctx)
+	return c.result, nil
+}

--- a/internal/api/handlers_deployments.go
+++ b/internal/api/handlers_deployments.go
@@ -1,8 +1,12 @@
 package api
 
 import (
+	"context"
+	"errors"
 	"net/http"
+	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/redscaresu/infrafactory/internal/livestore"
@@ -133,4 +137,120 @@ func deploymentsHandler(state *serverState) http.HandlerFunc {
 
 		writeJSON(w, http.StatusOK, payload)
 	}
+}
+
+// deploymentActionHandler serves the destructive half of live
+// management: `DELETE /api/deployments/{id}` and
+// `POST /api/deployments/reap`.
+//
+// # Why it can be absent
+//
+// A nil actor is a 404, not a 501, and the difference is deliberate. The
+// server is started with `--allow-teardown` or it is not, and when it is
+// not there is genuinely no such endpoint -- announcing "not
+// implemented" would advertise a capability the operator declined.
+//
+// The gate is start-time for the same reason S160b moved real-cloud
+// apply out of the request body: a REQUEST must not be able to talk this
+// server into destroying infrastructure. The origin guard (S160a) stops
+// a page the server did not serve from reaching here at all, and this
+// stops the capability existing unless a person asked for it in the
+// shell. Two properties, and the second survives a bug in the first.
+//
+// Teardown is not "safe because it only removes things". It is
+// irreversible, it acts on real infrastructure, and a demo torn down
+// mid-talk is a real cost even though the bill goes down.
+func deploymentActionHandler(state *serverState) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if state.deploymentActor == nil {
+			writeJSONError(w, http.StatusNotFound,
+				"this server was not started with --allow-teardown, so it cannot destroy deployments")
+			return
+		}
+
+		tail := strings.TrimPrefix(r.URL.Path, "/api/deployments/")
+		if tail == "reap" {
+			if r.Method != http.MethodPost {
+				writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+				return
+			}
+			ctx, cancel := destructiveContext(r)
+			defer cancel()
+			result, err := state.deploymentActor.Reap(ctx)
+			writeActionResult(w, result, err)
+			return
+		}
+
+		if r.Method != http.MethodDelete {
+			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		// One segment, and no separators. A deployment id addresses a
+		// file in the live store, so anything that could climb out of it
+		// is refused rather than cleaned up: `livestore.validateID`
+		// guards the store itself, and this refuses before the store is
+		// asked, so a traversal attempt is never a lookup.
+		if tail == "" || strings.ContainsAny(tail, "/\\.") {
+			writeJSONError(w, http.StatusBadRequest, "invalid deployment id")
+			return
+		}
+
+		ctx, cancel := destructiveContext(r)
+		defer cancel()
+
+		result, err := state.deploymentActor.Teardown(ctx, tail)
+		if errors.Is(err, os.ErrNotExist) {
+			writeJSONError(w, http.StatusNotFound, "no such deployment")
+			return
+		}
+		writeActionResult(w, result, err)
+	}
+}
+
+// writeActionResult reports what happened, and refuses to call a
+// partial teardown a success.
+//
+// A result carrying failures is 409, not 200: ADR-0024's rule is that a
+// teardown which cannot PROVE the account clean must not report success,
+// and a page rendering a green tick over "the state file has vanished
+// and the resources may still be running" is exactly the false green
+// this project exists to avoid.
+func writeActionResult(w http.ResponseWriter, result ActionResult, err error) {
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	status := http.StatusOK
+	if !result.Clean {
+		status = http.StatusConflict
+	}
+	writeJSON(w, status, result)
+}
+
+// destructiveTimeout bounds an action that is deliberately not
+// cancellable by its caller.
+//
+// Generous rather than tight: a destroy plus an orphan sweep plus the
+// project delete has taken minutes against real Scaleway, and cutting
+// one short is the failure this timeout exists to avoid, not the one it
+// exists to cause. It is a backstop against a hung provider call, not a
+// deadline.
+const destructiveTimeout = 30 * time.Minute
+
+// destructiveContext detaches an action from the HTTP request.
+//
+// `r.Context()` is cancelled when the client disconnects -- closing the
+// tab, navigating away, a flaky wifi hop. A teardown cancelled halfway
+// has already deleted some resources and not others, and the live record
+// then describes neither the old state nor the new one.
+//
+// The same rule `ensureRunProject` applies to creating a run's project:
+// once an operation begins changing real infrastructure, the caller
+// going away must not stop it. Whoever asked can leave; the destroy
+// finishes and the record ends up describing what is actually there.
+//
+// The request's VALUES are kept (tracing, deadlines set by middleware
+// upstream) while its cancellation is dropped.
+func destructiveContext(r *http.Request) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(r.Context()), destructiveTimeout)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -20,18 +20,23 @@ import (
 const uiAssetsMissingMessage = "UI assets not embedded. Run Vite dev server on :5173 or build with: make build"
 
 type ServerConfig struct {
-	Addr          string
-	Assets        fs.FS
-	Config        config.Config
-	Store         *runstore.FilesystemStore
-	MockState     MockStateReader
-	FakegcpState  MockStateReader
-	Formatter     IaCFormatter
-	Hub           *Hub
-	SchemaPath    string
-	RunStarter    RunStarter
-	Deployments   DeploymentLister
-	RuntimeErrors chan error
+	Addr         string
+	Assets       fs.FS
+	Config       config.Config
+	Store        *runstore.FilesystemStore
+	MockState    MockStateReader
+	FakegcpState MockStateReader
+	Formatter    IaCFormatter
+	Hub          *Hub
+	SchemaPath   string
+	RunStarter   RunStarter
+	Deployments  DeploymentLister
+
+	// DeploymentActor is nil unless the operator started the server with
+	// --allow-teardown. Nil means the destructive endpoints do not
+	// exist, rather than existing and refusing.
+	DeploymentActor DeploymentActor
+	RuntimeErrors   chan error
 }
 
 type StartRunRequest struct {
@@ -69,8 +74,10 @@ func NewServer(cfg ServerConfig) *http.Server {
 		schemaPath:   cfg.SchemaPath,
 		runStarter:   cfg.RunStarter,
 		deployments:  cfg.Deployments,
-		sessionID:    fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UTC().UnixNano()),
-		startedAt:    time.Now().UTC(),
+
+		deploymentActor: cfg.DeploymentActor,
+		sessionID:       fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UTC().UnixNano()),
+		startedAt:       time.Now().UTC(),
 	}
 	if state.hub == nil {
 		state.hub = NewHub()
@@ -104,6 +111,7 @@ func NewServer(cfg ServerConfig) *http.Server {
 	mux.HandleFunc("/api/pitfalls", pitfallsHandler(state))
 	mux.HandleFunc("/api/pitfalls/", pitfallsHandler(state))
 	mux.HandleFunc("/api/deployments", deploymentsHandler(state))
+	mux.HandleFunc("/api/deployments/", deploymentActionHandler(state))
 	mux.HandleFunc("/api/ws", websocketHandler(state))
 
 	mux.HandleFunc("/api", notImplementedAPIHandler)
@@ -133,8 +141,10 @@ type serverState struct {
 	schemaPath   string
 	runStarter   RunStarter
 	deployments  DeploymentLister
-	sessionID    string
-	startedAt    time.Time
+
+	deploymentActor DeploymentActor
+	sessionID       string
+	startedAt       time.Time
 }
 
 // mockStateForCloud picks the mock-state reader appropriate for the

--- a/internal/cli/live_service.go
+++ b/internal/cli/live_service.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	"github.com/redscaresu/infrafactory/internal/api"
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+// LiveActions performs teardown and reap for callers that are not a
+// cobra command -- today, the UI server (S159b).
+//
+// It exists so those callers reach the SAME code the CLI does rather
+// than a second implementation. Teardown is the guard between an
+// automated action and somebody's real infrastructure: it refuses unless
+// a run-owned marker and the API's own provenance BOTH say the project
+// is infrafactory's, and it declines to mark a deployment released when
+// its state has vanished, because doing so would retire the only record
+// saying the resources may still be running.
+//
+// None of that is re-expressed here. `tearDownDeployment` already takes
+// a context, a runtime and a store, so this type is a translation layer
+// and nothing else -- which is the point. A second implementation of a
+// guard is a second thing that can be wrong.
+type LiveActions struct {
+	runtime *CommandRuntime
+}
+
+// NewLiveActions builds the actor from an already-constructed runtime.
+func NewLiveActions(runtime *CommandRuntime) *LiveActions {
+	return &LiveActions{runtime: runtime}
+}
+
+func (l *LiveActions) store() *livestore.FilesystemStore {
+	return livestore.NewFilesystemStore(l.runtime.LiveStoreRoot())
+}
+
+// Teardown destroys one deployment, by id.
+func (l *LiveActions) Teardown(ctx context.Context, id string) (api.ActionResult, error) {
+	store := l.store()
+
+	d, err := store.Get(id)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return api.ActionResult{}, err
+		}
+		// An undecodable record still reaches teardown, which reports it
+		// as unreclaimable and names `live forget`. The CLI does the
+		// same; refusing here would hide a record that may describe
+		// running infrastructure.
+		d = livestore.Deployment{ID: id, Undecodable: true}
+	}
+
+	stages, failures := tearDownDeployment(ctx, l.runtime, store, d)
+	return actionResult(stages, failures), nil
+}
+
+// Reap destroys every deployment whose TTL has run out.
+//
+// Note it walks `Reapable` itself rather than calling the cobra command:
+// the command's job is flags, progress on stderr and an exit code, none
+// of which mean anything here. The per-deployment work is the same
+// function.
+func (l *LiveActions) Reap(ctx context.Context) (api.ActionResult, error) {
+	store := l.store()
+
+	expired, unreadable, err := store.Reapable(time.Now())
+	if err != nil {
+		return api.ActionResult{}, err
+	}
+
+	var stages []StageSummary
+	var failures []FailureSummary
+
+	// Surfaced BEFORE any teardown, as the CLI does: an unreadable
+	// record may describe running infrastructure this call is about to
+	// report as handled.
+	for _, readErr := range unreadable {
+		failures = append(failures, FailureSummary{
+			Layer: "live", Stage: "scan", Check: "readable", Command: "live reap",
+			Detail: readErr.Error() + " — this record may describe running infrastructure that reap cannot reach",
+		})
+	}
+
+	if len(expired) == 0 {
+		stages = append(stages, StageSummary{
+			Layer: "live", Stage: "reap", Status: StageStatusPass,
+			Detail: "no expired deployments",
+		})
+	}
+
+	for _, d := range expired {
+		s, f := tearDownDeployment(ctx, l.runtime, store, d)
+		stages = append(stages, s...)
+		failures = append(failures, f...)
+	}
+
+	return actionResult(stages, failures), nil
+}
+
+// actionResult translates the CLI's staged output into the neutral shape
+// the API seam speaks.
+//
+// `Clean` is the absence of failures and is reported as its own field,
+// because "it worked" and "nothing complained" are different claims and
+// ADR-0024 turns on the difference.
+func actionResult(stages []StageSummary, failures []FailureSummary) api.ActionResult {
+	out := api.ActionResult{
+		Clean:    len(failures) == 0,
+		Steps:    make([]api.ActionStep, 0, len(stages)),
+		Failures: make([]api.ActionStep, 0, len(failures)),
+	}
+	for _, s := range stages {
+		out.Steps = append(out.Steps, api.ActionStep{
+			Stage: s.Stage, Status: string(s.Status), Detail: s.Detail,
+		})
+	}
+	for _, f := range failures {
+		out.Failures = append(out.Failures, api.ActionStep{
+			Stage: f.Stage, Status: string(StageStatusFail), Detail: f.Detail,
+		})
+	}
+	return out
+}

--- a/internal/cli/ui_command.go
+++ b/internal/cli/ui_command.go
@@ -26,6 +26,7 @@ import (
 func newUICmd(assets fs.FS) *cobra.Command {
 	var addr string
 	var allowLayer3 bool
+	var allowTeardown bool
 
 	cmd := &cobra.Command{
 		Use:   "ui",
@@ -54,6 +55,11 @@ func newUICmd(assets fs.FS) *cobra.Command {
 			// start a UI.
 			cfg.Validation.Layers.SandboxDeploy.Enabled = allowLayer3
 
+			actor, err := teardownActor(cmd, allowTeardown)
+			if err != nil {
+				return formatCommandError("ui", err)
+			}
+
 			hub := api.NewHub()
 			go hub.Run(cmd.Context())
 			starter := &uiRunStarter{
@@ -64,16 +70,18 @@ func newUICmd(assets fs.FS) *cobra.Command {
 			}
 
 			srv := api.NewServer(api.ServerConfig{
-				Addr:       addr,
-				Assets:     assets,
-				Config:     cfg,
-				Store:      runstore.NewFilesystemStore(resolveRunStoreRoot()),
-				Hub:        hub,
-				RunStarter: starter,
-				// Read-only. Deploy, teardown and reap carry guards that
-				// live in this package and are not reachable from the API
-				// without a seam that does not exist yet (S159a).
+				Addr:        addr,
+				Assets:      assets,
+				Config:      cfg,
+				Store:       runstore.NewFilesystemStore(resolveRunStoreRoot()),
+				Hub:         hub,
+				RunStarter:  starter,
 				Deployments: livestore.NewFilesystemStore(resolveLiveStoreRoot()),
+				// Nil unless the operator asked. A server that cannot
+				// destroy infrastructure cannot be talked into
+				// destroying it, and that property survives a bug in
+				// the origin guard (S159b, ADR-0026).
+				DeploymentActor: actor,
 			})
 
 			errCh := make(chan error, 1)
@@ -104,8 +112,49 @@ func newUICmd(assets fs.FS) *cobra.Command {
 	cmd.Flags().StringVar(&addr, "addr", "127.0.0.1:4173", "Address to bind UI server")
 	cmd.Flags().BoolVar(&allowLayer3, "allow-layer3", false,
 		"Permit runs started from this UI to apply to real infrastructure and spend money")
+	cmd.Flags().BoolVar(&allowTeardown, "allow-teardown", false,
+		"Permit this UI to destroy live deployments (irreversible)")
 
 	return cmd
+}
+
+// teardownActor builds the destructive actor, or nil when the operator
+// did not ask for one.
+//
+// Returning nil rather than a refusing implementation is the point: the
+// endpoints do not exist, so there is nothing to bypass.
+//
+// It returns an ERROR rather than nil when the operator DID ask and the
+// runtime could not be built. Starting anyway would give them a UI that
+// silently lacks the capability they requested -- and a guard that stops
+// without saying why is half a guard (ADR-0023).
+func teardownActor(cmd *cobra.Command, allowTeardown bool) (api.DeploymentActor, error) {
+	if !allowTeardown {
+		return nil, nil
+	}
+	// Built WITHOUT a generator, for the same reason `pitfalls retire`
+	// is: teardown never generates, and `buildRuntime` constructs the
+	// LLM transport by default -- a construction that fails on a missing
+	// `claude` binary or an unreadable prompts directory.
+	//
+	// Requiring LLM credentials in order to DESTROY infrastructure would
+	// make the recovery capability unavailable in exactly the situation
+	// that needs it: real resources running on a machine where the
+	// generator is not configured. Nobody asked for that dependency.
+	//
+	// The stub refuses rather than returning nothing, so a call would be
+	// a loud bug rather than a silent no-op.
+	opts := defaultRuntimeOptions()
+	opts.deps.Generator = generator.SeedGeneratorFunc(
+		func(context.Context, generator.Request) (*generator.GeneratedCode, error) {
+			return nil, errors.New("the UI teardown path does not generate")
+		})
+
+	runtime, err := buildRuntime(cmd, opts)
+	if err != nil {
+		return nil, fmt.Errorf("--allow-teardown was requested but the teardown path could not be built: %w", err)
+	}
+	return NewLiveActions(runtime), nil
 }
 
 type uiRunStarter struct {

--- a/internal/cli/ui_command_test.go
+++ b/internal/cli/ui_command_test.go
@@ -212,3 +212,56 @@ mockway:
 
 	assert.True(t, loaded.Validation.Layers.SandboxDeploy.Enabled)
 }
+
+// Destroying infrastructure is not a capability a request may confer.
+// Without the flag the actor is nil, which means the endpoints do not
+// exist rather than existing and refusing (S159b).
+func TestUICommandBuildsNoTeardownActorWithoutTheFlag(t *testing.T) {
+	cmd := newUICmd(nil)
+
+	flag := cmd.Flags().Lookup("allow-teardown")
+	require.NotNil(t, flag, "without this flag there is no way to ask for the capability")
+	assert.Equal(t, "false", flag.DefValue, "destroying infrastructure is never the default")
+
+	actor, err := teardownActor(cmd, false)
+	require.NoError(t, err)
+	assert.Nil(t, actor, "nothing to bypass if it does not exist")
+}
+
+// A guard that stops without saying why is half a guard. If the operator
+// ASKED for teardown and it cannot be built, starting anyway would hand
+// them a UI silently missing the capability they requested.
+func TestUICommandRefusesToStartWhenRequestedTeardownCannotBeBuilt(t *testing.T) {
+	cmd := newUICmd(nil)
+	cmd.Flags().String("config", filepath.Join(t.TempDir(), "does-not-exist.yaml"), "")
+
+	_, err := teardownActor(cmd, true)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--allow-teardown was requested")
+}
+
+// Requiring LLM credentials in order to DESTROY infrastructure would
+// make the recovery capability unavailable in exactly the situation that
+// needs it: real resources running on a machine where the generator is
+// not configured. Same reasoning as `pitfalls retire`.
+func TestUITeardownActorDoesNotNeedTheGenerator(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "infrafactory.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`version: "1.0"
+agent:
+  type: claude-code
+  claude:
+    command: /nonexistent/claude-binary
+mockway:
+  url: http://localhost:8080
+`), 0o600))
+
+	cmd := newUICmd(nil)
+	cmd.Flags().String("config", path, "")
+
+	actor, err := teardownActor(cmd, true)
+
+	require.NoError(t, err, "a missing claude binary must not stop an operator tearing down real infrastructure")
+	assert.NotNil(t, actor)
+}


### PR DESCRIPTION
> **Not merged.** Codex hit its usage quota mid-review, so the loop has not
> reached a clean pass. Two findings were raised and fixed (passes 107–108); the
> confirming pass is queued for when quota returns.

The mutating half of the deployments endpoint. **The seam is much thinner than
the plan expected**: `tearDownDeployment` already took a context, a runtime and a
store, so `LiveActions` translates its staged output and does nothing else.

**None of the guards are restated at the seam.** Teardown still refuses unless a
run-owned marker *and* the API's own provenance both say the project is
infrafactory's, and still declines to mark a deployment released when its state
has vanished. A second implementation of a guard is a second thing that can be
wrong.

**Deploy is deliberately not here.** Teardown and reap reduce cost; deploy creates
it, and the deploy button still needs its safety model.

## The capability does not exist without `--allow-teardown`

Nil actor, 404 routes — not "exists and refuses". A request cannot talk this
server into destroying infrastructure even if the origin guard has a bug. Same
rule as `--allow-layer3`, applied to the other direction of harm: **teardown is
not safe merely because it removes rather than creates.** It is irreversible, and
a demo torn down mid-talk costs something even though the bill goes down.

404 rather than 501, because announcing "not implemented" advertises a capability
the operator declined. And if the flag *is* given and the runtime cannot be built,
the server refuses to start rather than coming up silently without it — a guard
that stops without saying why is half a guard.

A teardown that cannot *prove* the account clean answers **409**, not 200.

## Both review findings were rules already written in this codebase

- **Teardown required LLM credentials.** `buildRuntime` constructs the Claude
  transport, so `--allow-teardown` would refuse to start on a machine with no LLM
  configured — making the recovery capability unavailable in exactly the situation
  needing it. `withRuntimeNoGenerator` exists for `pitfalls retire` with a comment
  saying almost this.
- **A destroy was cancellable by the client disconnecting.** Closing a tab
  mid-teardown aborts after some resources are gone and others are not, leaving
  the record describing neither state. `ensureRunProject` already says the create
  is not cancellable by the caller's context.

Both rules live next to the code that follows them, which is exactly where a new
path cannot see them. That is now four findings in two days of the same shape.

## One test failed against correct code

The disconnect test captured the context and asserted on it *after* `ServeHTTP`
returned — by which point the handler's own `defer cancel()` had fired. It was
measuring the cleanup, not the disconnect. Recorded because the instinct on a red
test is to change the code, and the code was right.

ADR-0026 amended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD