### PR TITLE
S161b: teardown from the estate page

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,33 @@
 
 Last updated: 2026-08-31
 
+## 2026-09-02 — S161b: teardown from the estate page
+
+The estate page can now destroy what it lists, using S159b's endpoint. Three
+things make that a deliberate act rather than a click:
+
+**The control does not appear unless the server allows it.** The listing reports
+`teardown_allowed`, so the page does not offer a button it knows will 404 — and
+says how to enable it rather than silently omitting the capability. The *safety*
+is still that the endpoint does not exist; a client setting the field locally gets
+a button that 404s.
+
+**The confirmation names what is about to go** — scenario, project, address. "Are
+you sure?" is a speed bump people learn to click through; stating which project is
+about to be deleted makes a misclick on the wrong row visible while it is still
+reversible.
+
+**A teardown that cannot prove the account clean is never shown as success.** The
+409 carries the per-stage failures, and the shared `request` helper would have
+thrown them away — leaving a generic error where *"the state file has vanished and
+the resources may still be running"* belongs. `teardownOutcome` reads `clean`
+rather than counting failures, because they are different claims and ADR-0024
+turns on the difference.
+
+The table reloads whatever the outcome: a failed teardown changes the record too,
+since an unreclaimable deployment stays reapable rather than released, so the page
+must not keep showing what was true before the attempt.
+
 ## 2026-09-02 — S159b: teardown and reap over the API
 
 The mutating half of the deployments endpoint, and the seam turned out to be much

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -681,3 +681,24 @@ So `Deployment.Health()` always spells them out, and lives on the record rather
 than being assembled by each caller. `live ls` and `GET /api/deployments` must
 agree about what silence means; two implementations of "the last observation,
 unless there are none" is how one of them eventually gets it wrong.
+
+## Amendment, 2026-09-02 (S161b): what a teardown control must show
+
+A teardown offered from a page needs three things this ADR did not previously
+spell out, because a CLI supplies them for free and a UI does not.
+
+**It must name what is about to be destroyed.** Scenario, project and address, in
+the confirmation itself. "Are you sure?" is a speed bump people learn to click
+through; a misclick on the wrong row is only visible if the row's identity is on
+screen at the moment of confirming.
+
+**It must be a second, separate action.** A click cannot destroy real
+infrastructure on its own.
+
+**It must never render an unproven teardown as success.** The rule above — that a
+teardown which cannot prove the account clean is not a success — has to survive
+the trip through HTTP. The endpoint answers 409 *with the full result*, and the
+client must read the body rather than treating a non-2xx as a generic error: the
+per-stage failures are the whole message, and losing them substitutes "something
+went wrong" for "the state file has vanished and the resources may still be
+running".

--- a/docs/review-passes/pass110.md
+++ b/docs/review-passes/pass110.md
@@ -1,0 +1,16 @@
+# Codex review pass 110 — S161b
+
+**Clean** on the first pass. It specifically checked the two things the slice
+turns on: that the teardown affordance is gated by the server-reported
+capability, and that the 409 `ActionResult` body is preserved rather than
+collapsed into a generic error.
+
+Worth noting why this one converged immediately where S156d took seven passes and
+S161 took four. The dangerous decisions had **already been made and reviewed**:
+the endpoint's existence gate (S159b), the 409 semantics (S159b), what a view may
+not claim (S159a), how the page renders absence (S161). This slice only had to
+not undo them.
+
+That is the argument for slicing by question rather than by feature, restated as
+evidence: the fifth slice in a chain is cheap precisely because the first four
+were expensive in the right places.

--- a/internal/api/handlers_deployments.go
+++ b/internal/api/handlers_deployments.go
@@ -80,6 +80,15 @@ type deploymentsResponse struct {
 	// `live ls` exits non-zero for this; a GET cannot, so the payload
 	// has to carry it where a page will see it.
 	Unreadable []string `json:"unreadable"`
+
+	// TeardownAllowed reports whether this server was started with
+	// --allow-teardown.
+	//
+	// Carried so a page does not offer a button it knows will 404. That
+	// is a UI nicety; the SAFETY is that the endpoint does not exist,
+	// and this field cannot make it exist. A client that sets it locally
+	// gets a button that 404s.
+	TeardownAllowed bool `json:"teardown_allowed"`
 }
 
 // deploymentsHandler serves the live estate, read-only.
@@ -108,9 +117,10 @@ func deploymentsHandler(state *serverState) http.HandlerFunc {
 
 		now := time.Now()
 		payload := deploymentsResponse{
-			Schema:      "infrafactory.api.deployments.v1",
-			Deployments: make([]deploymentJSON, 0, len(deployments)),
-			Unreadable:  make([]string, 0, len(unreadable)),
+			Schema:          "infrafactory.api.deployments.v1",
+			Deployments:     make([]deploymentJSON, 0, len(deployments)),
+			Unreadable:      make([]string, 0, len(unreadable)),
+			TeardownAllowed: state.deploymentActor != nil,
 		}
 		for _, d := range deployments {
 			payload.Deployments = append(payload.Deployments, deploymentJSON{

--- a/internal/api/handlers_deployments_test.go
+++ b/internal/api/handlers_deployments_test.go
@@ -171,3 +171,22 @@ func TestDeploymentPayloadNeverCarriesAYearOneTimestamp(t *testing.T) {
 	assert.NotContains(t, rec.Body.String(), "0001-01-01",
 		"an absent moment must serialise as null; a page renders a date and a reader trusts it")
 }
+
+// A page should not offer a button it knows will 404. The safety is that
+// the endpoint does not exist; this only stops the UI advertising it.
+func TestDeploymentsReportWhetherTeardownIsAllowed(t *testing.T) {
+	_, off := getDeployments(t, &fakeDeployments{})
+	assert.False(t, off.TeardownAllowed)
+
+	srv := NewServer(ServerConfig{
+		Config: config.Default(), Deployments: &fakeDeployments{},
+		DeploymentActor: &fakeActor{},
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/deployments", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	var on deploymentsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &on))
+	assert.True(t, on.TeardownAllowed)
+}

--- a/ui/e2e/deployments.spec.ts
+++ b/ui/e2e/deployments.spec.ts
@@ -40,7 +40,11 @@ async function serveEstate(page, payload) {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ schema: 'infrafactory.api.deployments.v1', ...payload })
+      body: JSON.stringify({
+        schema: 'infrafactory.api.deployments.v1',
+        teardown_allowed: false,
+        ...payload
+      })
     })
   );
 }
@@ -195,6 +199,104 @@ test.describe('Deployments estate page', () => {
       await expect(page.locator('body')).not.toContainText('No live deployments.');
     });
   }
+
+  // A page must not offer a button it knows will 404, and must say why
+  // rather than silently omitting the capability.
+  test('no teardown control when the server did not allow it', async ({ page }) => {
+    await serveEstate(page, { deployments: [HEALTHY], unreadable: [] });
+    await page.goto('/deployments');
+
+    await expect(page.getByTestId('deployment-teardown-dep-healthy')).toHaveCount(0);
+    await expect(page.getByTestId('estate-readonly-note')).toContainText('--allow-teardown');
+  });
+
+  // A click must not destroy anything on its own, and the confirmation
+  // must NAME what is about to go -- "are you sure?" is a speed bump
+  // people learn to click through.
+  test('teardown needs a second, named confirmation', async ({ page }) => {
+    let deleted = 0;
+    await serveEstate(page, {
+      deployments: [{ ...HEALTHY, project_id: 'proj-abc' }],
+      unreadable: [],
+      teardown_allowed: true
+    });
+    await page.route('**/api/deployments/dep-healthy', (route) => {
+      deleted += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ clean: true, steps: [], failures: [] })
+      });
+    });
+    await page.goto('/deployments');
+
+    await page.getByTestId('deployment-teardown-dep-healthy').click();
+    const confirm = page.getByTestId('deployment-confirm-dep-healthy');
+    await expect(confirm).toContainText('web-live-paris');
+    await expect(confirm).toContainText('proj-abc');
+    await expect(confirm).toContainText('cannot be undone');
+    expect(deleted).toBe(0);
+
+    await page.getByTestId('deployment-cancel-dep-healthy').click();
+    await expect(page.getByTestId('deployment-confirm-dep-healthy')).toHaveCount(0);
+    expect(deleted).toBe(0);
+  });
+
+  test('confirming destroys and reports a proven-clean teardown', async ({ page }) => {
+    await serveEstate(page, {
+      deployments: [HEALTHY],
+      unreadable: [],
+      teardown_allowed: true
+    });
+    await page.route('**/api/deployments/dep-healthy', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ clean: true, steps: [], failures: [] })
+      })
+    );
+    await page.goto('/deployments');
+
+    await page.getByTestId('deployment-teardown-dep-healthy').click();
+    await page.getByTestId('deployment-destroy-dep-healthy').click();
+
+    await expect(page.getByTestId('deployment-outcome-dep-healthy')).toContainText(
+      'provably clean'
+    );
+  });
+
+  // ADR-0024: a teardown that cannot PROVE the account clean must not
+  // report success. The 409 carries the per-stage failures, and losing
+  // them would leave a generic error where "resources may still be
+  // running" belongs.
+  test('a teardown that cannot prove clean is not shown as success', async ({ page }) => {
+    await serveEstate(page, {
+      deployments: [HEALTHY],
+      unreadable: [],
+      teardown_allowed: true
+    });
+    await page.route('**/api/deployments/dep-healthy', (route) =>
+      route.fulfill({
+        status: 409,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          clean: false,
+          steps: [],
+          failures: [
+            { stage: 'teardown', status: 'fail', detail: 'state file has vanished' }
+          ]
+        })
+      })
+    );
+    await page.goto('/deployments');
+
+    await page.getByTestId('deployment-teardown-dep-healthy').click();
+    await page.getByTestId('deployment-destroy-dep-healthy').click();
+
+    const outcome = page.getByTestId('deployment-outcome-dep-healthy');
+    await expect(outcome).toContainText('may still be running');
+    await expect(outcome).toContainText('state file has vanished');
+  });
 
   test('the page is reachable from the sidebar', async ({ page }) => {
     await page.goto('/');

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   SavePitfallsResponse,
   ScenarioLayer3StatusResponse,
   ScenarioRunModeResponse,
+  ActionResult,
   DeploymentsResponse,
   StartRunOptions
 } from "$lib/types";
@@ -40,6 +41,25 @@ export const api = {
   getScenario: (path: string) => request(`/api/scenarios/${path}`),
   getScenarioRunMode: (path: string) => request<ScenarioRunModeResponse>(`/api/scenarios/${path}/run-mode`),
   getDeployments: () => request<DeploymentsResponse>("/api/deployments"),
+  // Not `request`, deliberately. A teardown that could not prove the
+  // account clean answers 409 WITH a full ActionResult -- the per-stage
+  // failures are the whole point, and `request` would throw them away
+  // and leave the page showing a generic message instead of "the state
+  // file has vanished and the resources may still be running".
+  tearDownDeployment: async (id: string): Promise<ActionResult> => {
+    const res = await fetch(`${base}/api/deployments/${encodeURIComponent(id)}`, {
+      method: "DELETE"
+    });
+    const ctype = res.headers.get("content-type") || "";
+    if ((res.ok || res.status === 409) && ctype.includes("application/json")) {
+      return (await res.json()) as ActionResult;
+    }
+    if (ctype.includes("application/json")) {
+      const payload = (await res.json()) as { error?: string };
+      throw new Error(payload.error || `teardown failed: ${res.status}`);
+    }
+    throw new Error((await res.text()) || `teardown failed: ${res.status}`);
+  },
   getScenarioLayer3Status: (path: string) => request<ScenarioLayer3StatusResponse>(`/api/scenarios/${path}/layer3-status`),
   putScenario: (path: string, rawYAML: string) =>
     request(`/api/scenarios/${path}`, {

--- a/ui/src/lib/deployments-view.js
+++ b/ui/src/lib/deployments-view.js
@@ -214,3 +214,44 @@ export function addressLabel(deployment) {
   const href = addressHref(deployment);
   return href ? href.replace(/^http:\/\//, "") : "";
 }
+
+/**
+ * teardownPrompt is what a person must read before destroying something.
+ *
+ * It names the scenario, the project and the address, because "are you
+ * sure?" is not a safeguard -- it is a speed bump that people learn to
+ * click through. What makes a confirmation real is that it states WHICH
+ * thing is about to be destroyed, so a misclick on the wrong row is
+ * visible before it is irreversible.
+ */
+export function teardownPrompt(deployment) {
+  const parts = [`Destroy ${deployment?.scenario || deployment?.id || "this deployment"}?`];
+  if (deployment?.project_id) parts.push(`Project ${deployment.project_id}`);
+  if (deployment?.address) parts.push(`serving ${deployment.address}`);
+  parts.push("This deletes real infrastructure and cannot be undone.");
+  return parts.join(" · ");
+}
+
+/**
+ * teardownOutcome turns an ActionResult into the one thing to say.
+ *
+ * `clean` is read rather than `failures.length`, because they are
+ * different claims and ADR-0024 turns on the difference: a teardown that
+ * cannot PROVE the account clean must not report success, and a green
+ * tick over "the state file has vanished and the resources may still be
+ * running" is exactly the false green this project exists to avoid.
+ */
+export function teardownOutcome(result) {
+  if (!result) return { ok: false, message: "Teardown returned nothing." };
+  if (result.clean) {
+    return { ok: true, message: "Destroyed. The account is provably clean." };
+  }
+  const reasons = (result.failures || []).map((f) => f.detail).filter(Boolean);
+  return {
+    ok: false,
+    message:
+      reasons.length > 0
+        ? `Not provably clean — resources may still be running. ${reasons.join(" ")}`
+        : "Not provably clean — resources may still be running."
+  };
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -162,4 +162,23 @@ export interface DeploymentsResponse {
   // billing infrastructure, so the page must show them rather than
   // letting "we could not check" look like "nothing is running".
   unreadable: string[];
+  // Whether the server was started with --allow-teardown. A page should
+  // not offer a button it knows will 404; the SAFETY is that the
+  // endpoint does not exist, and this field cannot make it exist.
+  teardown_allowed: boolean;
+}
+
+export interface ActionStep {
+  stage: string;
+  status: string;
+  detail?: string;
+}
+
+export interface ActionResult {
+  // Its own field, not the absence of failures: ADR-0024's rule is that
+  // a teardown which cannot PROVE the account clean must not report
+  // success.
+  clean: boolean;
+  steps: ActionStep[];
+  failures: ActionStep[];
 }

--- a/ui/src/routes/deployments/+page.svelte
+++ b/ui/src/routes/deployments/+page.svelte
@@ -9,6 +9,8 @@
     knownEmpty,
     needsAttention,
     observedLabel,
+    teardownOutcome,
+    teardownPrompt,
     ttlLabel,
     versionBadge
   } from "$lib/deployments-view.js";
@@ -16,6 +18,14 @@
 
   let deployments: Deployment[] = [];
   let unreadable: string[] = [];
+  let teardownAllowed = false;
+
+  // Confirming is a SECOND deliberate action on a named row, not a
+  // dialog that appears everywhere at once. A click cannot destroy
+  // anything on its own.
+  let confirming = "";
+  let destroying = "";
+  let outcomes: Record<string, { ok: boolean; message: string }> = {};
   let loadError = "";
   let loaded = false;
   let timer: ReturnType<typeof setInterval> | undefined;
@@ -25,6 +35,7 @@
       const payload: DeploymentsResponse = await api.getDeployments();
       deployments = payload?.deployments || [];
       unreadable = payload?.unreadable || [];
+      teardownAllowed = payload?.teardown_allowed === true;
       loadError = "";
     } catch (err) {
       // The previous rows are KEPT on error rather than cleared. An
@@ -34,6 +45,33 @@
       loadError = err instanceof Error ? err.message : "Could not read the live estate";
     } finally {
       loaded = true;
+    }
+  }
+
+  async function destroy(d: Deployment) {
+    confirming = "";
+    destroying = d.id;
+    try {
+      const result = await api.tearDownDeployment(d.id);
+      outcomes = { ...outcomes, [d.id]: teardownOutcome(result) };
+    } catch (err) {
+      outcomes = {
+        ...outcomes,
+        [d.id]: {
+          ok: false,
+          message:
+            err instanceof Error
+              ? `Teardown could not be completed: ${err.message}`
+              : "Teardown could not be completed."
+        }
+      };
+    } finally {
+      destroying = "";
+      // Reload whatever the outcome. A failed teardown changes the
+      // record too -- ADR-0024 keeps an unreclaimable deployment
+      // reapable rather than released -- so the table must not keep
+      // showing what was true before the attempt.
+      await load();
     }
   }
 
@@ -126,6 +164,7 @@
             <th class="px-3 py-2">Last observed</th>
             <th class="px-3 py-2">TTL</th>
             <th class="px-3 py-2">Address</th>
+            {#if teardownAllowed}<th class="px-3 py-2">Actions</th>{/if}
           </tr>
         </thead>
         <tbody class="divide-y divide-slate-200">
@@ -179,6 +218,51 @@
                   <span class="text-xs text-slate-500">no address recorded</span>
                 {/if}
               </td>
+              {#if teardownAllowed}
+                <td class="px-3 py-2">
+                  {#if destroying === d.id}
+                    <span class="text-xs text-slate-600" data-testid={`deployment-destroying-${d.id}`}>
+                      Destroying…
+                    </span>
+                  {:else if confirming === d.id}
+                    <!-- The confirmation NAMES what is about to go. "Are
+                         you sure?" is a speed bump people learn to click
+                         through; stating which project and address makes
+                         a misclick on the wrong row visible while it is
+                         still reversible. -->
+                    <div class="space-y-2" data-testid={`deployment-confirm-${d.id}`}>
+                      <p class="text-xs text-rose-900">{teardownPrompt(d)}</p>
+                      <div class="flex gap-2">
+                        <button
+                          class="rounded bg-rose-700 px-2 py-1 text-xs font-semibold text-white"
+                          data-testid={`deployment-destroy-${d.id}`}
+                          on:click={() => destroy(d)}>Destroy</button
+                        >
+                        <button
+                          class="rounded border border-slate-300 px-2 py-1 text-xs text-slate-700"
+                          data-testid={`deployment-cancel-${d.id}`}
+                          on:click={() => (confirming = "")}>Cancel</button
+                        >
+                      </div>
+                    </div>
+                  {:else}
+                    <button
+                      class="rounded border border-rose-300 px-2 py-1 text-xs font-semibold text-rose-800"
+                      data-testid={`deployment-teardown-${d.id}`}
+                      on:click={() => (confirming = d.id)}>Tear down</button
+                    >
+                  {/if}
+
+                  {#if outcomes[d.id]}
+                    <p
+                      class={`mt-2 text-xs ${outcomes[d.id].ok ? "text-emerald-800" : "text-rose-800 font-semibold"}`}
+                      data-testid={`deployment-outcome-${d.id}`}
+                    >
+                      {outcomes[d.id].message}
+                    </p>
+                  {/if}
+                </td>
+              {/if}
             </tr>
           {/each}
         </tbody>
@@ -186,8 +270,15 @@
     </div>
   {/if}
 
-  <p class="text-xs text-slate-500">
-    Read-only. Tear down with <code>infrafactory live teardown &lt;id&gt;</code> or reap expired
-    deployments with <code>infrafactory live reap</code>.
-  </p>
+  {#if !teardownAllowed}
+    <p class="text-xs text-slate-500" data-testid="estate-readonly-note">
+      Read-only. Start the server with <code>infrafactory ui --allow-teardown</code> to destroy
+      deployments from here, or use <code>infrafactory live teardown &lt;id&gt;</code>.
+    </p>
+  {:else}
+    <p class="text-xs text-slate-500">
+      Teardown deletes real infrastructure and cannot be undone. Expired deployments can be
+      cleared in one go with <code>infrafactory live reap</code>.
+    </p>
+  {/if}
 </section>

--- a/ui/tests/deployments-view.test.js
+++ b/ui/tests/deployments-view.test.js
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 
 import {
   addressHref,
+  teardownOutcome,
+  teardownPrompt,
   knownEmpty,
   addressLabel,
   estateSummary,
@@ -170,4 +172,48 @@ test("addressHref leaves an already-bracketed address alone", () => {
 test("addressHref does not bracket IPv4 or a hostname", () => {
   assert.equal(addressHref({ address: "51.15.0.1", port: 8080 }), "http://51.15.0.1:8080");
   assert.equal(addressHref({ address: "example.test", port: 8080 }), "http://example.test:8080");
+});
+
+// "Are you sure?" is a speed bump people learn to click through. What
+// makes a confirmation real is that it names WHICH thing is about to be
+// destroyed, so a misclick on the wrong row is visible beforehand.
+test("teardownPrompt names the scenario, project and address", () => {
+  const prompt = teardownPrompt({
+    id: "dep-1",
+    scenario: "web-live-paris",
+    project_id: "proj-abc",
+    address: "51.15.0.1"
+  });
+  assert.match(prompt, /web-live-paris/);
+  assert.match(prompt, /proj-abc/);
+  assert.match(prompt, /51\.15\.0\.1/);
+  assert.match(prompt, /cannot be undone/);
+});
+
+// ADR-0024: a teardown that cannot PROVE the account clean must not
+// report success. A green tick over "resources may still be running" is
+// the false green this project exists to avoid.
+test("teardownOutcome refuses to call an unproven teardown a success", () => {
+  const outcome = teardownOutcome({
+    clean: false,
+    steps: [],
+    failures: [{ stage: "teardown", status: "fail", detail: "state file has vanished" }]
+  });
+  assert.equal(outcome.ok, false);
+  assert.match(outcome.message, /may still be running/);
+  assert.match(outcome.message, /state file has vanished/);
+});
+
+test("teardownOutcome reads clean rather than counting failures", () => {
+  // No failures listed, but not clean. These are different claims.
+  const outcome = teardownOutcome({ clean: false, steps: [], failures: [] });
+  assert.equal(outcome.ok, false);
+});
+
+test("teardownOutcome reports a proven teardown as done", () => {
+  assert.equal(teardownOutcome({ clean: true, steps: [], failures: [] }).ok, true);
+});
+
+test("teardownOutcome treats a missing result as a failure", () => {
+  assert.equal(teardownOutcome(undefined).ok, false);
 });


### PR DESCRIPTION
The estate page can now destroy what it lists, using S159b's endpoint. Three
things make that a deliberate act rather than a click.

**The control does not appear unless the server allows it.** The listing reports
`teardown_allowed`, so the page does not offer a button it knows will 404 — and
says *how to enable it* rather than silently omitting the capability. The safety
is still that the endpoint does not exist; a client setting the field locally gets
a button that 404s.

**The confirmation names what is about to go** — scenario, project, address. "Are
you sure?" is a speed bump people learn to click through; stating which project is
about to be deleted makes a misclick on the wrong row visible while it is still
reversible.

**A teardown that cannot prove the account clean is never shown as success.** The
409 carries the per-stage failures, and the shared `request` helper would have
thrown them away — leaving a generic error where *"the state file has vanished and
the resources may still be running"* belongs. So `tearDownDeployment` reads the
409 body deliberately, and `teardownOutcome` reads `clean` rather than counting
failures, because they are different claims and ADR-0024 turns on the difference.

The table reloads whatever the outcome: a failed teardown changes the record too —
an unreclaimable deployment stays reapable rather than released — so the page must
not keep showing what was true before the attempt.

ADR-0024 amended with what a teardown control must show, since a CLI supplies
those three properties for free and a UI does not.

Codex pass 110 clean on the first review, which is worth a note: this slice
converged immediately where S156d took seven passes, because the dangerous
decisions had already been made and reviewed upstream — the existence gate and
409 semantics in S159b, what a view may not claim in S159a, how the page renders
absence in S161. It only had to not undo them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD