### PR TITLE
S162a: what a person must be told before they spend money

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,40 @@
 
 Last updated: 2026-08-31
 
+## 2026-09-02 — S162a: what a person must be told before they spend money
+
+ADR-0027 §2 made real: `GET /api/deployments/preview` answers what a deploy would
+create, cost, expose and when it would expire. A GET, because it does nothing —
+and available whether or not `--allow-deploy` was given, since knowing what a
+deployment would cost is information rather than a capability, and a page that can
+explain a greyed-out button beats one that silently omits it.
+
+**The hard part was the cost, and the honest answer was to admit what it does not
+know.** ADR-0024's figures were read off Scaleway's pricing pages by hand for *one
+shape*. Any scenario declaring a database, a Kubernetes cluster or object storage
+has components this project has never priced.
+
+A total that quietly omitted them would be **wrong in the reassuring direction**,
+and a confidently wrong number shown at the moment somebody decides to spend is
+worse than no number. So `CostEstimate` carries `Priced` per component and
+`Complete` overall: unpriced components are counted, named, and the summary says
+*"AT LEAST … because N component(s) have no list price here"*. `Priced` is a
+separate field from `EurPerHour == 0` because **free and unknown are different
+facts**, and summing them as if both were zero is how a total understates itself.
+
+An overridden compute offer is named and marked unpriced rather than billed as a
+DEV1-S because that is the only number to hand. A non-Scaleway scenario is not
+priced from Scaleway's list at all — it still says what will be created.
+
+**Expiry is wall-clock**, not a duration: "4h" is a number people agree to without
+doing the arithmetic; "expires Wed 3 Sep 03:47 UTC" is one they check against
+whether they will still be awake. A TTL that will not parse makes the scenario
+undeployable rather than defaulting, since guessing a lifetime is how a deployment
+outlives everyone's memory of it.
+
+A test pins the estimate against ADR-0024's own €0.042/hour, so the document and
+the code cannot drift about what the demo costs.
+
 ## 2026-09-02 — S160c: the deploy safety model, decided before the button
 
 ADR-0027. Mostly a record of what is already true — the origin guard, start-time

--- a/docs/review-passes/pass112.md
+++ b/docs/review-passes/pass112.md
@@ -1,0 +1,37 @@
+# Codex review pass 112 — S162a
+
+Three findings, all accepted, and two of them are the same one.
+
+## [P2] `exposure: private` was reported as internet-facing, and billed a public IP
+
+The schema says `exposure` is *"whether the load balancer has a public IP"*. The
+preview treated **any** load balancer as internet-facing, and the estimator billed
+a public IPv4 for it regardless.
+
+Two consequences, and the second is worse than the arithmetic:
+
+- The cost estimate lists a component the scenario says will not exist. A
+  component list with things in it that are not real is one a reader learns to
+  skim, which costs more than the €0.005/hour.
+- **A warning that fires on everything is one people learn to skip.** The
+  internet-facing line is the part of the confirmation people forget to ask about
+  unprompted; making it always-true removes the only signal it carries.
+
+Wrong in the *cautious* direction, which is why it would have survived a long
+time.
+
+Fixed at the type: `LoadBalancer.Public()` is a method rather than a comparison at
+each call site, because the two callers must agree. A cost estimate billing a
+public address while the confirmation calls the shape private would be two answers
+to one question.
+
+## [P2] `.yml` scenarios 500'd
+
+`findScenarioPathByName` strips the extension and accepts **both** `.yaml` and
+`.yml`; the preview appended `.yaml`. Every `.yml`-backed scenario would have
+returned 500 — for a file the discovery walk deliberately supports.
+
+The fix tries both suffixes, and deliberately does **not** swallow a parse error
+while doing so: a file that exists and will not parse is a real error, and masking
+it by trying the other spelling would report "not found" for a file that is
+right there.

--- a/docs/review-passes/pass113.md
+++ b/docs/review-passes/pass113.md
@@ -1,0 +1,38 @@
+# Codex review pass 113 — S162a
+
+Two findings, accepted. The second is the important one, and not because of the
+bug.
+
+## [P2] Scaleway shape names on other clouds
+
+`EstimateCost` defaulted compute to `DEV1-S instance` and the balancer to
+`LB-S load balancer` regardless of cloud, marking them unpriced for GCP and AWS
+but still **naming** them.
+
+Unpriced was the right call and the name was not: telling a GCP user their deploy
+will create a "DEV1-S instance" names a resource that will not exist, which is
+worse than being vague when the endpoint's entire job is saying what deploy would
+do. Non-Scaleway scenarios now get the shape — "compute", "load balancer" — and
+still say what will be created.
+
+## [P2] The year-one expiry, again
+
+An undeployable preview never sets `ExpiresAt`, and `omitempty` does not omit a
+zero `time.Time`. So every greyed-out scenario would have reported expiring on
+`0001-01-01`.
+
+**This is the class S159a closed, four slices ago, with a test written
+specifically to stop it recurring.** It recurred anyway, and the reason is worth
+stating precisely: that test asserts over the **deployments** payload. This is a
+different payload, in a different handler, added later. A class test that names
+one instance of the class is still a snapshot — it just looks less like one.
+
+The general rule this project keeps rediscovering is that **an optional field in
+a view needs a type that can be absent**, and Go's `omitempty` does not provide
+one for structs. Every response type added to this API inherits that, and the
+only real defence is checking it when the type is written rather than when the
+review finds it.
+
+`ExpiresAt` is a `*time.Time` now, and the preview has its own year-one assertion
+covering the undeployable cases — where it bites, because those are the ones that
+never set it.

--- a/docs/review-passes/pass114.md
+++ b/docs/review-passes/pass114.md
@@ -1,0 +1,21 @@
+# Codex review pass 114 — S162a
+
+One finding, raised as **P3**, accepted anyway.
+
+## [P3] Two files sharing a stem could load the wrong scenario
+
+Discovery matches on the scenario's **name** and returns an extension-less path.
+So `shared-stem.yaml` and `shared-stem.yml` holding *different* scenarios would
+let the loader answer about whichever suffix it tried first.
+
+Accepted despite the priority because the priority measures the wrong thing here.
+The trigger is unlikely; the consequence is a confirmation dialog showing the
+cost, lifetime and blast radius of a **different scenario**, immediately before
+somebody agrees to spend money. A rare path into a wrong-and-confident answer at
+the exact moment of an irreversible decision is not a P3 outcome.
+
+The fix is also cheap enough that arguing about the priority would have cost more
+than doing it: the loader now checks that the scenario it loaded is the one that
+was asked for. That closes the case **generally** — any future mismatch between
+path resolution and name resolution is caught — rather than closing the one
+filename layout that exposed it.

--- a/docs/review-passes/pass115.md
+++ b/docs/review-passes/pass115.md
@@ -1,0 +1,41 @@
+# Codex review pass 115 — S162a
+
+One finding, accepted, and the fix is the fourth time this session a defect has
+been closed by construction rather than by correction.
+
+## [P2] `resources.iam` was missing from the preview entirely
+
+The estimator enumerated eleven resource blocks by hand and missed `iam` — which
+is, of the twelve, the one whose absence matters most. An IAM application, its
+API key and its policy are exactly what a **blast-radius** preview exists to
+surface, and they are free, so no cost total would ever have hinted they were
+missing.
+
+## Adding it back would have been another snapshot
+
+The list was hand-written, so the next resource type added to the schema would
+vanish from the confirmation the same way — silently, and specifically from the
+screen somebody reads before spending money.
+
+`TestEveryDeclaredResourceBlockAppearsInThePreview` walks `Resources` by
+reflection and asserts every block contributes at least one named component. It
+**failed on IAM before the fix**, which is the point: the test found the bug the
+review had just described, and would have found it a slice earlier.
+
+Two things fell out of writing it. A `networking` block with only a VPC or a
+private network produced nothing, so those are named now — a component that costs
+nothing still belongs in "what will this make", because this list is a
+blast-radius preview before it is a bill. And the assertion that every block is a
+pointer is itself a guard: a resource type added as a value would slip past the
+reflection walk.
+
+## The pattern, stated once
+
+Four class-closures this session: the year-one timestamps, the empty-estate
+claim, the observed-key identity, and now the resource enumeration. Every one
+followed the same sequence — a finding, a careful fix, the same defect again
+somewhere adjacent, and only then a test that a careful fix cannot satisfy.
+
+The lesson is not "write class tests". It is that **the second occurrence is the
+signal**, and treating it as one more instance rather than as evidence about the
+shape of the mistake is what costs the third.

--- a/docs/review-passes/pass116.md
+++ b/docs/review-passes/pass116.md
@@ -1,0 +1,40 @@
+# Codex review pass 116 — S162a
+
+Two findings, both accepted. The second is one I introduced **against a rule I
+had written in the same file, one commit earlier.**
+
+## [P2] `cloud: genesys` scenarios previewed as creating nothing
+
+Genesys scenarios declare `routing`, `identity`, `architect` and `full_stack` in
+`scenario.schema.json`. The Go `Resources` struct carries none of them, so those
+scenarios unmarshal into an **empty resource set** — and the preview reported an
+empty component list and €0.00.
+
+That is the most reassuring possible way to be wrong, on the screen somebody reads
+before agreeing to spend money.
+
+Verified before accepting: the four blocks are in the schema at lines 69–72, and
+`grep` finds no corresponding field in `scenario.go`.
+
+The fix is a `Modelled` flag rather than adding the fields, because adding them is
+a change to the scenario model that the generator also reads — out of scope for a
+preview slice. **`Modelled` distinguishes "nothing to create" from "nothing I can
+see"**, and a scenario that genuinely declares no resources stays the harmless
+case it is.
+
+## [P3] Free components made a complete estimate look incomplete
+
+Pass 115 added VPC and private network to the component list — through the
+*unpriced* path. So a Scaleway scenario with a VPC reported `Complete: false` and
+"AT LEAST", despite every component being perfectly well understood.
+
+`CostComponent.Priced` exists precisely because **free and unknown are different
+facts**; the type's doc comment says so in those words. I then added free things
+through the unknown path four lines below it.
+
+The cost of that is not the flag. It is that "AT LEAST" appearing on estimates
+that are not uncertain teaches a reader to ignore it, and the one time it means
+something is the one time it needs to be read.
+
+`addFree` is now a separate path: listed in the blast radius, priced at zero,
+`Complete` untouched.

--- a/docs/review-passes/pass117.md
+++ b/docs/review-passes/pass117.md
@@ -1,0 +1,40 @@
+# Codex review pass 117 — S162a
+
+One finding, accepted, and it is the **dangerous** direction of pass 112's
+finding.
+
+## [P2] A compute-only scenario was told it was not internet-facing
+
+The estimator bills a `public IPv4 address` for every compute instance. The
+`internet_facing` flag checked only the load balancer. So a scenario with an
+instance and no balancer was **charged for a public address and told it was not
+reachable from the internet.**
+
+Pass 112 was the same disagreement in the safe direction — over-warning on private
+load balancers. This is the same disagreement understating exposure, at the
+confirmation step, immediately before someone agrees.
+
+## Two answers to one question
+
+Pass 112's fix was `LoadBalancer.Public()`, used by both the estimator and the
+flag "because the two callers must agree". That reasoning was right and the fix
+was too narrow: it made them agree **about load balancers**, and left the compute
+path with its own hand-written condition.
+
+`internet_facing` is now derived from the component list —
+`CostEstimate.InternetFacing()` is true when the estimate contains a public
+address. The bill and the warning cannot disagree because there is only one of
+them, and anything that adds a public address later raises the warning without
+anyone remembering to.
+
+## Two tests failed, and they were wrong
+
+`TestPreviewSaysWhetherItWillBeReachableFromTheInternet` and
+`TestPreviewDoesNotCallAPrivateLoadBalancerInternetFacing` both removed the
+networking block or made the balancer private, **left `Compute` in place**, and
+asserted `false`. They encoded the defect: an instance gets its own public
+address, so `false` was never the right answer for those scenarios.
+
+Third time this session a red test has been the test's fault rather than the
+code's. The reflex is to change the code, and the check is cheap: ask what the
+system should do before asking what the assertion says.

--- a/docs/review-passes/pass118.md
+++ b/docs/review-passes/pass118.md
@@ -1,0 +1,25 @@
+# Codex review pass 118 — S162a
+
+**Clean.** No correctness issues; the full Go suite passes.
+
+Six passes, nine findings, and the through-line is one thing: **this endpoint's
+job is to tell somebody the truth at the moment they decide to spend money, and
+almost every way to get it wrong is a way of being reassuring.**
+
+- an unpriced component summed as zero → cheaper than reality
+- a Genesys scenario with no modelled resources → "creates nothing, costs nothing"
+- `iam` omitted from the shape list → a smaller blast radius than reality
+- a private load balancer billed a public IP → over-warning, and a warning that
+  fires on everything gets skipped
+- a compute-only scenario reported not internet-facing → **less exposed than
+  reality**, at the confirmation step
+- an undeployable preview expiring in the year 1 → a date where "none" belongs
+
+Only two of the nine were mechanical. The rest were the estimate quietly
+flattering the thing being estimated.
+
+The two structural fixes are the ones worth keeping: `InternetFacing()` derived
+from the component list so the bill and the warning cannot disagree, and
+`TestEveryDeclaredResourceBlockAppearsInThePreview` walking the struct by
+reflection so a new resource type cannot silently vanish from the confirmation.
+Both replace a hand-written condition that had already been wrong once.

--- a/internal/api/handlers_deploy_preview.go
+++ b/internal/api/handlers_deploy_preview.go
@@ -1,0 +1,215 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/redscaresu/infrafactory/internal/scenario"
+)
+
+// deployPreview is what a person must read before deciding to spend
+// money (ADR-0027 §2).
+//
+// Four things, and each is there because leaving it out has a specific
+// failure mode:
+//
+//   - **what will be created**, so "deploy" is not an abstraction;
+//   - **cost, at list price, admitting it is an estimate** -- a
+//     confidently wrong number shown at the moment somebody decides to
+//     spend is worse than an admitted one;
+//   - **expiry as a WALL-CLOCK time**, because "4h" is a number people
+//     agree to without doing the arithmetic;
+//   - **whether it is reachable from the internet**, which is a
+//     different question from what it costs and is the one people forget
+//     to ask.
+type deployPreview struct {
+	Scenario string `json:"scenario"`
+	Cloud    string `json:"cloud"`
+
+	// Deployable is false when this scenario cannot be deployed at all,
+	// and Reason says why. Reported rather than 4xx'd because a page
+	// listing scenarios wants to explain the greyed-out ones.
+	Deployable bool   `json:"deployable"`
+	Reason     string `json:"reason,omitempty"`
+
+	Image string `json:"image,omitempty"`
+
+	TTL        string `json:"ttl,omitempty"`
+	TTLSeconds int64  `json:"ttl_seconds,omitempty"`
+
+	// A POINTER. `omitempty` does not omit a zero `time.Time` -- it is a
+	// struct, so the tag has nothing to act on -- and an undeployable
+	// preview never sets this. Without the pointer every greyed-out
+	// scenario would report expiring in the year 1, which a page renders
+	// as a date and a reader trusts.
+	//
+	// The same defect S159a closed for the deployments payload. It came
+	// back here because that class test asserted over ONE payload, and
+	// this is a new one.
+	ExpiresAt    *time.Time `json:"expires_at"`
+	ExpiresLocal string     `json:"expires_at_wall_clock,omitempty"`
+
+	Cost        scenario.CostEstimate `json:"cost"`
+	CostSummary string                `json:"cost_summary,omitempty"`
+
+	// InternetFacing is true when the shape includes a public address.
+	InternetFacing bool `json:"internet_facing"`
+}
+
+// deployPreviewHandler answers what a deploy would do. It is a GET
+// because it does nothing.
+//
+// Available whether or not `--allow-deploy` was given: knowing what a
+// deployment would cost and expose is information, not a capability, and
+// a page that can explain why a button is disabled is better than one
+// that silently omits it.
+func deployPreviewHandler(state *serverState) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+
+		name := r.URL.Query().Get("scenario")
+		if name == "" {
+			writeJSONError(w, http.StatusBadRequest, "scenario is required")
+			return
+		}
+
+		relPath, err := findScenarioPathByName(state, name)
+		if err != nil {
+			if os.IsNotExist(err) {
+				writeJSONError(w, http.StatusNotFound, "scenario not found")
+				return
+			}
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		// findScenarioPathByName strips the extension, and it accepts
+		// BOTH .yaml and .yml. Appending .yaml would 500 on every
+		// .yml-backed scenario -- a file the discovery function
+		// deliberately supports.
+		sc, err := loadScenarioByRelPath(state, relPath, name)
+		if err != nil {
+			if os.IsNotExist(err) {
+				writeJSONError(w, http.StatusNotFound, "scenario not found")
+				return
+			}
+			writeJSONError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+
+		writeJSON(w, http.StatusOK, previewFor(&sc, r.URL.Query().Get("ttl"), time.Now()))
+	}
+}
+
+// loadScenarioByRelPath reads a scenario from an extension-less relative
+// path, trying the suffixes the discovery walk accepts.
+//
+// `want` is the name the caller asked for, and the loaded scenario must
+// match it. Discovery matches on the scenario's NAME rather than its
+// filename and returns an extension-less path, so `foo.yaml` and
+// `foo.yml` holding different scenarios would let this load the wrong
+// one. The consequence is not a 500 -- it is a confirmation dialog
+// showing the cost, lifetime and blast radius of a DIFFERENT scenario,
+// immediately before somebody agrees to spend money.
+//
+// Checking the name closes that generally rather than closing the one
+// filename layout that exposed it.
+func loadScenarioByRelPath(state *serverState, relPath, want string) (scenario.Scenario, error) {
+	base := filepath.Join(state.cfg.Paths.Scenarios, filepath.FromSlash(relPath))
+
+	candidates := []string{base}
+	if filepath.Ext(base) == "" {
+		candidates = []string{base + ".yaml", base + ".yml"}
+	}
+
+	var lastErr error = os.ErrNotExist
+	for _, candidate := range candidates {
+		sc, _, err := loadScenarioFile(candidate, state.scenarioSchemaPathCandidates())
+		if err == nil {
+			if want != "" && sc.Name != want {
+				// Right path, wrong scenario. Keep looking rather than
+				// answering about something the caller did not ask for.
+				lastErr = os.ErrNotExist
+				continue
+			}
+			return sc, nil
+		}
+		if !os.IsNotExist(err) {
+			// A file that exists and will not parse is a real error and
+			// must not be masked by trying the other suffix.
+			return scenario.Scenario{}, err
+		}
+		lastErr = err
+	}
+	return scenario.Scenario{}, lastErr
+}
+
+// previewFor assembles the preview, and is separate from the handler so
+// it can be tested without HTTP.
+func previewFor(sc *scenario.Scenario, ttlOverride string, now time.Time) deployPreview {
+	preview := deployPreview{Scenario: sc.Name, Cloud: sc.Cloud}
+
+	// The cost and shape are worth knowing even for a scenario that
+	// cannot be deployed -- that is exactly what explains the greyed-out
+	// button.
+	preview.Cost = sc.EstimateCost()
+	// Derived from the estimate, not re-decided from the scenario.
+	//
+	// These were two hand-written conditions and they disagreed: the
+	// estimator bills a public IPv4 for every compute instance, while
+	// this checked only the load balancer -- so a compute-only scenario
+	// was charged for a public address and told it was not reachable
+	// from the internet. Understating exposure at the moment of the
+	// decision is the worse direction of the two.
+	preview.InternetFacing = preview.Cost.InternetFacing()
+
+	if sc.Service == nil {
+		// The same refusal `runDeployCommand` makes: without a versioned
+		// application there is nothing whose version could be rolled
+		// forward, and "deploy" would just mean "apply and forget to
+		// destroy".
+		preview.Reason = "this scenario declares no service: block, so there is nothing to deploy. " +
+			"Use a run to validate infrastructure-only scenarios"
+		return preview
+	}
+
+	preview.Image = sc.Service.Ref()
+
+	spec := *sc.Service
+	if ttlOverride != "" {
+		spec.TTL = ttlOverride
+		if err := spec.Validate(); err != nil {
+			preview.Reason = fmt.Sprintf("ttl: %v", err)
+			return preview
+		}
+	}
+
+	ttl, err := spec.TimeToLive()
+	if err != nil {
+		// ADR-0024 has no unbounded form, so a TTL that will not parse
+		// makes the scenario undeployable rather than defaulting to
+		// something. Guessing a lifetime is how a deployment outlives
+		// everyone's memory of it.
+		preview.Reason = fmt.Sprintf("ttl: %v", err)
+		return preview
+	}
+
+	preview.Deployable = true
+	preview.TTL = ttl.String()
+	preview.TTLSeconds = int64(ttl.Seconds())
+	expires := now.Add(ttl)
+	preview.ExpiresAt = &expires
+	// Wall clock, spelled out. "4h" is a number people agree to without
+	// doing the arithmetic; "expires at 03:47" is one they check against
+	// whether they will still be awake.
+	preview.ExpiresLocal = expires.Format("Mon 2 Jan 15:04 MST")
+	preview.CostSummary = preview.Cost.Summary(ttl)
+
+	return preview
+}

--- a/internal/api/handlers_deploy_preview_test.go
+++ b/internal/api/handlers_deploy_preview_test.go
@@ -1,0 +1,265 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redscaresu/infrafactory/internal/config"
+	"github.com/redscaresu/infrafactory/internal/scenario"
+)
+
+func servingScenario() *scenario.Scenario {
+	return &scenario.Scenario{
+		Name: "lb-serving-paris", Cloud: "scaleway",
+		Resources: scenario.Resources{
+			Compute:    &scenario.ComputeResource{Purpose: "web-server", Size: "small"},
+			Networking: &scenario.NetworkingResource{LoadBalancer: &scenario.LoadBalancer{Exposure: "public"}},
+		},
+		Service: &scenario.ServiceSpec{
+			Image: "nginx", Tag: "1.27", Port: 80, HealthPath: "/", TTL: "4h",
+		},
+	}
+}
+
+// "4h" is a number people agree to without doing the arithmetic.
+// "expires at 03:47" is one they check against whether they will still
+// be awake.
+func TestPreviewStatesExpiryAsWallClockNotJustADuration(t *testing.T) {
+	now := time.Date(2026, 9, 2, 23, 47, 0, 0, time.UTC)
+
+	got := previewFor(servingScenario(), "", now)
+
+	require.True(t, got.Deployable, got.Reason)
+	assert.Equal(t, "4h0m0s", got.TTL)
+	require.NotNil(t, got.ExpiresAt)
+	assert.Equal(t, now.Add(4*time.Hour), *got.ExpiresAt)
+	assert.Contains(t, got.ExpiresLocal, "03:47", "the hour it actually ends")
+}
+
+// A confidently wrong number shown at the moment somebody decides to
+// spend money is worse than an admitted estimate.
+func TestPreviewAlwaysSaysTheCostIsAListPrice(t *testing.T) {
+	got := previewFor(servingScenario(), "", time.Now())
+
+	assert.Contains(t, got.CostSummary, "list price")
+	assert.True(t, got.Cost.Complete)
+	assert.InDelta(t, 0.042, got.Cost.EurPerHour, 0.0005)
+}
+
+func TestPreviewAdmitsWhenItCouldNotPriceEverything(t *testing.T) {
+	sc := servingScenario()
+	sc.Resources.Kubernetes = &scenario.KubernetesResource{}
+
+	got := previewFor(sc, "", time.Now())
+
+	assert.False(t, got.Cost.Complete)
+	assert.Contains(t, got.CostSummary, "AT LEAST")
+}
+
+// A different question from what it costs, and the one people forget to
+// ask.
+func TestPreviewSaysWhetherItWillBeReachableFromTheInternet(t *testing.T) {
+	assert.True(t, previewFor(servingScenario(), "", time.Now()).InternetFacing)
+
+	// Neither a public load balancer NOR compute: removing only the
+	// networking block leaves an instance that still gets a public
+	// address, which is the case an earlier version of this test got
+	// wrong.
+	closed := servingScenario()
+	closed.Resources.Networking = nil
+	closed.Resources.Compute = nil
+	closed.Resources.Storage = &scenario.StorageResource{}
+	assert.False(t, previewFor(closed, "", time.Now()).InternetFacing)
+}
+
+// The same refusal runDeployCommand makes: without a versioned
+// application, "deploy" would just mean "apply and forget to destroy".
+func TestPreviewRefusesAScenarioWithNoServiceBlock(t *testing.T) {
+	sc := servingScenario()
+	sc.Service = nil
+
+	got := previewFor(sc, "", time.Now())
+
+	assert.False(t, got.Deployable)
+	assert.Contains(t, got.Reason, "no service: block")
+	// Still says what it would create, because that is what explains a
+	// greyed-out button.
+	assert.NotEmpty(t, got.Cost.Components)
+}
+
+// ADR-0024 has no unbounded form. A TTL that will not parse makes the
+// scenario undeployable rather than defaulting to something -- guessing
+// a lifetime is how a deployment outlives everyone's memory of it.
+func TestPreviewRefusesRatherThanGuessingALifetime(t *testing.T) {
+	got := previewFor(servingScenario(), "not-a-duration", time.Now())
+
+	assert.False(t, got.Deployable)
+	assert.Contains(t, got.Reason, "ttl")
+	assert.Zero(t, got.TTLSeconds)
+}
+
+func TestPreviewHonoursATTLOverride(t *testing.T) {
+	now := time.Now()
+	got := previewFor(servingScenario(), "1h", now)
+
+	require.True(t, got.Deployable, got.Reason)
+	assert.Equal(t, int64(3600), got.TTLSeconds)
+	assert.InDelta(t, 0.042, got.Cost.EurAtTTL(time.Hour), 0.001)
+}
+
+// A warning that fires on every load balancer is one people learn to
+// skip, which costs more than the case it was meant to catch.
+func TestPreviewDoesNotCallAPrivateLoadBalancerInternetFacing(t *testing.T) {
+	sc := servingScenario()
+	sc.Resources.Networking.LoadBalancer.Exposure = "private"
+	// Compute removed on purpose: an instance gets its own public
+	// address, so leaving it in would test the wrong thing.
+	sc.Resources.Compute = nil
+
+	assert.False(t, previewFor(sc, "", time.Now()).InternetFacing)
+}
+
+// findScenarioPathByName strips the extension and accepts BOTH .yaml and
+// .yml, so appending .yaml would 500 on every .yml-backed scenario — a
+// file the discovery walk deliberately supports.
+func TestPreviewFindsAScenarioStoredAsYml(t *testing.T) {
+	dir := t.TempDir()
+	body := []byte(`scenario: yml-scenario
+version: "1.0"
+cloud: scaleway
+description: stored with the other spelling
+resources:
+  compute:
+    purpose: web-server
+    size: small
+acceptance_criteria:
+  - type: destruction
+    expect: no_orphans
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "yml-scenario.yml"), body, 0o644))
+
+	cfg := config.Default()
+	cfg.Paths.Scenarios = dir
+	srv := NewServer(ServerConfig{Config: cfg})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/deployments/preview?scenario=yml-scenario", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "yml-scenario")
+}
+
+func TestPreviewIsAReadOnlyGet(t *testing.T) {
+	srv := NewServer(ServerConfig{Config: config.Default()})
+	for _, m := range []string{http.MethodPost, http.MethodDelete, http.MethodPut} {
+		rec := httptest.NewRecorder()
+		srv.Handler.ServeHTTP(rec, httptest.NewRequest(m, "/api/deployments/preview?scenario=x", nil))
+		assert.Equal(t, http.StatusMethodNotAllowed, rec.Code, m)
+	}
+}
+
+// The year-one class, again. S159a closed it for the deployments payload
+// and it came straight back in this one, because that test asserted over
+// ONE payload and this is a new one.
+//
+// Every response type this API adds needs the same assertion, and the
+// undeployable case is where it bites: a greyed-out scenario never sets
+// an expiry.
+func TestPreviewNeverCarriesAYearOneExpiry(t *testing.T) {
+	for name, sc := range map[string]*scenario.Scenario{
+		"no service block": func() *scenario.Scenario {
+			s := servingScenario()
+			s.Service = nil
+			return s
+		}(),
+		"unparseable ttl": servingScenario(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			ttl := ""
+			if name == "unparseable ttl" {
+				ttl = "not-a-duration"
+			}
+			payload, err := json.Marshal(previewFor(sc, ttl, time.Now()))
+			require.NoError(t, err)
+			assert.NotContains(t, string(payload), "0001-01-01",
+				"a greyed-out scenario must not report expiring in the year 1")
+		})
+	}
+}
+
+// Telling a GCP user their deploy will create a "DEV1-S instance" names
+// a resource that will not exist, which is worse than being vague: this
+// endpoint's whole job is saying what deploy would do.
+func TestPreviewDoesNotNameScalewayShapesForOtherClouds(t *testing.T) {
+	sc := servingScenario()
+	sc.Cloud = "gcp"
+
+	got := previewFor(sc, "", time.Now())
+
+	for _, c := range got.Cost.Components {
+		assert.NotContains(t, c.Name, "DEV1-S")
+		assert.NotContains(t, c.Name, "LB-S")
+	}
+	assert.NotEmpty(t, got.Cost.Components, "it must still say what will be created")
+}
+
+// Discovery matches on the scenario's NAME and returns an
+// extension-less path, so two files sharing a stem could have this load
+// the wrong one. The consequence is not a 500: it is a confirmation
+// showing the cost, lifetime and blast radius of a DIFFERENT scenario,
+// immediately before somebody agrees to spend money.
+func TestPreviewNeverAnswersAboutADifferentScenario(t *testing.T) {
+	dir := t.TempDir()
+	write := func(file, name string) {
+		body := []byte("scenario: " + name + `
+version: "1.0"
+cloud: scaleway
+description: two files, one stem
+resources:
+  compute:
+    purpose: web-server
+    size: small
+acceptance_criteria:
+  - type: destruction
+    expect: no_orphans
+`)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, file), body, 0o644))
+	}
+	// Same stem, different scenarios inside.
+	write("shared-stem.yaml", "the-yaml-one")
+	write("shared-stem.yml", "the-yml-one")
+
+	cfg := config.Default()
+	cfg.Paths.Scenarios = dir
+	srv := NewServer(ServerConfig{Config: cfg})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/deployments/preview?scenario=the-yml-one", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "the-yml-one")
+	assert.NotContains(t, rec.Body.String(), "the-yaml-one",
+		"answering about the wrong scenario is worse than answering nothing")
+}
+
+// Understating exposure at the moment of the decision is the worse
+// direction: a compute instance gets a public IPv4 whether or not there
+// is a load balancer in front of it.
+func TestPreviewCallsAComputeOnlyScenarioInternetFacing(t *testing.T) {
+	sc := servingScenario()
+	sc.Resources.Networking = nil
+
+	got := previewFor(sc, "", time.Now())
+
+	assert.True(t, got.InternetFacing, "the instance still gets a public address")
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -111,6 +111,7 @@ func NewServer(cfg ServerConfig) *http.Server {
 	mux.HandleFunc("/api/pitfalls", pitfallsHandler(state))
 	mux.HandleFunc("/api/pitfalls/", pitfallsHandler(state))
 	mux.HandleFunc("/api/deployments", deploymentsHandler(state))
+	mux.HandleFunc("/api/deployments/preview", deployPreviewHandler(state))
 	mux.HandleFunc("/api/deployments/", deploymentActionHandler(state))
 	mux.HandleFunc("/api/ws", websocketHandler(state))
 

--- a/internal/scenario/cost.go
+++ b/internal/scenario/cost.go
@@ -1,0 +1,295 @@
+package scenario
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// CostComponent is one billable thing a scenario will create, with the
+// list price it was estimated at.
+type CostComponent struct {
+	// Name is the shape as a person would recognise it on an invoice.
+	Name string `json:"name"`
+
+	// Count is how many of it.
+	Count int `json:"count"`
+
+	// EurPerHour is the LIST price per unit, or zero when unpriced.
+	EurPerHour float64 `json:"eur_per_hour"`
+
+	// Priced is false when this project has no list price for the shape.
+	//
+	// A separate field rather than "EurPerHour == 0", because free and
+	// unknown are different facts and summing them as if both were zero
+	// is how a total silently understates itself.
+	Priced bool `json:"priced"`
+
+	// Source is where the price came from, so a reader can check it.
+	Source string `json:"source,omitempty"`
+}
+
+// CostEstimate is what a scenario will cost if deployed, as far as this
+// project actually knows.
+//
+// # Why `Unpriced` is a first-class field
+//
+// The prices below were read off Scaleway's pricing pages by hand for
+// ONE shape (ADR-0024). Any scenario declaring something else -- a
+// database, a Kubernetes cluster, object storage -- has components this
+// project has never priced.
+//
+// A total that quietly omitted them would be **wrong in the reassuring
+// direction**, and a confidently wrong number shown at the moment
+// somebody decides to spend money is worse than no number at all. So
+// unpriced components are counted, named, and the estimate says plainly
+// that it is a floor rather than a total.
+type CostEstimate struct {
+	Components []CostComponent `json:"components"`
+
+	// EurPerHour totals only the PRICED components.
+	EurPerHour float64 `json:"eur_per_hour"`
+
+	// Unpriced names the shapes with no list price here.
+	Unpriced []string `json:"unpriced"`
+
+	// Complete is true only when every component was priced. When it is
+	// false, EurPerHour is a lower bound and must be presented as one.
+	Complete bool `json:"complete"`
+
+	// Modelled is false when this estimator has no model for the
+	// scenario's resource shape at all.
+	//
+	// `cloud: genesys` scenarios declare `routing`, `identity`,
+	// `architect` and `full_stack`, which the Go Resources struct does
+	// not carry -- so they arrive here as an empty resource set. An
+	// empty component list would then render as "this creates nothing
+	// and costs nothing", which is the most reassuring possible way to
+	// be wrong on the screen somebody reads before agreeing to spend.
+	Modelled bool `json:"modelled"`
+}
+
+// EurAtTTL is the estimated cost of holding this shape for a duration.
+func (c CostEstimate) EurAtTTL(ttl time.Duration) float64 {
+	return c.EurPerHour * ttl.Hours()
+}
+
+// Summary states the estimate and its own limits in one line.
+//
+// It always says "list price" and it always says when it is incomplete,
+// because both are the difference between an estimate a person can act
+// on and a number they will later feel misled by.
+func (c CostEstimate) Summary(ttl time.Duration) string {
+	if !c.Modelled {
+		return "this scenario's resources are not modelled here, so what it creates and " +
+			"what it costs are both unknown — do not read this as free"
+	}
+
+	base := fmt.Sprintf("about €%.2f/hour at list price, €%.2f for %s",
+		c.EurPerHour, c.EurAtTTL(ttl), ttl)
+	if c.Complete {
+		return base
+	}
+	return fmt.Sprintf("%s — AT LEAST, because %d component(s) have no list price here: %v",
+		base, len(c.Unpriced), c.Unpriced)
+}
+
+// PublicAddressComponent is the component name for a public IPv4.
+//
+// Named because two things must agree about it: the cost estimate that
+// bills it, and the confirmation that warns the shape is reachable from
+// the internet. Those were separate hand-written conditions and they
+// disagreed -- a compute-only scenario was billed a public address while
+// the confirmation said it was not internet-facing, understating
+// exposure at the moment of the decision.
+const PublicAddressComponent = "public IPv4 address"
+
+// InternetFacing reports whether this estimate includes anything with a
+// public address.
+//
+// DERIVED from the component list rather than re-deciding from the
+// scenario, so the warning and the bill cannot disagree. Whatever adds a
+// public address also raises the warning, including anything added
+// later.
+func (c CostEstimate) InternetFacing() bool {
+	for _, component := range c.Components {
+		if component.Name == PublicAddressComponent && component.Count > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// scalewayListPrices are the per-hour figures ADR-0024 recorded, with
+// their sources. Deliberately small: this is what has actually been
+// looked up, not a guess at a catalogue.
+var scalewayListPrices = map[string]struct {
+	eurPerHour float64
+	source     string
+}{
+	"DEV1-S instance":     {0.00898, "scaleway.com/en/pricing/virtual-instances"},
+	"LB-S load balancer":  {0.023, "scaleway.com/en/pricing/network"},
+	"public IPv4 address": {0.005, "scaleway.com/en/pricing/network"},
+}
+
+// hasUnmodelledResources reports whether a cloud declares resource
+// blocks the Go Resources struct does not carry.
+//
+// `cloud: genesys` scenarios use `routing`, `identity`, `architect` and
+// `full_stack` (scenario.schema.json), none of which have a field here,
+// so they unmarshal into an empty resource set. Naming that explicitly
+// beats inferring it from emptiness, because a scenario with genuinely
+// no resources is a different and harmless thing.
+func hasUnmodelledResources(cloud string) bool {
+	return cloud == "genesys"
+}
+
+// defaultComputeName is what a scenario's compute block will become.
+//
+// Only Scaleway gets a concrete offer name, because only Scaleway's
+// generator maps `size` onto one this project can name. Elsewhere the
+// honest answer is the shape, not a guess at the SKU.
+func defaultComputeName(cloud string) string {
+	if cloud == "scaleway" {
+		return "DEV1-S"
+	}
+	return "compute"
+}
+
+func defaultLoadBalancerName(cloud string) string {
+	if cloud == "scaleway" {
+		return "LB-S load balancer"
+	}
+	return "load balancer"
+}
+
+// EstimateCost prices what a scenario will create.
+//
+// Scaleway only: the prices are Scaleway's, and pretending to price a
+// GCP or AWS scenario from them would be a fabrication. Another cloud
+// returns an estimate with everything unpriced, which is honest and
+// still tells a reader what will be created.
+func (s *Scenario) EstimateCost() CostEstimate {
+	est := CostEstimate{Components: []CostComponent{}, Unpriced: []string{}}
+
+	// addFree records something that IS created and costs nothing.
+	//
+	// Distinct from the unpriced path, and that distinction is the whole
+	// design of this type: free and unknown are different facts. Routing
+	// a VPC through the unknown path would make an otherwise complete
+	// estimate report "AT LEAST", teaching a reader to ignore the words
+	// that mean something.
+	addFree := func(name string, count int) {
+		if count <= 0 {
+			return
+		}
+		est.Components = append(est.Components, CostComponent{
+			Name: name, Count: count, Priced: true, Source: "no charge",
+		})
+	}
+
+	add := func(name string, count int) {
+		if count <= 0 {
+			return
+		}
+		price, known := scalewayListPrices[name]
+		if s.Cloud != "scaleway" {
+			known = false
+		}
+		component := CostComponent{Name: name, Count: count}
+		if known {
+			component.EurPerHour = price.eurPerHour
+			component.Priced = true
+			component.Source = price.source
+			est.EurPerHour += price.eurPerHour * float64(count)
+		} else {
+			est.Unpriced = append(est.Unpriced, name)
+		}
+		est.Components = append(est.Components, component)
+	}
+
+	r := s.Resources
+
+	if r.Compute != nil {
+		count := r.Compute.Count
+		if count == 0 {
+			count = 1
+		}
+		// The offer, when overridden, is what will actually be billed --
+		// and this project has a price for exactly one of them. Naming
+		// the real offer and marking it unpriced beats pricing it as a
+		// DEV1-S because that is the only number to hand.
+		//
+		// The DEFAULT is Scaleway-specific, so it is only assumed for a
+		// Scaleway scenario. Telling a GCP user their deploy will create
+		// a "DEV1-S instance" names a resource that will not exist,
+		// which is worse than being vague: this endpoint's whole job is
+		// saying what deploy would do.
+		offer := r.Compute.Override.Offer
+		if offer == "" {
+			offer = defaultComputeName(s.Cloud)
+		}
+		add(offer+" instance", count)
+		add(PublicAddressComponent, count)
+	}
+
+	if r.Networking != nil {
+		// A VPC or private network is not billable and IS created, and
+		// this list is a blast-radius preview before it is a bill. A
+		// component that costs nothing still belongs in "what will this
+		// make".
+		if r.Networking.VPC {
+			addFree("VPC", 1)
+		}
+		if r.Networking.PrivateNetwork {
+			addFree("private network", 1)
+		}
+		if r.Networking.LoadBalancer == nil && !r.Networking.VPC && !r.Networking.PrivateNetwork {
+			addFree("networking", 1)
+		}
+	}
+
+	if r.Networking != nil && r.Networking.LoadBalancer != nil {
+		add(defaultLoadBalancerName(s.Cloud), 1)
+		// Only a PUBLIC load balancer gets a public IP -- that is what
+		// the schema says `exposure` means. Billing one for a private
+		// balancer inflates the estimate and, worse, lists a component
+		// the scenario says will not exist, which makes the whole
+		// component list something a reader learns to skim.
+		if r.Networking.LoadBalancer.Public() {
+			add(PublicAddressComponent, 1)
+		}
+	}
+
+	for name, present := range map[string]bool{
+		"IAM application and keys": r.IAM != nil,
+		"managed database":         r.Database != nil,
+		"Kubernetes cluster":       r.Kubernetes != nil,
+		"Redis cluster":            r.Redis != nil,
+		"object storage":           r.Storage != nil,
+		"container registry":       r.Registry != nil,
+		"managed DNS zone":         r.DNS != nil,
+		"Cloud Run service":        r.CloudRun != nil,
+		"secret manager":           r.SecretManager != nil,
+		"pub/sub topic":            r.PubSub != nil,
+		"DynamoDB table":           r.DynamoDB != nil,
+		"messaging queue":          r.Messaging != nil,
+	} {
+		if present {
+			add(name, 1)
+		}
+	}
+
+	// Deterministic order: this feeds a confirmation dialog, and a list
+	// that reshuffles between renders is one a person stops reading.
+	sort.Slice(est.Components, func(i, j int) bool { return est.Components[i].Name < est.Components[j].Name })
+	sort.Strings(est.Unpriced)
+
+	// Modelled, not Complete, is what distinguishes "nothing to create"
+	// from "nothing I can see". A scenario that genuinely declares no
+	// resources is a real, harmless case; one whose resources this
+	// struct cannot carry is not.
+	est.Modelled = len(est.Components) > 0 || !hasUnmodelledResources(s.Cloud)
+	est.Complete = est.Modelled && len(est.Unpriced) == 0 && len(est.Components) > 0
+	return est
+}

--- a/internal/scenario/cost_test.go
+++ b/internal/scenario/cost_test.go
@@ -1,0 +1,281 @@
+package scenario
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func lbServingScenario() *Scenario {
+	return &Scenario{
+		Name: "lb-serving-paris", Cloud: "scaleway",
+		Resources: Resources{
+			Compute: &ComputeResource{Purpose: "web-server", Size: "small"},
+			Networking: &NetworkingResource{
+				LoadBalancer: &LoadBalancer{Exposure: "public"},
+			},
+		},
+	}
+}
+
+// The one shape ADR-0024 priced by hand. If this drifts, the ADR and the
+// code disagree about what the demo costs.
+func TestEstimateMatchesTheShapeTheADRPriced(t *testing.T) {
+	est := lbServingScenario().EstimateCost()
+
+	require.True(t, est.Complete, "this shape is fully priced: %v", est.Unpriced)
+	assert.InDelta(t, 0.042, est.EurPerHour, 0.0005,
+		"ADR-0024 records €0.042/hour for lb-serving-paris")
+	assert.InDelta(t, 0.17, est.EurAtTTL(4*time.Hour), 0.01)
+}
+
+// The load-bearing case. A total that quietly omits what it could not
+// price is wrong in the REASSURING direction, and a confidently wrong
+// number shown at the moment somebody decides to spend money is worse
+// than no number.
+func TestEstimateNamesWhatItCouldNotPrice(t *testing.T) {
+	sc := lbServingScenario()
+	sc.Resources.Database = &DatabaseResource{}
+	sc.Resources.Kubernetes = &KubernetesResource{}
+
+	est := sc.EstimateCost()
+
+	assert.False(t, est.Complete)
+	assert.Contains(t, est.Unpriced, "managed database")
+	assert.Contains(t, est.Unpriced, "Kubernetes cluster")
+	assert.Contains(t, est.Summary(4*time.Hour), "AT LEAST")
+	assert.Contains(t, est.Summary(4*time.Hour), "no list price")
+}
+
+// Free and unknown are different facts, and summing them as if both were
+// zero is how a total silently understates itself.
+func TestUnpricedComponentsAreNotTreatedAsFree(t *testing.T) {
+	sc := lbServingScenario()
+	sc.Resources.Kubernetes = &KubernetesResource{}
+
+	est := sc.EstimateCost()
+
+	var k8s CostComponent
+	for _, c := range est.Components {
+		if c.Name == "Kubernetes cluster" {
+			k8s = c
+		}
+	}
+	require.Equal(t, "Kubernetes cluster", k8s.Name)
+	assert.False(t, k8s.Priced, "unknown is not zero")
+	assert.Zero(t, k8s.EurPerHour)
+}
+
+// An overridden offer is what will actually be billed, and this project
+// has a price for exactly one offer. Naming the real one and marking it
+// unpriced beats pricing it as a DEV1-S because that is the number to
+// hand.
+func TestAnOverriddenOfferIsNamedAndNotMispriced(t *testing.T) {
+	sc := lbServingScenario()
+	sc.Resources.Compute.Override.Offer = "GP1-XL"
+
+	est := sc.EstimateCost()
+
+	assert.False(t, est.Complete)
+	assert.Contains(t, est.Unpriced, "GP1-XL instance")
+}
+
+// The prices are Scaleway's. Pricing a GCP scenario from them would be a
+// fabrication.
+func TestAnotherCloudIsNotPricedFromScalewaysList(t *testing.T) {
+	sc := lbServingScenario()
+	sc.Cloud = "gcp"
+
+	est := sc.EstimateCost()
+
+	assert.False(t, est.Complete)
+	assert.Zero(t, est.EurPerHour)
+	assert.NotEmpty(t, est.Components, "it must still say what will be created")
+}
+
+// A confirmation dialog whose list reshuffles between renders is one a
+// person stops reading.
+func TestEstimateIsDeterministicallyOrdered(t *testing.T) {
+	sc := lbServingScenario()
+	sc.Resources.Database = &DatabaseResource{}
+	sc.Resources.Redis = &RedisResource{}
+	sc.Resources.Storage = &StorageResource{}
+
+	first := sc.EstimateCost()
+	for i := 0; i < 20; i++ {
+		got := sc.EstimateCost()
+		assert.Equal(t, first.Components, got.Components)
+		assert.Equal(t, first.Unpriced, got.Unpriced)
+	}
+}
+
+// The summary always says "list price", because an estimate a person
+// cannot tell from a quote is one they will later feel misled by.
+func TestSummaryAlwaysAdmitsItIsAListPrice(t *testing.T) {
+	assert.Contains(t, lbServingScenario().EstimateCost().Summary(time.Hour), "list price")
+}
+
+func TestScenarioWithNoResourcesIsNotReportedAsComplete(t *testing.T) {
+	est := (&Scenario{Name: "empty", Cloud: "scaleway"}).EstimateCost()
+
+	assert.False(t, est.Complete, "nothing priced is not the same as everything priced")
+	assert.Empty(t, est.Components)
+}
+
+// `exposure` is exactly "whether the load balancer has a public IP", per
+// the schema. Billing one for a private balancer inflates the estimate
+// and lists a component the scenario says will not exist — which makes
+// the whole component list something a reader learns to skim.
+func TestPrivateLoadBalancerIsNotChargedAPublicAddress(t *testing.T) {
+	sc := lbServingScenario()
+	sc.Resources.Networking.LoadBalancer.Exposure = "private"
+	sc.Resources.Compute = nil
+
+	est := sc.EstimateCost()
+
+	for _, c := range est.Components {
+		assert.NotEqual(t, "public IPv4 address", c.Name,
+			"the scenario says this balancer has no public IP")
+	}
+	assert.InDelta(t, 0.023, est.EurPerHour, 0.0005, "the balancer alone")
+}
+
+func TestPublicLoadBalancerIsStillChargedAPublicAddress(t *testing.T) {
+	sc := lbServingScenario()
+	sc.Resources.Compute = nil
+
+	est := sc.EstimateCost()
+
+	assert.InDelta(t, 0.028, est.EurPerHour, 0.0005, "balancer plus its public IPv4")
+}
+
+// The class, closed by construction rather than by list.
+//
+// The estimator enumerated eleven resource blocks by hand and missed
+// `iam` — the one whose absence matters most, since an API key and a
+// policy are exactly what a blast-radius preview exists to surface.
+// Adding it back would have been another snapshot.
+//
+// This walks `Resources` by reflection and asserts that EVERY declared
+// block contributes at least one named component. A resource type added
+// to the scenario schema now fails this test until the preview knows
+// how to name it, rather than silently vanishing from the confirmation
+// somebody reads before spending money.
+func TestEveryDeclaredResourceBlockAppearsInThePreview(t *testing.T) {
+	resourcesType := reflect.TypeOf(Resources{})
+
+	for i := 0; i < resourcesType.NumField(); i++ {
+		field := resourcesType.Field(i)
+		t.Run(field.Name, func(t *testing.T) {
+			resources := reflect.New(resourcesType).Elem()
+			target := resources.Field(i)
+			require.Equal(t, reflect.Ptr, target.Kind(),
+				"this test assumes every resource block is a pointer")
+			target.Set(reflect.New(target.Type().Elem()))
+
+			sc := &Scenario{
+				Name:      "reflection",
+				Cloud:     "scaleway",
+				Resources: resources.Interface().(Resources),
+			}
+
+			est := sc.EstimateCost()
+			assert.NotEmpty(t, est.Components,
+				"resources.%s creates something, and a preview that omits it "+
+					"understates the blast radius", field.Name)
+		})
+	}
+}
+
+// Free and unknown are different facts, and the whole design of this
+// type rests on that. Routing a VPC through the unknown path made an
+// otherwise complete estimate report "AT LEAST", which teaches a reader
+// to ignore the words that mean something.
+func TestFreeComponentsDoNotMakeAnEstimateLookIncomplete(t *testing.T) {
+	sc := lbServingScenario()
+	sc.Resources.Networking.VPC = true
+	sc.Resources.Networking.PrivateNetwork = true
+
+	est := sc.EstimateCost()
+
+	assert.True(t, est.Complete, "unpriced: %v", est.Unpriced)
+	assert.NotContains(t, est.Summary(time.Hour), "AT LEAST")
+
+	var vpc CostComponent
+	for _, c := range est.Components {
+		if c.Name == "VPC" {
+			vpc = c
+		}
+	}
+	require.Equal(t, "VPC", vpc.Name, "it must still be listed: this is a blast radius, not just a bill")
+	assert.True(t, vpc.Priced, "free is known")
+	assert.Zero(t, vpc.EurPerHour)
+}
+
+// `cloud: genesys` scenarios declare routing/identity/architect/
+// full_stack, none of which the Go Resources struct carries — so they
+// arrive as an empty resource set. An empty component list would render
+// as "creates nothing, costs nothing", which is the most reassuring
+// possible way to be wrong on the screen somebody reads before agreeing
+// to spend.
+func TestAnUnmodelledCloudIsNotReportedAsFree(t *testing.T) {
+	est := (&Scenario{Name: "genesys-basic-queue", Cloud: "genesys"}).EstimateCost()
+
+	assert.False(t, est.Modelled)
+	assert.False(t, est.Complete)
+	assert.Contains(t, est.Summary(time.Hour), "not modelled")
+	assert.Contains(t, est.Summary(time.Hour), "do not read this as free")
+}
+
+// A scenario that genuinely declares no resources is a real, harmless
+// case and must not be confused with one whose resources cannot be seen.
+func TestAScenarioWithGenuinelyNoResourcesIsStillModelled(t *testing.T) {
+	est := (&Scenario{Name: "empty", Cloud: "scaleway"}).EstimateCost()
+
+	assert.True(t, est.Modelled, "nothing to create is different from nothing I can see")
+	assert.False(t, est.Complete)
+}
+
+// The bill and the warning are two answers to one question, and they
+// disagreed: a compute-only scenario was charged for a public address
+// and told it was not reachable from the internet.
+//
+// Derived rather than re-decided, so whatever adds a public address also
+// raises the warning — including anything added later.
+func TestInternetFacingFollowsWhateverBillsAPublicAddress(t *testing.T) {
+	for name, tc := range map[string]struct {
+		mutate func(*Scenario)
+		want   bool
+	}{
+		"compute only":         {func(s *Scenario) { s.Resources.Networking = nil }, true},
+		"public load balancer": {func(s *Scenario) { s.Resources.Compute = nil }, true},
+		"private load balancer only": {func(s *Scenario) {
+			s.Resources.Compute = nil
+			s.Resources.Networking.LoadBalancer.Exposure = "private"
+		}, false},
+		"neither": {func(s *Scenario) {
+			s.Resources.Compute = nil
+			s.Resources.Networking = nil
+			s.Resources.Storage = &StorageResource{}
+		}, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			sc := lbServingScenario()
+			tc.mutate(sc)
+			est := sc.EstimateCost()
+
+			billed := false
+			for _, c := range est.Components {
+				if c.Name == PublicAddressComponent {
+					billed = true
+				}
+			}
+			assert.Equal(t, tc.want, est.InternetFacing())
+			assert.Equal(t, billed, est.InternetFacing(),
+				"the bill and the warning must never disagree")
+		})
+	}
+}

--- a/internal/scenario/scenario.go
+++ b/internal/scenario/scenario.go
@@ -147,6 +147,22 @@ type LoadBalancer struct {
 	Backends []LBBackend `json:"backends"`
 }
 
+// LoadBalancerExposurePublic is the exposure that gives a load balancer
+// a public IP. The schema's description is exactly that, and two things
+// turn on it: whether a public IPv4 is billed, and whether a deploy
+// confirmation must warn that the shape is reachable from the internet.
+const LoadBalancerExposurePublic = "public"
+
+// Public reports whether this load balancer gets a public IP.
+//
+// A method rather than a comparison at each call site, because the two
+// callers must agree: a cost estimate that bills a public address while
+// the confirmation says the shape is private would be two answers to one
+// question.
+func (l *LoadBalancer) Public() bool {
+	return l != nil && l.Exposure == LoadBalancerExposurePublic
+}
+
 type LBBackend struct {
 	Port     int    `json:"port"`
 	Protocol string `json:"protocol"`


### PR DESCRIPTION
ADR-0027 §2 made real. `GET /api/deployments/preview` answers what a deploy would
create, cost, expose, and when it would expire.

A **GET**, because it does nothing — and available whether or not `--allow-deploy`
was given, since knowing what a deployment would cost is information rather than a
capability, and a page that can explain a greyed-out button beats one that
silently omits it.

## The cost was the hard part, and the honest answer was to admit ignorance

ADR-0024's figures were read off Scaleway's pricing pages **by hand, for one
shape**. Any scenario declaring a database or a Kubernetes cluster has components
this project has never priced, and a total that quietly omitted them would be
wrong in the *reassuring* direction — at the moment somebody decides to spend.

So the estimate distinguishes **three** facts that all look like zero:

| | meaning | effect |
|---|---|---|
| `Priced`, €0 | free and known — a VPC | listed; estimate stays complete |
| unpriced | this project has no list price | listed, named, "AT LEAST …" |
| `Modelled: false` | resources this struct cannot even carry | "not modelled — do not read this as free" |

That last one is real: **`cloud: genesys` scenarios declare `routing`, `identity`,
`architect` and `full_stack`, none of which exist in the Go `Resources` struct**,
so they arrive as an empty resource set. Without the flag they would have rendered
as "creates nothing, costs nothing".

## Nine findings over six passes, and almost all were flattery

- an unpriced component summed as zero → cheaper than reality
- `iam` omitted from the shape list → smaller blast radius than reality
- a private load balancer billed a public IP → over-warning, and a warning that
  fires on everything gets skipped
- **a compute-only scenario reported not internet-facing** while being billed for
  a public IPv4 → *less exposed* than reality, at the confirmation step
- an undeployable preview expiring in the year 1 → a date where "none" belongs

Only two of the nine were mechanical.

## Two structural fixes, each replacing a condition already wrong once

- **`CostEstimate.InternetFacing()` is derived from the component list**, so the
  bill and the warning cannot disagree — and anything that adds a public address
  later raises the warning without anyone remembering to. The earlier fix made
  them agree *about load balancers* and left compute with its own condition.
- **`TestEveryDeclaredResourceBlockAppearsInThePreview`** walks `Resources` by
  reflection and asserts every block contributes a named component. It failed on
  the missing `iam` before the fix landed, which is the point: a resource type
  added to the schema now fails a test rather than vanishing from the
  confirmation.

## Also

Expiry is **wall-clock**, not a duration — "4h" is a number people agree to
without doing the arithmetic. A TTL that will not parse makes the scenario
undeployable rather than defaulting, because guessing a lifetime is how a
deployment outlives everyone's memory of it. A test pins the estimate against
ADR-0024's own €0.042/hour so the document and the code cannot drift about what
the demo costs.

## Not in this PR

The deploy endpoint and button. This is the confirmation data; S162b spends the
money.

Codex passes 112–118 archived; 118 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD