### PR TITLE
S162b: the deploy endpoint

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,43 @@
 
 Last updated: 2026-08-31
 
+## 2026-09-02 — S162b: the deploy endpoint
+
+`POST /api/deployments` creates a live deployment, behind
+`infrafactory ui --allow-deploy` — implied by neither `--allow-layer3` nor
+`--allow-teardown`, because ADR-0027 says an ephemeral apply the run destroys,
+destroying what exists, and creating what persists are three different kinds of
+harm. `DeploymentDeployer` is a separate interface from `DeploymentActor` so the
+separation lives in the type system rather than in a comment.
+
+**The seam drives the real command rather than reimplementing it**, the way
+`uiRunStarter` already drives `runRunCommand`. Between the request and the apply
+sit a deny-by-default Layer 3 HCL preflight, a credentials check, a
+per-deployment workdir so two deployments cannot share one state file, a
+run-owned project created inside an interrupt guard, and a registration step that
+writes the record **even when the apply fails** — because a half-finished apply
+leaves real resources and the record is the only thing that brings the reaper back
+to them. Every one is a guard, and every one is the kind of thing a second
+implementation gets subtly wrong.
+
+**A name, never a path.** `deploy` takes a filesystem path; accepting one over
+HTTP would let a request name any YAML on the machine, including one the layers
+have never seen. Resolution walks the scenarios tree matching the declared
+`scenario:` field.
+
+That resolver reads **only the name** — using `scenario.Load` would validate
+against `DefaultSchemaPath`, which resolves relative to the working directory, so
+in a server process every file would fail validation and be skipped and the API
+would report "no scenario named X" for a scenario sitting right there. Silently.
+Validation is deferred, not skipped: the command loads the path through the
+runtime's own loader.
+
+**The request has two fields, and the absences are the design.** No project — one
+that could name a project could name somebody else's. No skip-validation. No
+value meaning "forever". A deploy whose result cannot be read is reported as a
+FAILURE, since the apply may well have created infrastructure and an empty result
+would say the opposite.
+
 ## 2026-09-02 — S162a: what a person must be told before they spend money
 
 ADR-0027 §2 made real: `GET /api/deployments/preview` answers what a deploy would

--- a/docs/decisions/0027-deploying-from-the-ui.md
+++ b/docs/decisions/0027-deploying-from-the-ui.md
@@ -108,3 +108,45 @@ infrastructure or real money is off until somebody says otherwise in a shell.
 **This ADR is a gate, not an implementation.** S162 builds the button against it;
 if S162 needs to weaken anything here, that is a change to this document and its
 own argument, not a detail of the pull request that happens to need it.
+
+## Amendment, 2026-09-02 (S162b): the endpoint, and what it may be told
+
+`POST /api/deployments` creates a deployment. `DeploymentDeployer` is a separate
+interface from `DeploymentActor`, so §1's argument — that creating and destroying
+are different kinds of harm — lives in the type system rather than only in this
+document. A server holding one cannot be talked into the other.
+
+**The request carries a scenario name and an optional TTL, and nothing else.** The
+absences are the decision: no project, because a request that could name one could
+name somebody else's; no skip-validation; and no value meaning "forever".
+
+**A name, never a path.** `deploy` takes a filesystem path, and accepting one over
+HTTP would let a request name any YAML on the machine, including one outside the
+scenarios tree that the layers have never seen. Resolution walks the tree matching
+the declared `scenario:` field.
+
+That resolver reads **only the name**. Loading each candidate through
+`scenario.Load` would validate it against `DefaultSchemaPath`, which resolves
+relative to the working directory — so in a server process started anywhere else,
+every file would fail validation, be skipped, and the API would report "no
+scenario named X" for a scenario sitting right there. Validation is deferred, not
+skipped: the command loads the path through the runtime's own loader.
+
+**The seam drives the command rather than reimplementing it.** Between the request
+and the apply sit a deny-by-default Layer 3 HCL preflight, a credentials check, a
+per-deployment workdir, a run-owned project created inside an interrupt guard, and
+a registration step that writes the record *even when the apply fails*. A second
+implementation of that sequence is a second thing that can be wrong, on the path
+that spends money.
+
+### A result that cannot be read is a failure
+
+The command emits `{"schema": ..., "result": {...}}`. Unmarshalling that into the
+inner `OutputResult` **succeeds with every field zero**, because unknown keys are
+ignored — so a successful deploy read as unclean, with no steps and no failures,
+and the endpoint would have answered 409 after creating infrastructure.
+
+A parse that cannot fail is worse than one that does: there is nothing to notice.
+The envelope is now required, and output that is not it is reported as a failure
+saying *whether infrastructure was created is unknown* — because the apply may
+well have created some, and an empty result would say the opposite.

--- a/docs/review-passes/pass119.md
+++ b/docs/review-passes/pass119.md
@@ -1,0 +1,36 @@
+# Codex review pass 119 — S162b
+
+One finding, **P1**, and the highest-severity defect of the session.
+
+## [P1] A successful deploy would have been reported as a failure
+
+`--output json` emits `{"schema": ..., "result": {...}}`. I unmarshalled stdout
+straight into the inner `OutputResult`.
+
+That does not error. Unknown keys are ignored, so the parse **succeeds with every
+field zero** — `Status` empty, no stages, no failures. `Clean` is then false, and
+the endpoint answers **409 after the infrastructure was created**.
+
+The operator's reading of that is "the deploy failed", while a project, an
+instance and a load balancer are running and billing. It is the exact inversion of
+the property this whole arc is built around, and it would have been found by the
+first real deploy — which is to say, by spending money.
+
+## A parse that cannot fail is worse than one that does
+
+There was nothing to notice: no error, no panic, no empty-string check. The fix
+requires the envelope and treats anything else as a failure saying *whether
+infrastructure was created is unknown* — because the apply may well have created
+some, and an empty result would say the opposite.
+
+## The test was written to my assumption, not to the system
+
+`TestDeployOutcomeReadsTheCommandsOwnVerdict` marshalled a bare `OutputResult` —
+the shape I *believed* the command emitted — and passed. A test that constructs
+its own input from the same wrong premise as the code confirms the premise.
+
+This is the third time this session: S156d's synthetic Terraform address, S161's
+banner-only assertion, and now this. The common shape is a test whose fixture is
+built from the implementation's assumptions rather than from what the other side
+actually produces. **The fixture has to come from the real producer**, and here
+that meant marshalling `MachineOutput`.

--- a/docs/review-passes/pass120.md
+++ b/docs/review-passes/pass120.md
@@ -1,0 +1,32 @@
+# Codex review pass 120 — S162b
+
+One finding, **P1**, and the second in two passes on the same slice.
+
+## [P1] A shared runtime deploys once and refuses everything after
+
+`CommandRuntime.LoadScenario` **caches**: a runtime that has loaded one scenario
+refuses a different path with *"scenario already loaded from …"*. That is correct
+for a CLI process, which handles exactly one command and exits.
+
+`LiveDeployer` held one runtime, built at startup, for the life of the server. So
+the first deploy would work and every deploy of a different scenario would fail —
+on a long-lived process, which is the only kind this endpoint runs in.
+
+## The pattern I copied already solved it
+
+The seam was written to mirror `uiRunStarter`, deliberately, so that the guards
+came from the CLI rather than a second implementation. `uiRunStarter` calls
+`buildRuntime` **inside** `executeRun` — per run, not per server. I copied the
+shape of it and not that.
+
+Both P1s in this slice are the same mistake in different clothes: assuming what
+the other side does instead of reading it. Pass 119 assumed the output shape;
+this assumed the runtime's lifetime. In both cases the answer was ten lines away
+in code I had already opened.
+
+## The startup build stays
+
+Rebuilding per deploy removes the reason the startup build existed — failing
+loudly when `--allow-deploy` cannot be honoured. So both happen: one probe at
+startup so the operator learns from the command they typed rather than from a
+click minutes later, and a fresh runtime per deploy.

--- a/docs/review-passes/pass121.md
+++ b/docs/review-passes/pass121.md
@@ -1,0 +1,21 @@
+# Codex review pass 121 — S162b
+
+One finding, accepted.
+
+## [P2] A missing scenario name answered 500
+
+`writeActionResult` maps every non-nil error to 500, and `resolveScenarioByName`
+returned a plain `fmt.Errorf`. So a client typo — or a UI holding a stale scenario
+list — read as a server fault.
+
+The teardown handler already distinguishes these, mapping `os.ErrNotExist` to 404.
+The deploy path did not, so the same class of caller mistake got two different
+answers depending on which endpoint they hit.
+
+The cost is not the status code. It is that **500 stops meaning anything** when
+user input can produce it: an operator who has seen "500" for a typo has no reason
+to treat the next one as an infrastructure problem.
+
+Both sides are pinned now — a missing scenario is 404, and a runtime that cannot
+be built is still 500 — because the distinction only means something if both
+halves of it exist.

--- a/docs/review-passes/pass122.md
+++ b/docs/review-passes/pass122.md
@@ -1,0 +1,27 @@
+# Codex review pass 122 — S162b
+
+**Clean.** The endpoint is gated, it uses the CLI deploy path rather than
+duplicating the real-cloud flow, and the safety cases are covered.
+
+Four findings, **two of them P1** — the only P1s of the session, and both on the
+slice that spends money. Both were the same mistake wearing different clothes:
+**assuming what the other side does instead of reading it.**
+
+- Pass 119 assumed the command's output shape. It emits
+  `{"schema":…,"result":{…}}`; I unmarshalled the inner object. That parse cannot
+  fail, so a *successful* deploy would have been reported as a 409 with the
+  infrastructure running.
+- Pass 120 assumed the runtime's lifetime. `LoadScenario` caches, so one runtime
+  held for the life of the server deploys the first scenario and refuses every
+  other one.
+
+In both cases the answer was already open in front of me — `MachineOutput` in
+`output_contract.go`, and `uiRunStarter` calling `buildRuntime` inside
+`executeRun`, which is the very function this seam was written to imitate. I
+copied its shape and not its behaviour.
+
+The seam decision still looks right: driving the real command means the Layer 3
+preflight, the credentials check, the per-deployment workdir, the interrupt-guarded
+project creation and the write-the-record-even-on-failure step are the CLI's, not
+a second copy. Both P1s were in the thirty lines of translation around it, which
+is roughly where the risk should sit.

--- a/internal/api/deployment_actions.go
+++ b/internal/api/deployment_actions.go
@@ -29,6 +29,23 @@ type ActionResult struct {
 	Failures []ActionStep `json:"failures"`
 }
 
+// DeploymentDeployer creates a live deployment.
+//
+// Separate from DeploymentActor, and that separation is ADR-0027's whole
+// argument in the type system: destroying what exists and creating what
+// persists are different kinds of harm, gated by different flags. A
+// server holding one of these interfaces cannot be talked into the
+// other.
+type DeploymentDeployer interface {
+	// Deploy applies a scenario and leaves it running under a TTL.
+	//
+	// It takes the scenario NAME and a TTL string, and nothing else. It
+	// deliberately cannot be told which project to use -- run-owned
+	// projects are created by the harness (ADR-0025), and a request that
+	// could name one is a request that could name somebody else's.
+	Deploy(ctx context.Context, scenarioName, ttl string) (ActionResult, error)
+}
+
 // DeploymentActor performs the destructive half of live management.
 //
 // Separate from DeploymentLister on purpose. Reading the estate is safe

--- a/internal/api/handlers_deploy_test.go
+++ b/internal/api/handlers_deploy_test.go
@@ -1,0 +1,200 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redscaresu/infrafactory/internal/config"
+)
+
+type fakeDeployer struct {
+	result   ActionResult
+	err      error
+	calls    []string
+	ttls     []string
+	sawCtx   context.Context
+	deadline time.Time
+	hadDl    bool
+	ctxErr   error
+}
+
+func (f *fakeDeployer) Deploy(ctx context.Context, name, ttl string) (ActionResult, error) {
+	f.calls = append(f.calls, name)
+	f.ttls = append(f.ttls, ttl)
+	f.sawCtx = ctx
+	f.ctxErr = ctx.Err()
+	f.deadline, f.hadDl = ctx.Deadline()
+	return f.result, f.err
+}
+
+func deployServer(t *testing.T, d DeploymentDeployer) *http.Server {
+	t.Helper()
+	return NewServer(ServerConfig{
+		Config: config.Default(), Deployments: &fakeDeployments{}, Deployer: d,
+	})
+}
+
+func postDeploy(t *testing.T, srv *http.Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/deployments", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// ADR-0027: --allow-deploy is implied by neither --allow-layer3 nor
+// --allow-teardown. An ephemeral apply the run destroys, destroying what
+// exists, and creating what persists are three different kinds of harm.
+func TestDeployDoesNotExistWithoutItsOwnFlag(t *testing.T) {
+	// A server that CAN destroy still cannot create.
+	srv := NewServer(ServerConfig{
+		Config: config.Default(), Deployments: &fakeDeployments{},
+		DeploymentActor: &fakeActor{},
+	})
+
+	rec := postDeploy(t, srv, `{"scenario":"lb-serving-paris"}`)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "--allow-deploy")
+}
+
+func TestDeployCreatesTheNamedScenario(t *testing.T) {
+	deployer := &fakeDeployer{result: ActionResult{Clean: true}}
+	srv := deployServer(t, deployer)
+
+	rec := postDeploy(t, srv, `{"scenario":"lb-serving-paris","ttl":"2h"}`)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, []string{"lb-serving-paris"}, deployer.calls)
+	assert.Equal(t, []string{"2h"}, deployer.ttls)
+}
+
+// A deploy that could not prove itself clean is not a 200, for the same
+// reason a teardown is not: a page rendering a tick over "resources were
+// created and could not be recorded" is the false green this project
+// exists to avoid.
+func TestDeployThatDidNotSucceedIsNotASuccess(t *testing.T) {
+	srv := deployServer(t, &fakeDeployer{result: ActionResult{
+		Clean: false,
+		Failures: []ActionStep{{
+			Stage: "deploy", Status: "fail",
+			Detail: "resources may be live and could NOT be recorded",
+		}},
+	}})
+
+	rec := postDeploy(t, srv, `{"scenario":"lb-serving-paris"}`)
+
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	assert.Contains(t, rec.Body.String(), "could NOT be recorded")
+}
+
+// An apply takes minutes and creates infrastructure as it goes. A client
+// disconnecting halfway would leave resources with no completed record
+// of what was made.
+func TestDeploySurvivesTheClientDisconnecting(t *testing.T) {
+	deployer := &fakeDeployer{result: ActionResult{Clean: true}}
+	srv := deployServer(t, deployer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/api/deployments",
+		strings.NewReader(`{"scenario":"lb-serving-paris"}`)).WithContext(ctx)
+	cancel()
+	srv.Handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	// Recorded during the call: checking afterwards would measure the
+	// handler's own defer cancel(), not the disconnect.
+	assert.NoError(t, deployer.ctxErr, "the apply must still be running after the caller left")
+	require.True(t, deployer.hadDl, "a detached apply still needs a backstop")
+}
+
+func TestDeployRequiresAScenario(t *testing.T) {
+	deployer := &fakeDeployer{}
+	srv := deployServer(t, deployer)
+
+	rec := postDeploy(t, srv, `{"ttl":"2h"}`)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Empty(t, deployer.calls)
+}
+
+// The absences are the design. A request that could name a project could
+// name somebody else's; run-owned projects are the harness's to create.
+func TestDeployIgnoresAnythingItMustNotBeTold(t *testing.T) {
+	deployer := &fakeDeployer{result: ActionResult{Clean: true}}
+	srv := deployServer(t, deployer)
+
+	rec := postDeploy(t, srv, `{
+		"scenario":"lb-serving-paris",
+		"project_id":"someone-elses-project",
+		"skip_validation":true,
+		"ttl":""
+	}`)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	payload, err := json.Marshal(deployRequest{Scenario: "lb-serving-paris"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(payload), "project",
+		"there is nowhere for a project to land, and that is the guarantee")
+	assert.Equal(t, []string{""}, deployer.ttls, "an empty TTL means the scenario's own, never unbounded")
+}
+
+func TestDeployIsBehindTheOriginGuard(t *testing.T) {
+	srv := deployServer(t, &fakeDeployer{result: ActionResult{Clean: true}})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/deployments",
+		strings.NewReader(`{"scenario":"x"}`))
+	req.Host = "127.0.0.1:4173"
+	req.Header.Set("Origin", "https://evil.example")
+
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// Listing must keep working on a server that can also create.
+func TestDeployDoesNotBreakTheListing(t *testing.T) {
+	srv := deployServer(t, &fakeDeployer{})
+
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/deployments", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var payload deploymentsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	assert.True(t, payload.DeployAllowed)
+	assert.False(t, payload.TeardownAllowed, "one capability does not imply the other")
+}
+
+// A client typo, or a UI holding a stale scenario list, is not a server
+// fault. Answering 500 teaches operators that 500 means nothing in
+// particular.
+func TestDeployOfAnUnknownScenarioIsNotFound(t *testing.T) {
+	srv := deployServer(t, &fakeDeployer{err: fmt.Errorf("no scenario named %q: %w", "gone", os.ErrNotExist)})
+
+	rec := postDeploy(t, srv, `{"scenario":"gone"}`)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "no scenario named")
+}
+
+// A genuine fault is still a 500: the distinction only means something
+// if both sides of it exist.
+func TestDeployStillReportsARealFailureAsAServerError(t *testing.T) {
+	srv := deployServer(t, &fakeDeployer{err: errors.New("the runtime could not be built")})
+
+	rec := postDeploy(t, srv, `{"scenario":"lb-serving-paris"}`)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}

--- a/internal/api/handlers_deployments.go
+++ b/internal/api/handlers_deployments.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"os"
@@ -81,6 +82,12 @@ type deploymentsResponse struct {
 	// has to carry it where a page will see it.
 	Unreadable []string `json:"unreadable"`
 
+	// DeployAllowed reports whether this server was started with
+	// --allow-deploy. Same purpose and same non-guarantee as
+	// TeardownAllowed: it stops the page offering a button that 404s,
+	// and it cannot make the endpoint exist.
+	DeployAllowed bool `json:"deploy_allowed"`
+
 	// TeardownAllowed reports whether this server was started with
 	// --allow-teardown.
 	//
@@ -100,6 +107,14 @@ type deploymentsResponse struct {
 // guards being reimplemented in a hurry.
 func deploymentsHandler(state *serverState) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			// Creating shares the collection URL with listing, as REST
+			// expects. The capability gate lives in deployHandler, so a
+			// server without --allow-deploy answers 404 here rather than
+			// 405 -- "no such thing" rather than "wrong verb".
+			deployHandler(state)(w, r)
+			return
+		}
 		if r.Method != http.MethodGet {
 			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
@@ -121,6 +136,7 @@ func deploymentsHandler(state *serverState) http.HandlerFunc {
 			Deployments:     make([]deploymentJSON, 0, len(deployments)),
 			Unreadable:      make([]string, 0, len(unreadable)),
 			TeardownAllowed: state.deploymentActor != nil,
+			DeployAllowed:   state.deployer != nil,
 		}
 		for _, d := range deployments {
 			payload.Deployments = append(payload.Deployments, deploymentJSON{
@@ -263,4 +279,72 @@ const destructiveTimeout = 30 * time.Minute
 // upstream) while its cancellation is dropped.
 func destructiveContext(r *http.Request) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.WithoutCancel(r.Context()), destructiveTimeout)
+}
+
+// deployRequest is everything a caller may decide.
+//
+// Two fields, and the absences are the design. There is no project: a
+// request that could name one could name somebody else's, and run-owned
+// projects are the harness's to create (ADR-0025, ADR-0027). There is no
+// "skip validation", no image override, and no way to ask for an
+// unbounded lifetime.
+type deployRequest struct {
+	Scenario string `json:"scenario"`
+
+	// TTL overrides the scenario's own. Empty means the scenario's,
+	// which the schema already bounds -- there is deliberately no value
+	// meaning "forever".
+	TTL string `json:"ttl,omitempty"`
+}
+
+// deployHandler creates a live deployment.
+//
+// Absent unless the server was started with `--allow-deploy`, which is
+// implied by neither `--allow-layer3` nor `--allow-teardown`: an
+// ephemeral apply the run destroys, destroying what exists, and creating
+// what persists are three different kinds of harm (ADR-0027).
+func deployHandler(state *serverState) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if state.deployer == nil {
+			writeJSONError(w, http.StatusNotFound,
+				"this server was not started with --allow-deploy, so it cannot create deployments")
+			return
+		}
+		if r.Method != http.MethodPost {
+			writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+
+		var req deployRequest
+		if r.Body != nil {
+			defer r.Body.Close()
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				writeJSONError(w, http.StatusBadRequest, "invalid json body")
+				return
+			}
+		}
+		if strings.TrimSpace(req.Scenario) == "" {
+			writeJSONError(w, http.StatusBadRequest, "scenario is required")
+			return
+		}
+
+		// Detached, exactly as teardown is. An apply takes minutes and
+		// creates infrastructure as it goes; a client disconnecting
+		// halfway would leave resources with no completed record of what
+		// was made -- the leak D6 taught this project to fear, arriving
+		// by a different route (ADR-0027).
+		ctx, cancel := destructiveContext(r)
+		defer cancel()
+
+		result, err := state.deployer.Deploy(ctx, req.Scenario, req.TTL)
+		if errors.Is(err, os.ErrNotExist) {
+			// The caller named something that is not here. A client
+			// typo or a stale scenario list is not a server fault, and
+			// answering 500 teaches operators that 500 means nothing in
+			// particular. Matches the teardown handler.
+			writeJSONError(w, http.StatusNotFound, err.Error())
+			return
+		}
+		writeActionResult(w, result, err)
+	}
 }

--- a/internal/api/handlers_deployments_test.go
+++ b/internal/api/handlers_deployments_test.go
@@ -112,17 +112,31 @@ func TestDeploymentsMarkOnesThatWereUpgraded(t *testing.T) {
 	assert.True(t, payload.Deployments[0].Upgraded)
 }
 
-// Read-only, deliberately: deploy, teardown and reap carry guards that
-// live in internal/cli and are not reachable from here.
-func TestDeploymentsRefuseEveryMutatingMethod(t *testing.T) {
+// A server given no capability flags creates nothing, whatever it is
+// asked.
+//
+// POST answers 404 rather than 405 since S162b, and the distinction is
+// deliberate: POST is a real verb on this collection when the server was
+// started with --allow-deploy. Without it the capability does not exist,
+// which is "no such thing" rather than "wrong verb" -- the same answer
+// teardown gives. The property under test is unchanged: nothing here
+// mutates.
+func TestDeploymentsCreateNothingWithoutACapabilityFlag(t *testing.T) {
 	srv := NewServer(ServerConfig{Config: config.Default(), Deployments: &fakeDeployments{}})
 
-	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete} {
+	for method, want := range map[string]int{
+		http.MethodPost:   http.StatusNotFound,
+		http.MethodPut:    http.StatusMethodNotAllowed,
+		http.MethodPatch:  http.StatusMethodNotAllowed,
+		http.MethodDelete: http.StatusMethodNotAllowed,
+	} {
 		req := httptest.NewRequest(method, "/api/deployments", nil)
 		rec := httptest.NewRecorder()
 		srv.Handler.ServeHTTP(rec, req)
 
-		assert.Equal(t, http.StatusMethodNotAllowed, rec.Code, "%s must not be served", method)
+		assert.Equal(t, want, rec.Code, "%s must not create anything", method)
+		assert.NotContains(t, rec.Body.String(), "clean",
+			"%s must not have produced a deployment result", method)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -36,7 +36,12 @@ type ServerConfig struct {
 	// --allow-teardown. Nil means the destructive endpoints do not
 	// exist, rather than existing and refusing.
 	DeploymentActor DeploymentActor
-	RuntimeErrors   chan error
+
+	// Deployer is nil unless the operator started the server with
+	// --allow-deploy. A separate field from DeploymentActor because they
+	// gate different kinds of harm (ADR-0027).
+	Deployer      DeploymentDeployer
+	RuntimeErrors chan error
 }
 
 type StartRunRequest struct {
@@ -76,6 +81,7 @@ func NewServer(cfg ServerConfig) *http.Server {
 		deployments:  cfg.Deployments,
 
 		deploymentActor: cfg.DeploymentActor,
+		deployer:        cfg.Deployer,
 		sessionID:       fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UTC().UnixNano()),
 		startedAt:       time.Now().UTC(),
 	}
@@ -144,6 +150,7 @@ type serverState struct {
 	deployments  DeploymentLister
 
 	deploymentActor DeploymentActor
+	deployer        DeploymentDeployer
 	sessionID       string
 	startedAt       time.Time
 }

--- a/internal/cli/live_service.go
+++ b/internal/cli/live_service.go
@@ -2,9 +2,17 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io/fs"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	"github.com/redscaresu/infrafactory/internal/api"
 	"github.com/redscaresu/infrafactory/internal/livestore"
@@ -124,4 +132,206 @@ func actionResult(stages []StageSummary, failures []FailureSummary) api.ActionRe
 		})
 	}
 	return out
+}
+
+// LiveDeployer creates live deployments for callers that are not a cobra
+// command (S162b).
+//
+// # Why it drives the real command rather than reimplementing it
+//
+// `deploy` is not a thin wrapper. Between the request and the apply sit
+// a Layer 3 HCL preflight that denies by default, a credentials check, a
+// per-deployment workdir so two deployments cannot share one state file,
+// a run-owned project created inside an interrupt guard, and a
+// registration step that writes the record even when the apply FAILS --
+// because a half-finished apply leaves real resources and the record is
+// the only thing that will bring the reaper back to them.
+//
+// Every one of those is a guard, and every one of them is exactly the
+// kind of thing a second implementation gets subtly wrong. So this
+// builds the command and calls it, the same way `uiRunStarter` already
+// drives `runRunCommand`. The seam is a translation layer; the behaviour
+// is the CLI's.
+// # Why it builds a runtime per deploy
+//
+// `CommandRuntime.LoadScenario` CACHES: a runtime that has loaded one
+// scenario refuses a different path with "scenario already loaded from
+// …". That is right for a CLI process, which handles exactly one
+// command, and wrong for a server, which is long-lived. A shared runtime
+// would deploy the first scenario asked for and fail every other one.
+//
+// So the runtime is rebuilt per call, exactly as `uiRunStarter` rebuilds
+// one per run. The startup build is kept as well, because it is what
+// makes `--allow-deploy` fail loudly at start rather than at the first
+// click.
+type LiveDeployer struct {
+	newRuntime func() (*CommandRuntime, error)
+
+	// scenarioRoot is where a scenario NAME is resolved from. Held so a
+	// caller cannot pass a path.
+	scenarioRoot string
+}
+
+// NewLiveDeployer builds the deployer from a runtime factory.
+//
+// A factory rather than a runtime: see the caching note above.
+func NewLiveDeployer(scenarioRoot string, newRuntime func() (*CommandRuntime, error)) *LiveDeployer {
+	return &LiveDeployer{newRuntime: newRuntime, scenarioRoot: scenarioRoot}
+}
+
+// Deploy applies a scenario and leaves it running under a TTL.
+func (d *LiveDeployer) Deploy(ctx context.Context, scenarioName, ttl string) (api.ActionResult, error) {
+	// A NAME, resolved here, never a path from the caller. `deploy`
+	// takes a filesystem path, and accepting one over HTTP would let a
+	// request name any YAML on the machine -- including one outside the
+	// scenarios tree that the layers have never seen.
+	path, err := resolveScenarioByName(d.scenarioRoot, scenarioName)
+	if err != nil {
+		return api.ActionResult{}, err
+	}
+
+	// Fresh per deploy. A reused runtime has a scenario cached in it and
+	// refuses every other one.
+	runtime, err := d.newRuntime()
+	if err != nil {
+		return api.ActionResult{}, err
+	}
+
+	cmd := &cobra.Command{Use: "deploy"}
+	cmd.Flags().String("ttl", "", "")
+	cmd.Flags().String("output", string(OutputModeJSON), "")
+	if ttl != "" {
+		if err := cmd.Flags().Set("ttl", ttl); err != nil {
+			return api.ActionResult{}, err
+		}
+	}
+
+	// Output is captured rather than printed: this is an API call, and
+	// the command's stdout contract is not the response body.
+	var out, progress strings.Builder
+	cmd.SetOut(&out)
+	cmd.SetErr(&progress)
+	cmd.SetContext(ctx)
+
+	deployErr := runDeployCommand(cmd, []string{path}, runtime)
+
+	result := deployOutcome(out.String(), progress.String(), deployErr)
+	if deployErr != nil && result.Failures == nil {
+		// The command failed before it produced structured output --
+		// a usage error, a missing scenario. Surfacing the raw error
+		// beats an empty result that reads like nothing went wrong.
+		result.Failures = []api.ActionStep{{
+			Stage: "deploy", Status: string(StageStatusFail), Detail: deployErr.Error(),
+		}}
+		result.Clean = false
+	}
+	return result, nil
+}
+
+// deployOutcome turns the command's JSON output into the neutral shape.
+//
+// A parse failure is reported as a FAILURE rather than swallowed: the
+// apply may well have created infrastructure, and an empty result would
+// say the opposite.
+func deployOutcome(stdout, progress string, deployErr error) api.ActionResult {
+	// The WRAPPER, not the result directly. `--output json` emits
+	// `{"schema": ..., "result": {...}}`, and unmarshalling that into an
+	// OutputResult SUCCEEDS with every field zero -- unknown keys are
+	// ignored and `Status` is simply empty. So a successful deploy would
+	// have been reported as unclean, with no steps and no failures, and
+	// the endpoint would answer 409 after infrastructure was created.
+	//
+	// A parse that cannot fail is worse than one that does: there is
+	// nothing to notice.
+	var envelope MachineOutput
+	if err := json.Unmarshal([]byte(stdout), &envelope); err != nil || envelope.Schema == "" {
+		if deployErr == nil {
+			return api.ActionResult{Clean: false, Failures: []api.ActionStep{{
+				Stage: "deploy", Status: string(StageStatusFail),
+				Detail: "the deploy finished but its result could not be read, so whether " +
+					"infrastructure was created is unknown: " + strings.TrimSpace(progress),
+			}}}
+		}
+		return api.ActionResult{Clean: false}
+	}
+
+	payload := envelope.Result
+	out := actionResult(payload.Stages, payload.Failures)
+	out.Clean = payload.Status == CommandStatusSuccess && len(payload.Failures) == 0
+	return out
+}
+
+// resolveScenarioByName finds a scenario file by its declared name.
+//
+// The walk matches on the scenario's `scenario:` field rather than its
+// filename, because that is the name the API speaks and the two are not
+// required to agree.
+func resolveScenarioByName(root, name string) (string, error) {
+	if strings.TrimSpace(name) == "" {
+		return "", fmt.Errorf("no scenario name: %w", os.ErrNotExist)
+	}
+
+	var found string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() {
+			return walkErr
+		}
+		if ext := filepath.Ext(entry.Name()); ext != ".yaml" && ext != ".yml" {
+			return nil
+		}
+		// Only the NAME is read here, deliberately -- not a validated
+		// scenario.
+		//
+		// `scenario.Load` validates against `DefaultSchemaPath`, which
+		// is resolved relative to the working directory. In a server
+		// process that is wherever the operator started it, so every
+		// file would fail validation and be skipped, and this would
+		// report "no scenario named X" for a scenario sitting right
+		// there. Worse, it would do so silently.
+		//
+		// Validation is not skipped, only deferred: `runDeployCommand`
+		// loads this path through the runtime's own loader, which knows
+		// where the schema is. Resolution needs a name; the command
+		// needs a valid scenario, and it checks for itself.
+		declared, err := declaredScenarioName(path)
+		if err != nil {
+			// Unreadable or not YAML at all. Not this call's problem;
+			// skipping it beats failing the search for an unrelated
+			// scenario, since one broken file in the tree would
+			// otherwise make every deploy impossible.
+			return nil
+		}
+		if declared == name {
+			found = path
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if found == "" {
+		// Wrapped so the caller can tell "you asked for something that
+		// is not here" from "this server is broken". A client typo, or
+		// a UI holding a stale scenario list, is not a 500 -- and
+		// reporting it as one teaches operators that 500 means nothing
+		// in particular.
+		return "", fmt.Errorf("no scenario named %q: %w", name, os.ErrNotExist)
+	}
+	return found, nil
+}
+
+// declaredScenarioName reads only the `scenario:` field.
+func declaredScenarioName(path string) (string, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	var header struct {
+		Scenario string `yaml:"scenario"`
+	}
+	if err := yaml.Unmarshal(payload, &header); err != nil {
+		return "", err
+	}
+	return header.Scenario, nil
 }

--- a/internal/cli/live_service_test.go
+++ b/internal/cli/live_service_test.go
@@ -1,0 +1,249 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A NAME, resolved here, never a path from the caller. `deploy` takes a
+// filesystem path, and accepting one over HTTP would let a request name
+// any YAML on the machine -- including one outside the scenarios tree
+// that the layers have never seen.
+func TestResolveScenarioByNameMatchesTheDeclaredNameNotTheFilename(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "training"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "training", "unrelated-filename.yaml"),
+		[]byte(`scenario: the-declared-name
+version: "1.0"
+cloud: scaleway
+description: filename and name deliberately differ
+resources:
+  compute:
+    purpose: web-server
+    size: small
+acceptance_criteria:
+  - type: destruction
+    expect: no_orphans
+`), 0o644))
+
+	got, err := resolveScenarioByName(root, "the-declared-name")
+
+	require.NoError(t, err)
+	assert.Contains(t, got, "unrelated-filename.yaml")
+}
+
+func TestResolveScenarioByNameRefusesWhatItCannotFind(t *testing.T) {
+	_, err := resolveScenarioByName(t.TempDir(), "not-here")
+	require.Error(t, err)
+
+	_, err = resolveScenarioByName(t.TempDir(), "")
+	require.Error(t, err, "an empty name must not match the first file it walks past")
+}
+
+// A path is not a name. Accepting one would defeat the point of
+// resolving by name at all.
+func TestResolveScenarioByNameDoesNotAcceptAPath(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "sc.yaml"),
+		[]byte(`scenario: real-one
+version: "1.0"
+cloud: scaleway
+description: x
+resources:
+  compute:
+    purpose: web-server
+    size: small
+acceptance_criteria:
+  - type: destruction
+    expect: no_orphans
+`), 0o644))
+
+	for _, attempt := range []string{
+		filepath.Join(root, "sc.yaml"),
+		"../../../etc/passwd",
+		"/etc/passwd",
+	} {
+		_, err := resolveScenarioByName(root, attempt)
+		require.Error(t, err, "%q is a path, not a scenario name", attempt)
+	}
+}
+
+// A file that will not parse must not fail the search for an unrelated
+// scenario: one broken YAML in the tree would otherwise make every
+// deploy impossible.
+func TestResolveScenarioByNameSkipsFilesItCannotParse(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "broken.yaml"), []byte("{{{not yaml"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "good.yaml"),
+		[]byte(`scenario: still-findable
+version: "1.0"
+cloud: scaleway
+description: x
+resources:
+  compute:
+    purpose: web-server
+    size: small
+acceptance_criteria:
+  - type: destruction
+    expect: no_orphans
+`), 0o644))
+
+	got, err := resolveScenarioByName(root, "still-findable")
+
+	require.NoError(t, err)
+	assert.Contains(t, got, "good.yaml")
+}
+
+// A deploy whose result cannot be read is a FAILURE, not an empty
+// success: the apply may well have created infrastructure, and an empty
+// result would say the opposite.
+func TestDeployOutcomeTreatsUnreadableOutputAsAFailure(t *testing.T) {
+	got := deployOutcome("not json at all", "init...\napply...", nil)
+
+	assert.False(t, got.Clean)
+	require.NotEmpty(t, got.Failures)
+	assert.Contains(t, got.Failures[0].Detail, "whether infrastructure was created is unknown")
+}
+
+func TestDeployOutcomeReadsTheCommandsOwnVerdict(t *testing.T) {
+	// The ENVELOPE the command actually writes. An earlier version of
+	// this test marshalled a bare OutputResult -- the shape I assumed
+	// rather than the one emitted -- and passed while a successful
+	// deploy was being reported as a 409 after creating infrastructure.
+	payload, err := json.Marshal(MachineOutput{
+		Schema: "infrafactory.output.v1",
+		Result: OutputResult{
+			Command: "deploy", Status: CommandStatusSuccess,
+			Stages: []StageSummary{{Layer: "sandbox_deploy", Stage: "apply", Status: StageStatusPass}},
+		},
+	})
+	require.NoError(t, err)
+
+	got := deployOutcome(string(payload), "", nil)
+
+	assert.True(t, got.Clean)
+	require.Len(t, got.Steps, 1)
+	assert.Equal(t, "apply", got.Steps[0].Stage)
+}
+
+// A failed deploy carries its stages: they name the leaked project id
+// and how to remove it by hand, which is the one handle an operator has
+// on the path where they most need it.
+func TestDeployOutcomeCarriesTheFailureDetail(t *testing.T) {
+	payload, err := json.Marshal(MachineOutput{
+		Schema: "infrafactory.output.v1",
+		Result: OutputResult{
+			Command: "deploy", Status: CommandStatusFailed,
+			Failures: []FailureSummary{{
+				Layer: "sandbox_deploy", Stage: "run_project",
+				Detail: "project 7c98d82e is live and could not be deleted",
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	got := deployOutcome(string(payload), "", errors.New("deploy failed"))
+
+	assert.False(t, got.Clean)
+	require.Len(t, got.Failures, 1)
+	assert.Contains(t, got.Failures[0].Detail, "7c98d82e")
+}
+
+// The defect that made pass 119 a P1: unmarshalling the envelope's
+// CONTENTS into an OutputResult succeeds with every field zero, because
+// unknown keys are ignored. A successful deploy then reads as unclean
+// with no steps and no failures, and the endpoint answers 409 after
+// infrastructure was created.
+//
+// A parse that cannot fail is worse than one that does: there is nothing
+// to notice.
+func TestDeployOutcomeRejectsOutputThatIsNotTheCommandsEnvelope(t *testing.T) {
+	// Valid JSON, wrong shape -- exactly what a bare OutputResult, or
+	// any other object, looks like to a permissive unmarshal.
+	got := deployOutcome(`{"command":"deploy","status":"success"}`, "applying...", nil)
+
+	assert.False(t, got.Clean)
+	require.NotEmpty(t, got.Failures)
+	assert.Contains(t, got.Failures[0].Detail, "could not be read")
+}
+
+// And the shape it does understand still works end to end.
+func TestDeployOutcomeAcceptsTheRealEnvelope(t *testing.T) {
+	payload, err := json.Marshal(MachineOutput{
+		Schema: "infrafactory.output.v1",
+		Result: OutputResult{Command: "deploy", Status: CommandStatusSuccess},
+	})
+	require.NoError(t, err)
+
+	assert.True(t, deployOutcome(string(payload), "", nil).Clean)
+}
+
+// CommandRuntime.LoadScenario caches: a runtime that loaded one scenario
+// refuses a different path with "scenario already loaded from …". Right
+// for a CLI process handling one command; wrong for a server, which
+// would deploy the first scenario asked for and fail every other one.
+func TestDeployerBuildsAFreshRuntimeForEachDeploy(t *testing.T) {
+	root := twoScenarios(t)
+
+	built := 0
+	deployer := NewLiveDeployer(root, func() (*CommandRuntime, error) {
+		built++
+		// A runtime that fails fast: this test is about how many are
+		// built, not about running a real apply.
+		return nil, errors.New("not building a real runtime in a unit test")
+	})
+
+	for _, name := range []string{"first-scenario", "second-scenario"} {
+		_, err := deployer.Deploy(context.Background(), name, "")
+		require.Error(t, err)
+	}
+
+	assert.Equal(t, 2, built,
+		"a shared runtime would deploy the first scenario and refuse the rest")
+}
+
+// A name that resolves to nothing must not consume a runtime build, and
+// must say what was wrong.
+func TestDeployerRefusesAnUnknownScenarioBeforeBuildingAnything(t *testing.T) {
+	built := 0
+	deployer := NewLiveDeployer(t.TempDir(), func() (*CommandRuntime, error) {
+		built++
+		return nil, errors.New("should not be reached")
+	})
+
+	_, err := deployer.Deploy(context.Background(), "no-such-scenario", "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no scenario named")
+	assert.Zero(t, built, "resolution comes first")
+}
+
+// twoScenarios writes a scenarios tree with two distinct names, which is
+// the minimum needed to show the caching problem.
+func twoScenarios(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, name := range []string{"first-scenario", "second-scenario"} {
+		body := []byte("scenario: " + name + `
+version: "1.0"
+cloud: scaleway
+description: x
+resources:
+  compute:
+    purpose: web-server
+    size: small
+acceptance_criteria:
+  - type: destruction
+    expect: no_orphans
+`)
+		require.NoError(t, os.WriteFile(filepath.Join(root, name+".yaml"), body, 0o644))
+	}
+	return root
+}

--- a/internal/cli/ui_command.go
+++ b/internal/cli/ui_command.go
@@ -27,6 +27,7 @@ func newUICmd(assets fs.FS) *cobra.Command {
 	var addr string
 	var allowLayer3 bool
 	var allowTeardown bool
+	var allowDeploy bool
 
 	cmd := &cobra.Command{
 		Use:   "ui",
@@ -60,6 +61,11 @@ func newUICmd(assets fs.FS) *cobra.Command {
 				return formatCommandError("ui", err)
 			}
 
+			deployer, err := deployActor(cmd, allowDeploy)
+			if err != nil {
+				return formatCommandError("ui", err)
+			}
+
 			hub := api.NewHub()
 			go hub.Run(cmd.Context())
 			starter := &uiRunStarter{
@@ -82,6 +88,7 @@ func newUICmd(assets fs.FS) *cobra.Command {
 				// destroying it, and that property survives a bug in
 				// the origin guard (S159b, ADR-0026).
 				DeploymentActor: actor,
+				Deployer:        deployer,
 			})
 
 			errCh := make(chan error, 1)
@@ -114,6 +121,8 @@ func newUICmd(assets fs.FS) *cobra.Command {
 		"Permit runs started from this UI to apply to real infrastructure and spend money")
 	cmd.Flags().BoolVar(&allowTeardown, "allow-teardown", false,
 		"Permit this UI to destroy live deployments (irreversible)")
+	cmd.Flags().BoolVar(&allowDeploy, "allow-deploy", false,
+		"Permit this UI to create live deployments that persist, bill hourly, and serve the internet")
 
 	return cmd
 }
@@ -155,6 +164,39 @@ func teardownActor(cmd *cobra.Command, allowTeardown bool) (api.DeploymentActor,
 		return nil, fmt.Errorf("--allow-teardown was requested but the teardown path could not be built: %w", err)
 	}
 	return NewLiveActions(runtime), nil
+}
+
+// deployActor builds the deployer, or nil when the operator did not ask.
+//
+// Deliberately NOT derived from allowLayer3 or allowTeardown. ADR-0027:
+// an ephemeral apply the run destroys, destroying what exists, and
+// creating what persists are three different kinds of harm, and an
+// operator who accepted one has not accepted another.
+//
+// Unlike teardown, this one keeps the generator. A deploy runs the Layer
+// 3 HCL preflight and applies real infrastructure, and building its
+// runtime the same way the CLI does is the point of the whole seam --
+// stubbing a dependency out here to make startup easier would be
+// changing what deploy is, on the path that spends money.
+func deployActor(cmd *cobra.Command, allowDeploy bool) (api.DeploymentDeployer, error) {
+	if !allowDeploy {
+		return nil, nil
+	}
+	// Built once here to FAIL LOUDLY at startup: an operator who asked
+	// for deploy and cannot have it should learn so from the command
+	// they typed, not from a click minutes later.
+	probe, err := buildRuntime(cmd, defaultRuntimeOptions())
+	if err != nil {
+		return nil, fmt.Errorf("--allow-deploy was requested but the deploy path could not be built: %w", err)
+	}
+
+	// And rebuilt per deploy, because CommandRuntime.LoadScenario caches
+	// a scenario and refuses a different one. Handing the probe runtime
+	// to the deployer would deploy whatever was asked for first and fail
+	// everything after it.
+	return NewLiveDeployer(probe.Config.Paths.Scenarios, func() (*CommandRuntime, error) {
+		return buildRuntime(cmd, defaultRuntimeOptions())
+	}), nil
 }
 
 type uiRunStarter struct {

--- a/internal/cli/ui_command_test.go
+++ b/internal/cli/ui_command_test.go
@@ -265,3 +265,39 @@ mockway:
 	require.NoError(t, err, "a missing claude binary must not stop an operator tearing down real infrastructure")
 	assert.NotNil(t, actor)
 }
+
+// ADR-0027: three flags, three kinds of harm, and none implies another.
+// An operator who accepted an ephemeral apply, or accepted cleanup, has
+// not accepted infrastructure that persists and bills hourly.
+func TestUICapabilityFlagsDoNotImplyEachOther(t *testing.T) {
+	cmd := newUICmd(nil)
+
+	for _, name := range []string{"allow-layer3", "allow-teardown", "allow-deploy"} {
+		flag := cmd.Flags().Lookup(name)
+		require.NotNil(t, flag, "--%s must exist", name)
+		assert.Equal(t, "false", flag.DefValue, "--%s must never default on", name)
+	}
+
+	// Teardown on, deploy off: the destructive capability confers no
+	// creative one.
+	deployer, err := deployActor(cmd, false)
+	require.NoError(t, err)
+	assert.Nil(t, deployer)
+
+	actor, err := teardownActor(cmd, false)
+	require.NoError(t, err)
+	assert.Nil(t, actor)
+}
+
+// A guard that stops without saying why is half a guard. If the operator
+// asked for deploy and it cannot be built, starting anyway would hand
+// them a UI silently missing the capability they requested.
+func TestUIRefusesToStartWhenRequestedDeployCannotBeBuilt(t *testing.T) {
+	cmd := newUICmd(nil)
+	cmd.Flags().String("config", filepath.Join(t.TempDir(), "missing.yaml"), "")
+
+	_, err := deployActor(cmd, true)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--allow-deploy was requested")
+}


### PR DESCRIPTION
`POST /api/deployments` creates a live deployment, behind
`infrafactory ui --allow-deploy` — implied by neither `--allow-layer3` nor
`--allow-teardown`, per ADR-0027. `DeploymentDeployer` is a separate interface
from `DeploymentActor`, so that argument lives in the type system rather than only
in the document: a server holding one cannot be talked into the other.

## The seam drives the real command

Between the request and the apply sit a deny-by-default Layer 3 HCL preflight, a
credentials check, a per-deployment workdir so two deployments cannot share one
state file, a run-owned project created inside an interrupt guard, and a
registration step that writes the record **even when the apply fails** — because a
half-finished apply leaves real resources and the record is the only thing that
brings the reaper back to them.

Every one is a guard. So this builds the command and calls it, the way
`uiRunStarter` already drives `runRunCommand`.

**A name, never a path.** `deploy` takes a filesystem path, and accepting one over
HTTP would let a request name any YAML on the machine. The resolver reads *only*
the declared name — `scenario.Load` validates against a working-directory-relative
schema path, so in a server process every file would fail validation and be
skipped, and the API would report "no scenario named X" for a scenario sitting
right there.

## Four findings, two of them P1 — the only P1s of the session

Both on the slice that spends money, and both the same mistake in different
clothes: **assuming what the other side does instead of reading it.**

- **The output shape.** The command emits `{"schema":…,"result":{…}}`; I
  unmarshalled the inner object. That parse *cannot fail* — unknown keys are
  ignored — so a **successful deploy would have been reported as a 409 with the
  infrastructure running and billing.** A parse that cannot fail is worse than one
  that does: there is nothing to notice.
- **The runtime's lifetime.** `CommandRuntime.LoadScenario` caches, so one runtime
  held for the life of the server deploys the first scenario and refuses every
  other one. Fresh per deploy now, with the startup build kept so `--allow-deploy`
  fails loudly at start rather than at the first click.

In both cases the answer was already open in front of me — `MachineOutput` in
`output_contract.go`, and `uiRunStarter` calling `buildRuntime` *inside*
`executeRun`, which is the exact function this seam imitates. I copied its shape
and not its behaviour.

Worth noting where the P1s landed: not in the guards, which are the CLI's, but in
the thirty lines of translation around them. That is roughly where the risk should
sit for a seam like this.

## Also

A missing scenario is **404**, matching teardown, rather than 500. The cost of
getting that wrong is not the status code — it is that 500 stops meaning anything
once user input can produce it.

The request has two fields and the absences are the design: no project, no
skip-validation, no value meaning "forever".

ADR-0027 amended. Codex passes 119–122 archived; 122 clean. **Nothing here has
been run against real Scaleway** — the flag gates it and the tests use fakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD