### PR TITLE
S162c: the deploy button

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,37 @@
 
 Last updated: 2026-08-31
 
+## 2026-09-02 — S162c: the deploy button, and a correction to S161
+
+The scenario page can deploy. Deliberately a **separate button from Run**, and
+deliberately not matched to it in colour or weight: S153 split the verbs so that
+keeping infrastructure could not be reached by accident from the one that proves a
+change is safe, and ADR-0027 §4 says the UI must not re-merge them.
+
+The confirmation is S162a's preview rendered as **a list rather than a paragraph**,
+because each line is a separate thing somebody might object to and a paragraph is a
+thing people skim: what will be created, the cost with "list price" in it, expiry
+as wall-clock, the image, and — separated out and styled differently — the
+warnings that should actually stop somebody.
+
+`modelled === false` leads the warnings, because it is the one that invalidates
+everything above it: an unmodelled scenario's empty component list and €0.00 mean
+*unknown*, not *nothing*.
+
+### A correction: S161's visual-baseline claim was overstated
+
+S161 said a visual baseline pinned the three health states being distinguishable,
+and that "a regression making them look alike would pass every text assertion".
+The first half is not true. `maxDiffPixelRatio: 0.02` means a change confined to
+three small badges on a full-page screenshot passes comfortably — and **adding a
+whole Deploy button to the scenario page did not fail its baseline either**, which
+is what surfaced it.
+
+The property is now asserted directly, which is both stricter and immune to
+font-rendering flake: the three health badges must have pairwise-different
+computed background colours, and an unconfirmed version must differ from a
+confirmed one. A reader tells those apart by colour before they read a word.
+
 ## 2026-09-02 — S162b: the deploy endpoint
 
 `POST /api/deployments` creates a live deployment, behind

--- a/docs/review-passes/pass123.md
+++ b/docs/review-passes/pass123.md
@@ -1,0 +1,38 @@
+# Codex review pass 123 — S162c
+
+One finding, **P1**, and the sharpest of the session.
+
+## [P1] The confirmation could describe one scenario and create another
+
+SvelteKit reuses this component across scenario routes. An open confirmation from
+scenario A survives navigation to scenario B, and `confirmDeploy` posted
+`detail.name` — which by then is B.
+
+So a person could read A's shape, A's cost, A's expiry and A's blast radius, click
+*"Deploy and keep it running"*, and **create B's infrastructure**.
+
+That is worse than having no confirmation at all. A confirmation that describes
+one thing and does another converts a careful person into a confident one: they
+have checked, and what they checked was not what happened.
+
+## Fixed on both sides, because either alone leaves a hole
+
+- `confirmDeploy` posts `preview.scenario` — the scenario the displayed text came
+  from. The action now matches the description by construction, whatever the page
+  is showing.
+- `afterNavigate` clears the confirmation anyway. Accepting a stale one would now
+  be harmless, but leaving it on screen invites the reader to trust a dialog about
+  something they are no longer looking at.
+
+## Where it came from
+
+The confirmation was built to satisfy ADR-0027 §2 — state cost, lifetime and blast
+radius before the click — and it did, correctly, for the scenario it was opened
+on. The defect is not in what it says but in the **binding between what it says
+and what it does**, which the ADR did not think to require because a CLI cannot
+get it wrong: `infrafactory deploy <scenario>` names its target in the same
+sentence as the decision.
+
+Worth noting as a category: a UI can separate a description from its action in a
+way a command line structurally cannot, and every confirmation dialog in this
+project inherits that risk.

--- a/docs/review-passes/pass124.md
+++ b/docs/review-passes/pass124.md
@@ -1,0 +1,34 @@
+# Codex review pass 124 — S162c
+
+One finding, accepted. It is the third fix to the same property, and each
+previous one was necessary and insufficient.
+
+## [P2] A slow preview could open a confirmation on the page you moved to
+
+`afterNavigate` clears the dialog when the route changes. A preview takes a round
+trip, so a response arriving *after* that sets `preview` and `confirmingDeploy`
+again — re-opening a confirmation for a scenario the reader is no longer looking
+at.
+
+The request now captures the path it belongs to and discards its own response if
+that changed.
+
+## Three fixes, one property
+
+| pass | fix | what it did not cover |
+|---|---|---|
+| 123 | deploy `preview.scenario`, not `detail.name` | the dialog could still be *shown* for the wrong page |
+| 123 | clear the dialog on navigation | a response in flight re-opens it |
+| 124 | discard responses that outlive their page | — |
+
+The property is **"the confirmation on screen describes the thing this page is
+about, and accepting it does that thing"**, and it needed all three. Two of them
+look like the same fix at a glance, which is presumably why I wrote one and
+stopped.
+
+Worth naming the general shape: **asynchrony gives a UI a way to separate a
+description from its subject that a command line does not have.** `infrafactory
+deploy <scenario>` names its target in the same sentence as the decision, and
+nothing can arrive later to change it. Every dialog in this project that is
+populated by a fetch inherits this risk, and the deploy one inherits it while
+holding the ability to spend money.

--- a/docs/review-passes/pass125.md
+++ b/docs/review-passes/pass125.md
@@ -1,0 +1,35 @@
+# Codex review pass 125 — S162c
+
+One finding, accepted. **Fourth instance of one class in three passes.**
+
+## [P2] A deploy result could appear on a different scenario's page
+
+An apply takes minutes. Navigate during it and the outcome message lands on
+whatever page is showing — an unattributed *"Deployed."* that is a claim about the
+wrong thing.
+
+**Attributed rather than discarded.** The deploy really did create
+infrastructure, and throwing the news away because the reader moved is the worse
+of the two failures. Every outcome now names its scenario, success and failure
+alike, so the message is true wherever it appears.
+
+## The class, and why it took four passes
+
+Every one of these is *"asynchrony lets a UI separate a statement from its
+subject"*:
+
+1. the confirmation described A and deployed B (P1)
+2. a stale confirmation stayed visible after navigation
+3. an in-flight preview re-opened one on the page you moved to
+4. an in-flight deploy reported its result on the page you moved to
+
+Passes 123 and 124 each fixed the instance in front of them and I did not go
+looking for the others — after having written, in pass 124's own note, that this
+risk belongs to *"every dialog in this project that is populated by a fetch"*.
+Writing the generalisation is not the same as applying it, and the gap between
+those two is where finding 4 lived.
+
+The durable rule: **anything a page says about a long-running action must name its
+subject**, because the page's own context can change before the action finishes.
+That is not a UI style preference. On this page it is the difference between "you
+created infrastructure" and "something created infrastructure, possibly this".

--- a/docs/review-passes/pass126.md
+++ b/docs/review-passes/pass126.md
@@ -1,0 +1,36 @@
+# Codex review pass 126 — S162c
+
+One finding, accepted. **Fifth instance of the same class, in four passes.**
+
+## [P2] The page could still be showing the previous scenario
+
+`afterNavigate` sets the new path and starts loading, but `detail` kept the
+**previous** scenario until that load resolved. In that window the page — title,
+badges, Deploy button — still described the old one, at a URL that said otherwise.
+
+Clicking Deploy there previewed and deployed the old scenario. Internally
+consistent, since pass 123 made the action follow the preview, and still wrong:
+the address bar named something else.
+
+## The structural fix, finally
+
+`detail = null` on navigation. The whole page is inside `{#if detail}`, so nothing
+renders — button included — until the new scenario is really loaded. The cost is a
+blink of empty page; the gain is that it is not possible to act on a scenario the
+address bar no longer names.
+
+That is the first fix in this sequence that removes the *possibility* rather than
+handling an occurrence, and it is the one I should have reached for at finding 2.
+
+## Five findings, one sentence
+
+**Asynchrony lets a UI separate a statement from its subject.** The confirmation
+described A and deployed B; a stale confirmation survived navigation; an in-flight
+preview re-opened one; an in-flight deploy reported onto the wrong page; and the
+page itself lagged behind its own URL.
+
+Four of the five were fixed one at a time, each with a guard around the specific
+sequence that had been found. The fifth was fixed by making the state impossible.
+The lesson is not "clear state on navigation" — it is that **when the third
+instance of a class arrives, the next move is to remove the state that permits it,
+not to guard the path that reached it.**

--- a/docs/review-passes/pass127.md
+++ b/docs/review-passes/pass127.md
@@ -1,0 +1,47 @@
+# Codex review pass 127 — S162c
+
+One finding, **P1**, and the **sixth** instance of one class in five passes.
+
+## [P1] Route loads can resolve out of order
+
+`loadDetail` had no ordering guard at all, so a response could overwrite the page
+after the reader had moved on. And the guard I *had* written elsewhere compared
+`scenarioPath` — which A → B → A restores, so a genuinely stale response passes it.
+
+## So the state that permits it is gone
+
+A monotonic `navigation` counter, incremented in `afterNavigate`. Every async
+setter on the page captures it and discards its own response if it changed:
+`loadDetail`, `loadRunMode`, `loadLayer3Status`, and the deploy preview.
+
+A counter cannot collide the way a path can, and a setter added later has an
+obvious thing to use.
+
+## Six findings, and the shape of my mistake
+
+1. the confirmation described A and deployed B — P1
+2. a stale confirmation survived navigation
+3. an in-flight preview re-opened one on the next page
+4. an in-flight deploy reported its result onto the next page
+5. the page itself lagged behind its own URL
+6. route loads resolving out of order — P1
+
+Findings 2 through 5 each got a guard around the exact sequence that had been
+found. Pass 126's own note says, in as many words, that *"when the third instance
+of a class arrives, the next move is to remove the state that permits it, not to
+guard the path that reached it"* — and I then wrote finding 5's fix as another
+guard.
+
+The generalisation was correct, written down, and not acted on. That is a
+different failure from not seeing the pattern, and a worse one.
+
+## The test was wrong first
+
+The first version used `page.goto` twice, which does full page loads that abort
+each other — so it exercised nothing. The race only exists in **client-side**
+routing, where the component is reused rather than rebuilt, so the test navigates
+by clicking sidebar links.
+
+Fourth red test this session that was the test's fault. Here it failed for a
+reason that had nothing to do with the property, which is the kind that quietly
+becomes a deleted test.

--- a/docs/review-passes/pass128.md
+++ b/docs/review-passes/pass128.md
@@ -1,0 +1,28 @@
+# Codex review pass 128 — S162c
+
+One finding, **P3**, accepted. Seventh instance of the class, and the first with a
+consequence small enough to argue about.
+
+## [P3] Two clicks could reopen a dismissed dialog
+
+Repeated clicks on Deploy left multiple previews in flight for the same
+navigation. The token guard only checks the *route*, so an older response could
+still set `confirmingDeploy = true` after the reader had cancelled.
+
+No wrong infrastructure — the action follows the preview, and both previews were
+for the same scenario. A dialog reappearing after you dismissed it, which is
+annoying rather than dangerous.
+
+Accepted anyway, on two grounds. The fix is four lines: a `previewing` flag that
+disables the button, so **only one request can be in flight** — removing the state
+rather than guarding it, which is what the last two passes were about. And it
+gives the reader feedback that the click landed, which the button did not
+previously do for the round trip.
+
+## Where this slice stands
+
+Seven findings, two of them P1. Every one is the same sentence: *asynchrony lets a
+UI separate a statement from its subject.* The consequences ran from "creates the
+wrong infrastructure" down to "a dialog reappears", and they were found in roughly
+that order — which is luck rather than method, since nothing about the code made
+the severe ones easier to find first.

--- a/docs/review-passes/pass129.md
+++ b/docs/review-passes/pass129.md
@@ -1,0 +1,33 @@
+# Codex review pass 129 — S162c
+
+**Clean.** No actionable correctness issues; the preview flag, the confirmation
+flow and the tests are consistent with the API and the safety model.
+
+Eight passes, seven findings, two P1. Every finding was one sentence:
+**asynchrony lets a UI separate a statement from its subject.**
+
+A command line cannot do this. `infrafactory deploy <scenario>` names its target
+in the same breath as the decision, and nothing arrives later to change it. A page
+holds a description, an action, a URL and several in-flight responses, and any of
+them can be about a different thing than the others.
+
+The sequence is worth keeping because the *fixes* tell the story better than the
+bugs:
+
+| # | finding | fix | kind |
+|---|---|---|---|
+| 1 | described A, deployed B (P1) | act on `preview.scenario` | bind the action to the statement |
+| 2 | stale dialog after navigation | clear on navigate | guard the occurrence |
+| 3 | in-flight preview reopened it | compare paths | guard the occurrence |
+| 4 | deploy result on the wrong page | name the scenario | make the statement self-describing |
+| 5 | page lagged its own URL | clear `detail` | remove the state |
+| 6 | loads resolving out of order (P1) | navigation token | remove the state |
+| 7 | two clicks, two previews | disable the button | remove the state |
+
+Findings 2 and 3 were guards. 5, 6 and 7 removed the state that permitted the
+problem — and each of those closed a *category*, where the guards closed a path.
+Pass 126 wrote that lesson down and pass 127 still had to learn it again.
+
+The thing I would keep from this slice is not the code. It is that **writing the
+generalisation is not applying it**, and the gap between them is exactly where
+findings 5, 6 and 7 lived.

--- a/internal/api/handlers_deploy_preview.go
+++ b/internal/api/handlers_deploy_preview.go
@@ -57,6 +57,15 @@ type deployPreview struct {
 
 	// InternetFacing is true when the shape includes a public address.
 	InternetFacing bool `json:"internet_facing"`
+
+	// Allowed reports whether this server would accept the deploy.
+	//
+	// Carried here rather than fetched separately because the preview is
+	// meant to be everything a person needs in order to decide, and
+	// "this server will refuse" is part of that. It stops the page
+	// offering a button that 404s; the SAFETY is that the endpoint does
+	// not exist, and this field cannot make it exist.
+	Allowed bool `json:"deploy_allowed"`
 }
 
 // deployPreviewHandler answers what a deploy would do. It is a GET
@@ -103,7 +112,9 @@ func deployPreviewHandler(state *serverState) http.HandlerFunc {
 			return
 		}
 
-		writeJSON(w, http.StatusOK, previewFor(&sc, r.URL.Query().Get("ttl"), time.Now()))
+		preview := previewFor(&sc, r.URL.Query().Get("ttl"), time.Now())
+		preview.Allowed = state.deployer != nil
+		writeJSON(w, http.StatusOK, preview)
 	}
 }
 

--- a/internal/api/handlers_deploy_preview_test.go
+++ b/internal/api/handlers_deploy_preview_test.go
@@ -263,3 +263,41 @@ func TestPreviewCallsAComputeOnlyScenarioInternetFacing(t *testing.T) {
 
 	assert.True(t, got.InternetFacing, "the instance still gets a public address")
 }
+
+// The preview is meant to be everything a person needs in order to
+// decide, and "this server will refuse" is part of that.
+func TestPreviewReportsWhetherTheServerWouldAcceptTheDeploy(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sc.yaml"), []byte(`scenario: previewable
+version: "1.0"
+cloud: scaleway
+description: x
+resources:
+  compute:
+    purpose: web-server
+    size: small
+acceptance_criteria:
+  - type: destruction
+    expect: no_orphans
+`), 0o644))
+
+	cfg := config.Default()
+	cfg.Paths.Scenarios = dir
+
+	for name, deployer := range map[string]DeploymentDeployer{
+		"without the flag": nil,
+		"with the flag":    &fakeDeployer{},
+	} {
+		t.Run(name, func(t *testing.T) {
+			srv := NewServer(ServerConfig{Config: cfg, Deployer: deployer})
+			rec := httptest.NewRecorder()
+			srv.Handler.ServeHTTP(rec,
+				httptest.NewRequest(http.MethodGet, "/api/deployments/preview?scenario=previewable", nil))
+
+			require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+			var got deployPreview
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+			assert.Equal(t, deployer != nil, got.Allowed)
+		})
+	}
+}

--- a/ui/e2e/deploy.spec.ts
+++ b/ui/e2e/deploy.spec.ts
@@ -1,0 +1,397 @@
+import { test, expect } from '@playwright/test';
+
+// The deploy button (S162c). Every test is about the confirmation
+// telling the truth before somebody creates infrastructure that
+// persists, bills hourly, and serves the internet.
+
+const PREVIEW = {
+  scenario: 'web-app-paris',
+  cloud: 'scaleway',
+  deployable: true,
+  image: 'nginx:1.27',
+  ttl: '4h0m0s',
+  expires_at: '2026-09-03T03:47:00Z',
+  expires_at_wall_clock: 'Wed 3 Sep 03:47 UTC',
+  cost_summary: 'about €0.04/hour at list price, €0.17 for 4h0m0s',
+  internet_facing: true,
+  deploy_allowed: true,
+  cost: {
+    components: [
+      { name: 'DEV1-S instance', count: 1, eur_per_hour: 0.00898, priced: true },
+      { name: 'public IPv4 address', count: 2, eur_per_hour: 0.005, priced: true }
+    ],
+    eur_per_hour: 0.042,
+    unpriced: [],
+    complete: true,
+    modelled: true
+  }
+};
+
+async function servePreview(page, over = {}) {
+  await page.route('**/api/deployments/preview**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ...PREVIEW, ...over })
+    })
+  );
+}
+
+test.describe('Deploy from the scenario page', () => {
+  test('deploy is a separate button from run', async ({ page }) => {
+    await page.goto('/scenarios/training/web-app-paris');
+
+    await expect(page.getByRole('button', { name: 'Run' })).toBeVisible();
+    await expect(page.getByTestId('scenario-deploy')).toBeVisible();
+    await expect(page.getByTestId('scenario-deploy')).not.toHaveText('Run');
+  });
+
+  // Cost, lifetime and blast radius before the click (ADR-0027 §2).
+  test('the confirmation states shape, cost, expiry and exposure', async ({ page }) => {
+    await servePreview(page);
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+
+    const confirm = page.getByTestId('deploy-confirm');
+    await expect(confirm).toContainText('DEV1-S instance');
+    await expect(confirm).toContainText('list price');
+    await expect(confirm).toContainText('Wed 3 Sep 03:47');
+    await expect(confirm).toContainText('nginx:1.27');
+    await expect(page.getByTestId('deploy-warning').first()).toContainText('public internet');
+  });
+
+  // A click cannot create infrastructure on its own.
+  test('nothing is created until the confirmation is accepted', async ({ page }) => {
+    let posted = 0;
+    await servePreview(page);
+    await page.route('**/api/deployments', (route) => {
+      if (route.request().method() === 'POST') posted += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ clean: true, steps: [], failures: [] })
+      });
+    });
+    await page.goto('/scenarios/training/web-app-paris');
+
+    await page.getByTestId('scenario-deploy').click();
+    expect(posted).toBe(0);
+
+    await page.getByTestId('deploy-cancel').click();
+    await expect(page.getByTestId('deploy-confirm')).toHaveCount(0);
+    expect(posted).toBe(0);
+  });
+
+  // The one that invalidates everything above it: an unmodelled
+  // scenario's empty component list and €0.00 mean "unknown", not
+  // "nothing".
+  test('an unmodelled scenario says its figures are not complete', async ({ page }) => {
+    await servePreview(page, {
+      cost_summary:
+        "this scenario's resources are not modelled here, so what it creates and what it costs are both unknown — do not read this as free",
+      cost: { components: [], eur_per_hour: 0, unpriced: [], complete: false, modelled: false }
+    });
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+
+    await expect(page.getByTestId('deploy-warning').first()).toContainText('not modelled');
+    await expect(page.getByTestId('deploy-confirm')).toContainText('unknown');
+  });
+
+  test('an incomplete estimate is described as a floor, not a total', async ({ page }) => {
+    await servePreview(page, {
+      internet_facing: false,
+      cost: {
+        components: [{ name: 'Kubernetes cluster', count: 1, eur_per_hour: 0, priced: false }],
+        eur_per_hour: 0.042,
+        unpriced: ['Kubernetes cluster'],
+        complete: false,
+        modelled: true
+      }
+    });
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+
+    await expect(page.getByTestId('deploy-warning').first()).toContainText('floor, not a total');
+  });
+
+  // A page must not offer a button it knows will 404, and must say why.
+  test('a server that cannot deploy says so instead of failing later', async ({ page }) => {
+    await servePreview(page, { deploy_allowed: false });
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+
+    await expect(page.getByTestId('deploy-not-allowed')).toContainText('--allow-deploy');
+    await expect(page.getByTestId('deploy-confirm-go')).toBeDisabled();
+  });
+
+  test('a scenario with nothing to deploy explains why', async ({ page }) => {
+    await servePreview(page, {
+      deployable: false,
+      reason: 'this scenario declares no service: block, so there is nothing to deploy'
+    });
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+
+    await expect(page.getByTestId('deploy-not-deployable')).toContainText('no service: block');
+    await expect(page.getByTestId('deploy-confirm-go')).toBeDisabled();
+  });
+
+  // A deploy that could not prove itself is never rendered as success:
+  // the 409 carries the leaked project id and how to remove it by hand.
+  test('a deploy that did not succeed shows what went wrong', async ({ page }) => {
+    await servePreview(page);
+    await page.route('**/api/deployments', (route) =>
+      route.request().method() === 'POST'
+        ? route.fulfill({
+            status: 409,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              clean: false,
+              steps: [],
+              failures: [
+                {
+                  stage: 'run_project',
+                  status: 'fail',
+                  detail: 'project 7c98d82e is live and could not be deleted'
+                }
+              ]
+            })
+          })
+        : route.continue()
+    );
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+    await page.getByTestId('deploy-confirm-go').click();
+
+    const outcome = page.getByTestId('deploy-outcome');
+    await expect(outcome).toContainText('7c98d82e');
+    await expect(outcome).not.toContainText('Deployed.');
+  });
+
+  // A confirmation that describes one thing and does another is worse
+  // than no confirmation: it converts a careful person into a confident
+  // one. This component is reused across scenario routes, so an open
+  // confirmation can outlive the page it was opened on.
+  test('navigating away clears a confirmation from the previous scenario', async ({ page }) => {
+    await servePreview(page);
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+    await expect(page.getByTestId('deploy-confirm')).toBeVisible();
+
+    await page.goto('/scenarios/training/lb-serving-paris');
+
+    await expect(page.getByTestId('deploy-confirm')).toHaveCount(0);
+  });
+
+  // And the deeper guarantee, independent of the reset firing: the POST
+  // carries the scenario that was PREVIEWED, not whatever the page shows
+  // now.
+  test('the deploy posts the scenario the confirmation described', async ({ page }) => {
+    let posted = '';
+    await servePreview(page, { scenario: 'the-previewed-one' });
+    await page.route('**/api/deployments', (route) => {
+      if (route.request().method() === 'POST') {
+        posted = JSON.parse(route.request().postData() || '{}').scenario;
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ clean: true, steps: [], failures: [] })
+        });
+      }
+      return route.continue();
+    });
+    await page.goto('/scenarios/training/web-app-paris');
+
+    await page.getByTestId('scenario-deploy').click();
+    await page.getByTestId('deploy-confirm-go').click();
+
+    await expect(page.getByTestId('deploy-outcome')).toBeVisible();
+    expect(posted).toBe('the-previewed-one');
+  });
+
+  // afterNavigate clearing the dialog is not enough on its own: a
+  // preview takes a round trip, and a response arriving after the route
+  // changed would re-open a confirmation for a scenario the reader is no
+  // longer looking at.
+  test('a slow preview does not open a confirmation on the page you moved to', async ({ page }) => {
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => (release = resolve));
+
+    await page.route('**/api/deployments/preview**', async (route) => {
+      await held;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(PREVIEW)
+      });
+    });
+
+    await page.goto('/scenarios/training/web-app-paris');
+    const clicked = page.getByTestId('scenario-deploy').click();
+
+    await page.goto('/scenarios/training/lb-serving-paris');
+    release();
+    await clicked.catch(() => {});
+
+    await expect(page.getByTestId('deploy-confirm')).toHaveCount(0);
+  });
+
+  test('a successful deploy points at where it now lives', async ({ page }) => {
+    await servePreview(page);
+    await page.route('**/api/deployments', (route) =>
+      route.request().method() === 'POST'
+        ? route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ clean: true, steps: [], failures: [] })
+          })
+        : route.continue()
+    );
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+    await page.getByTestId('deploy-confirm-go').click();
+
+    await expect(page.getByTestId('deploy-outcome')).toContainText('Deployments page');
+  });
+
+  // An apply takes minutes and the reader can navigate during it, so
+  // this message can land on a different scenario's page. An
+  // unattributed "Deployed." there is a claim about the wrong thing.
+  //
+  // Attributed rather than discarded: the deploy really did create
+  // infrastructure, and throwing the news away because the reader moved
+  // is the worse of the two failures.
+  // Between the route changing and the new scenario loading, `detail`
+  // used to still hold the PREVIOUS one -- so Deploy in that window
+  // previewed and deployed the old scenario from a URL that said
+  // otherwise. Clearing `detail` hides the whole page, button included,
+  // until the new scenario is really there.
+  test('deploy cannot act on the scenario the address bar no longer names', async ({ page }) => {
+    await servePreview(page);
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => (release = resolve));
+    await page.route('**/api/scenarios/training/lb-serving-paris**', async (route) => {
+      await held;
+      return route.continue();
+    });
+
+    await page.goto('/scenarios/training/web-app-paris');
+    await expect(page.getByTestId('scenario-deploy')).toBeVisible();
+
+    const navigating = page.goto('/scenarios/training/lb-serving-paris');
+    // While the new scenario is still loading, there is nothing to click.
+    await expect(page.getByTestId('scenario-deploy')).toHaveCount(0);
+
+    release();
+    await navigating;
+    await expect(page.getByTestId('scenario-deploy')).toBeVisible();
+  });
+
+  // Route loads can resolve OUT OF ORDER, and the race lives in
+  // CLIENT-SIDE routing, where the component is reused rather than
+  // rebuilt. Comparing `scenarioPath` is not enough there: A → B → A
+  // leaves the path equal to what an in-flight request for the first A
+  // captured, so a genuinely stale response passes. A monotonic
+  // navigation token cannot collide that way.
+  test('a scenario load that resolves after navigation does not repopulate the page', async ({
+    page
+  }) => {
+    await servePreview(page);
+
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => (release = resolve));
+    await page.route('**/api/scenarios/training/web-app-paris**', async (route) => {
+      await held;
+      return route.continue();
+    });
+
+    // Settle on one scenario with a full load, then move CLIENT-SIDE.
+    await page.goto('/scenarios/training/lb-serving-paris');
+    await expect(page.locator('main h1')).toContainText('lb-serving-paris');
+
+    await page.getByTestId('sidebar-scenario-training/web-app-paris').click();
+    // Its detail request is held, so nothing is rendered yet.
+    await expect(page.getByTestId('scenario-deploy')).toHaveCount(0);
+
+    // Go back before it resolves, then let it through.
+    await page.getByTestId('sidebar-scenario-training/lb-serving-paris').click();
+    await expect(page.locator('main h1')).toContainText('lb-serving-paris');
+    release();
+
+    // The stale response must not overwrite the page it arrived on.
+    await expect(page.locator('main h1')).toContainText('lb-serving-paris');
+    await expect(page).toHaveURL(/lb-serving-paris/);
+  });
+
+  // Two clicks left two previews racing, and an older response could
+  // reopen a dialog the reader had already dismissed. Only one may be in
+  // flight.
+  test('repeated clicks cannot reopen a dismissed confirmation', async ({ page }) => {
+    let calls = 0;
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => (release = resolve));
+    await page.route('**/api/deployments/preview**', async (route) => {
+      calls += 1;
+      await held;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(PREVIEW)
+      });
+    });
+
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+    await expect(page.getByTestId('scenario-deploy')).toBeDisabled();
+
+    release();
+    await expect(page.getByTestId('deploy-confirm')).toBeVisible();
+    expect(calls).toBe(1);
+
+    await page.getByTestId('deploy-cancel').click();
+    await expect(page.getByTestId('deploy-confirm')).toHaveCount(0);
+  });
+
+  test('the outcome names the scenario it is about', async ({ page }) => {
+    await servePreview(page, { scenario: 'the-deployed-one' });
+    await page.route('**/api/deployments', (route) =>
+      route.request().method() === 'POST'
+        ? route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ clean: true, steps: [], failures: [] })
+          })
+        : route.continue()
+    );
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+    await page.getByTestId('deploy-confirm-go').click();
+
+    await expect(page.getByTestId('deploy-outcome')).toContainText('the-deployed-one');
+  });
+
+  test('a failed outcome names its scenario too', async ({ page }) => {
+    await servePreview(page, { scenario: 'the-failed-one' });
+    await page.route('**/api/deployments', (route) =>
+      route.request().method() === 'POST'
+        ? route.fulfill({
+            status: 409,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              clean: false,
+              steps: [],
+              failures: [{ stage: 'run_project', status: 'fail', detail: 'project 7c98d82e is live' }]
+            })
+          })
+        : route.continue()
+    );
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+    await page.getByTestId('deploy-confirm-go').click();
+
+    const outcome = page.getByTestId('deploy-outcome');
+    await expect(outcome).toContainText('the-failed-one');
+    await expect(outcome).toContainText('7c98d82e');
+  });
+});

--- a/ui/e2e/deployments.spec.ts
+++ b/ui/e2e/deployments.spec.ts
@@ -298,6 +298,60 @@ test.describe('Deployments estate page', () => {
     await expect(outcome).toContainText('state file has vanished');
   });
 
+  // The property S161 claimed a visual baseline would protect. It does
+  // not: `maxDiffPixelRatio: 0.02` means a change confined to three
+  // small badges on a full-page screenshot passes comfortably, and a
+  // Deploy button added to another page proved it by not failing one.
+  //
+  // Asserted directly instead, which is both stricter and not subject to
+  // font-rendering flake: the three states must be visually distinct
+  // from each other, because a reader tells them apart by colour before
+  // they read a word.
+  test('healthy, failing and never-observed are visually distinct', async ({ page }) => {
+    await serveEstate(page, {
+      deployments: [
+        HEALTHY,
+        { ...HEALTHY, id: 'dep-bad', health: { status: 'unhealthy', version: 'confirmed', at: '2026-09-02T10:00:00Z', observations: 3 } },
+        NEVER_OBSERVED
+      ],
+      unreadable: []
+    });
+    await page.goto('/deployments');
+
+    const colourOf = async (id: string) =>
+      page.getByTestId(`deployment-health-${id}`).evaluate(
+        (el) => getComputedStyle(el).backgroundColor
+      );
+
+    const healthy = await colourOf('dep-healthy');
+    const unhealthy = await colourOf('dep-bad');
+    const unobserved = await colourOf('dep-silent');
+
+    expect(new Set([healthy, unhealthy, unobserved]).size).toBe(3);
+  });
+
+  // And the version axis, where the dangerous state is the one that
+  // looks fine on the health axis.
+  test('an unconfirmed version is visually distinct from a confirmed one', async ({ page }) => {
+    await serveEstate(page, {
+      deployments: [
+        HEALTHY,
+        { ...HEALTHY, id: 'dep-drifted', health: { status: 'healthy', version: 'unconfirmed', at: '2026-09-02T10:00:00Z', observations: 3 } }
+      ],
+      unreadable: []
+    });
+    await page.goto('/deployments');
+
+    const confirmed = await page
+      .getByTestId('deployment-version-dep-healthy')
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+    const unconfirmed = await page
+      .getByTestId('deployment-version-dep-drifted')
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+
+    expect(confirmed).not.toBe(unconfirmed);
+  });
+
   test('the page is reachable from the sidebar', async ({ page }) => {
     await page.goto('/');
     await page.getByRole('link', { name: 'Deployments' }).click();

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -6,6 +6,7 @@ import type {
   ScenarioLayer3StatusResponse,
   ScenarioRunModeResponse,
   ActionResult,
+  DeployPreview,
   DeploymentsResponse,
   StartRunOptions
 } from "$lib/types";
@@ -41,6 +42,30 @@ export const api = {
   getScenario: (path: string) => request(`/api/scenarios/${path}`),
   getScenarioRunMode: (path: string) => request<ScenarioRunModeResponse>(`/api/scenarios/${path}/run-mode`),
   getDeployments: () => request<DeploymentsResponse>("/api/deployments"),
+  getDeployPreview: (scenario: string, ttl = "") =>
+    request<DeployPreview>(
+      `/api/deployments/preview?scenario=${encodeURIComponent(scenario)}` +
+        (ttl ? `&ttl=${encodeURIComponent(ttl)}` : "")
+    ),
+  // Like teardown, this reads a 409 body rather than throwing it away: a
+  // deploy that could not prove itself carries the per-stage failures,
+  // and those name the leaked project id and how to remove it by hand.
+  deployScenario: async (scenario: string, ttl = ""): Promise<ActionResult> => {
+    const res = await fetch(`${base}/api/deployments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(ttl ? { scenario, ttl } : { scenario })
+    });
+    const ctype = res.headers.get("content-type") || "";
+    if ((res.ok || res.status === 409) && ctype.includes("application/json")) {
+      return (await res.json()) as ActionResult;
+    }
+    if (ctype.includes("application/json")) {
+      const payload = (await res.json()) as { error?: string };
+      throw new Error(payload.error || `deploy failed: ${res.status}`);
+    }
+    throw new Error((await res.text()) || `deploy failed: ${res.status}`);
+  },
   // Not `request`, deliberately. A teardown that could not prove the
   // account clean answers 409 WITH a full ActionResult -- the per-stage
   // failures are the whole point, and `request` would throw them away

--- a/ui/src/lib/deployments-view.js
+++ b/ui/src/lib/deployments-view.js
@@ -255,3 +255,68 @@ export function teardownOutcome(result) {
         : "Not provably clean — resources may still be running."
   };
 }
+
+/**
+ * deployConfirmation is what a person must read before creating
+ * infrastructure (ADR-0027 §2).
+ *
+ * Returns an ordered list of lines rather than a sentence, because each
+ * one is a separate thing they might object to and a paragraph is a
+ * thing people skim.
+ */
+export function deployConfirmation(preview) {
+  if (!preview) return [];
+
+  const lines = [];
+
+  const shapes = (preview.cost?.components || [])
+    .map((c) => (c.count > 1 ? `${c.count} × ${c.name}` : c.name))
+    .join(", ");
+  lines.push(shapes ? `Creates: ${shapes}` : "Creates: unknown — see below");
+
+  // The cost line always says list price, and always says when it is a
+  // floor rather than a total.
+  lines.push(preview.cost_summary || "Cost unknown.");
+
+  if (preview.expires_at_wall_clock) {
+    lines.push(`Expires ${preview.expires_at_wall_clock} — after that, reap destroys it.`);
+  }
+
+  if (preview.internet_facing) {
+    lines.push("Reachable from the public internet.");
+  }
+
+  if (preview.image) lines.push(`Running ${preview.image}.`);
+
+  return lines;
+}
+
+/**
+ * deployWarnings are the things that should stop somebody, separated
+ * from the descriptive lines so a page can render them differently.
+ *
+ * `modelled === false` is first because it is the one that invalidates
+ * everything above it: an unmodelled scenario's empty component list and
+ * €0.00 mean "unknown", not "nothing".
+ */
+export function deployWarnings(preview) {
+  const warnings = [];
+  if (!preview) return warnings;
+
+  if (preview.cost && preview.cost.modelled === false) {
+    warnings.push(
+      "This scenario's resources are not modelled here, so what it creates and what it costs are both unknown. Do not read the figures above as complete."
+    );
+  } else if (preview.cost && preview.cost.complete === false) {
+    const unpriced = (preview.cost.unpriced || []).join(", ");
+    warnings.push(
+      `The cost is a floor, not a total: ${unpriced || "some components"} have no list price here.`
+    );
+  }
+
+  if (preview.internet_facing) {
+    warnings.push("This will be reachable from the public internet for its whole lifetime.");
+  }
+
+  return warnings;
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -182,3 +182,42 @@ export interface ActionResult {
   steps: ActionStep[];
   failures: ActionStep[];
 }
+
+export interface CostComponent {
+  name: string;
+  count: number;
+  eur_per_hour: number;
+  // Free and unknown are different facts. `false` means this project has
+  // no list price for the shape, not that it is free.
+  priced: boolean;
+  source?: string;
+}
+
+export interface CostEstimate {
+  components: CostComponent[];
+  eur_per_hour: number;
+  unpriced: string[];
+  // Every component priced. When false, eur_per_hour is a LOWER BOUND.
+  complete: boolean;
+  // False when this scenario's resource shape is not modelled at all —
+  // an empty component list then means "unknown", not "nothing".
+  modelled: boolean;
+}
+
+export interface DeployPreview {
+  scenario: string;
+  cloud?: string;
+  deployable: boolean;
+  reason?: string;
+  image?: string;
+  ttl?: string;
+  ttl_seconds?: number;
+  // null when the scenario cannot be deployed, rather than a zero time
+  // that would render as a date in the year 1.
+  expires_at: string | null;
+  expires_at_wall_clock?: string;
+  cost: CostEstimate;
+  cost_summary?: string;
+  internet_facing: boolean;
+  deploy_allowed: boolean;
+}

--- a/ui/src/routes/scenarios/[...path]/+page.svelte
+++ b/ui/src/routes/scenarios/[...path]/+page.svelte
@@ -3,10 +3,34 @@
   import { onDestroy } from "svelte";
   import { page } from "$app/stores";
   import { api } from "$lib/api";
+  import {
+    deployConfirmation,
+    deployWarnings,
+    teardownOutcome
+  } from "$lib/deployments-view.js";
   import { modeSummary, normalizeRunOptions } from "$lib/scenario-run.js";
-  import type { ScenarioLayer3StatusResponse, ScenarioRunModeResponse } from "$lib/types";
+  import type { DeployPreview, ScenarioLayer3StatusResponse, ScenarioRunModeResponse } from "$lib/types";
 
   let scenarioPath = "";
+
+  // Every async response on this page belongs to a navigation, and this
+  // is how one is identified.
+  //
+  // Comparing `scenarioPath` is not enough: A → B → A leaves the path
+  // equal to what an in-flight request for the FIRST A captured, so a
+  // response that is genuinely stale passes the check. The counter is
+  // monotonic, so it cannot collide that way.
+  //
+  // It exists because the alternative was found six times in four review
+  // passes: a confirmation describing one scenario while the page had
+  // moved to another, an in-flight preview reopening a dialog, a deploy
+  // result landing on the wrong page, and route loads resolving out of
+  // order. Guarding each occurrence produced the next one. This guards
+  // the shape.
+  let navigation = 0;
+
+  /** current reports whether a response still belongs to the page. */
+  const current = (token: number) => token === navigation;
   let detail: any = null;
   let rawYAML = "";
   let status = "";
@@ -91,27 +115,124 @@
 
   async function loadDetail() {
     if (!scenarioPath) return;
-    detail = await api.getScenario(scenarioPath);
-    rawYAML = detail.raw_yaml;
+    const token = navigation;
+    const loaded = await api.getScenario(scenarioPath);
+    if (!current(token)) return;
+    detail = loaded;
+    rawYAML = loaded.raw_yaml;
   }
 
   async function loadRunMode() {
     if (!scenarioPath) return;
+    const token = navigation;
     runModeError = "";
     try {
-      runMode = await api.getScenarioRunMode(scenarioPath);
+      const loaded = await api.getScenarioRunMode(scenarioPath);
+      if (!current(token)) return;
+      runMode = loaded;
     } catch (err) {
+      if (!current(token)) return;
       runMode = null;
       runModeError = err instanceof Error ? err.message : "Run mode detection failed";
     }
   }
 
+  // Deploy is a DISTINCT verb from run (ADR-0027 section 4). S153 split
+  // them so that keeping infrastructure could not be reached by accident
+  // from the verb that proves a change is safe, and merging them into
+  // one "go" button here would undo that.
+  let preview: DeployPreview | null = null;
+  let previewError = "";
+  let confirmingDeploy = false;
+  // Only one preview may be in flight. Two clicks on Deploy left two
+  // responses racing, and an older one could reopen a dialog the reader
+  // had already dismissed.
+  //
+  // Disabling the button removes that state rather than guarding it,
+  // which is the move pass 126 argued for and pass 127 had to learn
+  // twice. It also gives the reader feedback that the click landed.
+  let previewing = false;
+  let deploying = false;
+  let deployOutcomeMessage = "";
+  let deployOk = false;
+
+  async function openDeployConfirmation() {
+    previewError = "";
+    deployOutcomeMessage = "";
+
+    // A preview takes a round trip and the reader can navigate during
+    // it, so the response is discarded if it arrives after the page has
+    // moved on.
+    const token = navigation;
+    const requestedName = detail?.name;
+    if (!requestedName || previewing) return;
+
+    previewing = true;
+    try {
+      const fetched = await api.getDeployPreview(requestedName);
+      if (!current(token)) return;
+      preview = fetched;
+      confirmingDeploy = true;
+    } catch (err) {
+      if (!current(token)) return;
+      preview = null;
+      previewError = err instanceof Error ? err.message : "Could not read what this would deploy";
+    } finally {
+      previewing = false;
+    }
+  }
+
+  async function confirmDeploy() {
+    // The scenario from the PREVIEW, never the one the page currently
+    // shows. This component is reused across scenario routes, so an
+    // open confirmation can outlive the page it was opened on -- and
+    // posting `detail.name` would let somebody read scenario A's cost,
+    // lifetime and blast radius and create scenario B's infrastructure.
+    //
+    // A confirmation that describes one thing and does another is worse
+    // than no confirmation at all: it converts a careful person into a
+    // confident one.
+    const target = preview?.scenario;
+    if (!target) return;
+
+    deploying = true;
+    try {
+      const result = await api.deployScenario(target);
+      const outcome = teardownOutcome(result);
+      deployOk = outcome.ok;
+      // NAMED, always. An apply takes minutes and the reader can
+      // navigate during it, so this message can land on a different
+      // scenario's page -- and an unattributed "Deployed." there is a
+      // claim about the wrong thing.
+      //
+      // Attributed rather than discarded: the deploy really did create
+      // infrastructure, and throwing the news away because the reader
+      // moved is the worse of the two failures.
+      deployOutcomeMessage = outcome.ok
+        ? `${target}: deployed. It is listed on the Deployments page until its TTL expires.`
+        : `${target}: ${outcome.message}`;
+    } catch (err) {
+      deployOk = false;
+      deployOutcomeMessage =
+        err instanceof Error
+          ? `${target}: deploy could not be completed: ${err.message}`
+          : `${target}: deploy failed.`;
+    } finally {
+      deploying = false;
+      confirmingDeploy = false;
+    }
+  }
+
   async function loadLayer3Status() {
     if (!scenarioPath) return;
+    const token = navigation;
     layer3Error = "";
     try {
-      layer3Status = await api.getScenarioLayer3Status(scenarioPath);
+      const loaded = await api.getScenarioLayer3Status(scenarioPath);
+      if (!current(token)) return;
+      layer3Status = loaded;
     } catch (err) {
+      if (!current(token)) return;
       layer3Status = null;
       layer3Error = err instanceof Error ? err.message : "Layer 3 status lookup failed";
     }
@@ -159,7 +280,32 @@
   // SvelteKit reuses the component for [...path] route changes.
   // afterNavigate fires on both initial load and subsequent navigations.
   afterNavigate(() => {
+    // Every response in flight now belongs to a page that no longer
+    // exists.
+    navigation += 1;
     scenarioPath = ($page.params.path || "").toString();
+    // Belt and braces with confirmDeploy reading preview.scenario: a
+    // confirmation describing the page you just left must not still be
+    // on screen, even though accepting it would now be harmless.
+    // Leaving it visible invites the reader to trust a dialog about
+    // something they are no longer looking at.
+    confirmingDeploy = false;
+    preview = null;
+    previewError = "";
+    deployOutcomeMessage = "";
+    // `detail` is cleared too, and that is the STRUCTURAL half of this.
+    //
+    // The whole page is inside `{#if detail}`, so clearing it means
+    // nothing is rendered until the new scenario loads -- including the
+    // Deploy button. Without this there is a window after the route
+    // changes where `detail` still holds the PREVIOUS scenario, and
+    // clicking Deploy in it previews and deploys that one from a URL
+    // that says otherwise.
+    //
+    // The cost is a blink of empty page during navigation. That is a
+    // fair price for making it impossible to act on a scenario the
+    // address bar no longer names.
+    detail = null;
     loadDetail();
     loadRunMode();
     loadLayer3Status();
@@ -284,7 +430,72 @@
       {running ? "Starting..." : "Run"}
     </button>
     <button class="rounded border border-slate-400 px-3 py-1.5 text-xs text-slate-900" on:click={saveScenario}>Save</button>
+    <!-- Deliberately a separate button, and deliberately not next to Run
+         in colour or weight. `run` proves a change is safe; `deploy`
+         keeps it. Merging them would undo the split S153 made. -->
+    <button
+      class="rounded border border-sky-500 px-3 py-1.5 text-xs font-semibold text-sky-900 disabled:opacity-50"
+      data-testid="scenario-deploy"
+      on:click={openDeployConfirmation}
+      disabled={deploying || previewing}
+      >{deploying ? "Deploying…" : previewing ? "Checking…" : "Deploy…"}</button
+    >
   </div>
+
+  {#if previewError}
+    <p class="mt-3 text-sm text-rose-800" data-testid="deploy-preview-error">{previewError}</p>
+  {/if}
+
+  {#if confirmingDeploy && preview}
+    <div
+      class="mt-3 rounded border border-sky-300 bg-sky-50 px-4 py-3 text-sm"
+      data-testid="deploy-confirm"
+    >
+      <p class="font-semibold text-slate-900">Deploy {preview.scenario}?</p>
+
+      <ul class="mt-2 list-disc space-y-1 pl-5 text-slate-800">
+        {#each deployConfirmation(preview) as line}
+          <li>{line}</li>
+        {/each}
+      </ul>
+
+      {#each deployWarnings(preview) as warning}
+        <p class="mt-2 font-semibold text-rose-900" data-testid="deploy-warning">{warning}</p>
+      {/each}
+
+      {#if !preview.deployable}
+        <p class="mt-2 text-rose-900" data-testid="deploy-not-deployable">{preview.reason}</p>
+      {:else if !preview.deploy_allowed}
+        <p class="mt-2 text-slate-700" data-testid="deploy-not-allowed">
+          This server cannot deploy. Restart it with
+          <code>infrafactory ui --allow-deploy</code>.
+        </p>
+      {/if}
+
+      <div class="mt-3 flex gap-2">
+        <button
+          class="rounded bg-sky-700 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-40"
+          data-testid="deploy-confirm-go"
+          disabled={!preview.deployable || !preview.deploy_allowed || deploying}
+          on:click={confirmDeploy}>Deploy and keep it running</button
+        >
+        <button
+          class="rounded border border-slate-300 px-3 py-1.5 text-xs text-slate-700"
+          data-testid="deploy-cancel"
+          on:click={() => (confirmingDeploy = false)}>Cancel</button
+        >
+      </div>
+    </div>
+  {/if}
+
+  {#if deployOutcomeMessage}
+    <p
+      class={`mt-3 text-sm ${deployOk ? "text-emerald-800" : "font-semibold text-rose-800"}`}
+      data-testid="deploy-outcome"
+    >
+      {deployOutcomeMessage}
+    </p>
+  {/if}
   {#if status}<p class="mt-3 text-sm text-slate-700">{status}</p>{/if}
   <textarea
     class="mt-4 h-[460px] w-full rounded border border-slate-300 p-3 font-mono text-sm"

--- a/ui/tests/deployments-view.test.js
+++ b/ui/tests/deployments-view.test.js
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 
 import {
   addressHref,
+  deployConfirmation,
+  deployWarnings,
   teardownOutcome,
   teardownPrompt,
   knownEmpty,
@@ -216,4 +218,89 @@ test("teardownOutcome reports a proven teardown as done", () => {
 
 test("teardownOutcome treats a missing result as a failure", () => {
   assert.equal(teardownOutcome(undefined).ok, false);
+});
+
+const previewFixture = (over = {}) => ({
+  scenario: "lb-serving-paris",
+  deployable: true,
+  image: "nginx:1.27",
+  ttl: "4h0m0s",
+  expires_at: "2026-09-03T03:47:00Z",
+  expires_at_wall_clock: "Wed 3 Sep 03:47 UTC",
+  cost_summary: "about €0.04/hour at list price, €0.17 for 4h0m0s",
+  internet_facing: true,
+  deploy_allowed: true,
+  cost: {
+    components: [
+      { name: "DEV1-S instance", count: 1, eur_per_hour: 0.00898, priced: true },
+      { name: "public IPv4 address", count: 2, eur_per_hour: 0.005, priced: true }
+    ],
+    eur_per_hour: 0.042,
+    unpriced: [],
+    complete: true,
+    modelled: true,
+    ...over.cost
+  },
+  ...over
+});
+
+// Each line is a separate thing somebody might object to. A paragraph is
+// a thing people skim.
+test("deployConfirmation states shape, cost, expiry and exposure", () => {
+  const lines = deployConfirmation(previewFixture());
+
+  assert.match(lines[0], /DEV1-S instance/);
+  assert.match(lines[0], /2 × public IPv4 address/);
+  assert.match(lines.join(" "), /list price/);
+  assert.match(lines.join(" "), /Wed 3 Sep 03:47/);
+  assert.match(lines.join(" "), /public internet/);
+  assert.match(lines.join(" "), /nginx:1\.27/);
+});
+
+// An unmodelled scenario's empty component list and €0.00 mean
+// "unknown", not "nothing" — and that invalidates everything above it.
+test("deployWarnings leads with an unmodelled scenario", () => {
+  const warnings = deployWarnings(
+    previewFixture({ cost: { components: [], eur_per_hour: 0, unpriced: [], complete: false, modelled: false } })
+  );
+
+  assert.match(warnings[0], /not modelled/);
+  assert.match(warnings[0], /Do not read the figures above as complete/);
+});
+
+test("deployWarnings says when the cost is a floor rather than a total", () => {
+  const warnings = deployWarnings(
+    previewFixture({
+      internet_facing: false,
+      cost: {
+        components: [],
+        eur_per_hour: 0.042,
+        unpriced: ["Kubernetes cluster"],
+        complete: false,
+        modelled: true
+      }
+    })
+  );
+
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /floor, not a total/);
+  assert.match(warnings[0], /Kubernetes cluster/);
+});
+
+test("deployWarnings warns about internet exposure", () => {
+  const warnings = deployWarnings(previewFixture());
+  assert.ok(warnings.some((w) => /public internet/.test(w)));
+});
+
+// A complete, private, modelled estimate has nothing to warn about, and
+// a warning that always fires is one people stop reading.
+test("deployWarnings stays silent when there is nothing to warn about", () => {
+  assert.deepEqual(deployWarnings(previewFixture({ internet_facing: false })), []);
+});
+
+test("deployConfirmation admits when it does not know what will be created", () => {
+  const lines = deployConfirmation(
+    previewFixture({ cost: { components: [], eur_per_hour: 0, unpriced: [], complete: false, modelled: false } })
+  );
+  assert.match(lines[0], /unknown/);
 });


### PR DESCRIPTION
The scenario page can deploy, against ADR-0027. Deliberately a **separate button
from Run**, and deliberately not matched to it in colour or weight: S153 split the
verbs so keeping infrastructure could not be reached by accident from the one that
proves a change is safe.

The confirmation is S162a's preview rendered as a **list rather than a paragraph**
— each line is a separate thing somebody might object to, and a paragraph is a
thing people skim. `modelled === false` leads the warnings, because it invalidates
everything above it: an unmodelled scenario's empty component list and €0.00 mean
*unknown*, not *nothing*.

## Seven findings across eight passes, two P1, all one sentence

**Asynchrony lets a UI separate a statement from its subject.** A command line
cannot do this: `infrafactory deploy <scenario>` names its target in the same
breath as the decision, and nothing arrives later to change it. A page holds a
description, an action, a URL and several in-flight responses, and any of them can
be about a different thing than the others.

The worst: **the confirmation could describe scenario A's cost, lifetime and blast
radius while creating scenario B's infrastructure**, because the component is
reused across routes and the action posted `detail.name`. A confirmation that
describes one thing and does another is worse than no confirmation — it converts a
careful person into a confident one.

Then: a stale dialog surviving navigation; an in-flight preview reopening one on
the page you moved to; a deploy result landing on the wrong page; the page lagging
its own URL; route loads resolving out of order (P1); and two clicks racing two
previews.

## The fixes tell the story better than the bugs

| # | fix | kind |
|---|---|---|
| 1 | act on `preview.scenario` | bind the action to the statement |
| 2–3 | clear on navigate, compare paths | **guard the occurrence** |
| 4 | every outcome names its scenario | make the statement self-describing |
| 5–7 | clear `detail`; a navigation token every async setter checks; one preview in flight | **remove the state** |

Guards close a path. Removing state closes a category. Pass 126 wrote that lesson
down explicitly and pass 127 still had to learn it again — **writing the
generalisation is not applying it**, and that gap is exactly where findings 5, 6
and 7 lived.

## A correction to S161

S161 claimed a visual baseline pinned the three health states being
distinguishable, and that "a regression making them look alike would pass every
text assertion". **The first half is not true.** `maxDiffPixelRatio: 0.02` means a
change confined to three small badges passes comfortably — and adding a whole
Deploy button to the scenario page did not fail *its* baseline either, which is
what surfaced it.

The property is asserted directly now: the three health badges must have
pairwise-different computed background colours, and an unconfirmed version must
differ from a confirmed one. Stricter than a pixel ratio and immune to
font-rendering flake.

Codex passes 123–129 archived; 129 clean. **Nothing has been run against real
Scaleway.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD