### PR TITLE
S163: stream a deploy while it runs

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,42 @@
 
 Last updated: 2026-08-31
 
+## 2026-09-02 — S163: streaming a deploy
+
+A deploy runs for minutes, and **minutes of silence reads as broken**: a reader
+cannot tell a long apply from a hung one, and the difference matters when the
+thing running is creating billable infrastructure. The command's progress now
+goes to the websocket as it happens.
+
+**Lines, not writes.** The existing `WebSocketSink` broadcasts each `Write`, so a
+command using several `Fprintf` calls produces fragments and a page appending them
+shows half a word followed by the rest of it on the next row. `ProgressSink`
+buffers to a newline, and flushes on close — a command's last line often has no
+trailing newline and is frequently the one that matters.
+
+**Every event names its subject**, which is the S162c lesson applied before it
+could cost anything: a deploy outlives the page it was started from, so these
+arrive on whatever is open. The page discards lines whose subject is not the
+deploy it is showing, rather than appending them under the wrong heading.
+
+The writer is passed in by the API rather than the deployer reaching for a hub, so
+`internal/cli` still does not know a websocket exists. stderr is tee'd rather than
+redirected: the stream goes out live *and* is kept, so a failure that produced no
+structured output can still be explained.
+
+Leaving the page closes the socket and does not touch the deploy — it is detached
+from the request on the server, so it finishes whether or not anybody is watching.
+
+**The first version of that claim was false**, and review caught it. `onDestroy`
+does not fire when SvelteKit reuses the route component, which is every
+client-side move between scenarios — so the stream survived, and the
+subject filter was checking against a `deployingScenario` that still held the old
+one. The reset was a hand-written list twenty lines from the state it covered, and
+S163 added stream state without adding it to the list; it is one
+`resetDeployState()` now, called from both paths. The progress panel was also
+gated on `deploying`, a bare boolean about no particular thing: **state without a
+subject cannot be filtered by subject.**
+
 ## 2026-09-02 — S162c: the deploy button, and a correction to S161
 
 The scenario page can deploy. Deliberately a **separate button from Run**, and

--- a/docs/decisions/0027-deploying-from-the-ui.md
+++ b/docs/decisions/0027-deploying-from-the-ui.md
@@ -150,3 +150,23 @@ A parse that cannot fail is worse than one that does: there is nothing to notice
 The envelope is now required, and output that is not it is reported as a failure
 saying *whether infrastructure was created is unknown* — because the apply may
 well have created some, and an empty result would say the opposite.
+
+## Amendment, 2026-09-02 (S163): a long action reports as it goes
+
+A deploy runs for minutes. Minutes of silence reads as broken, and a reader who
+cannot tell a long apply from a hung one will do one of two harmful things: kill
+it, or start another.
+
+The command's progress is streamed to the websocket, one **line** per event.
+Lines rather than writes, because a command using several `Fprintf` calls
+otherwise produces fragments, and the last line — often the one that matters — is
+flushed on close even without a trailing newline.
+
+**Every event names its subject.** A deploy outlives the page it was started from,
+so its events arrive on whatever page is open. This is the same rule S162c arrived
+at for outcome messages, applied to progress before it could cost anything: a
+client can filter, label or ignore, but it is never handed an unattributed
+statement about something the reader may not be looking at.
+
+Watching is never required. The apply is detached from the request, so closing the
+tab stops the stream and not the deploy.

--- a/docs/review-passes/pass130.md
+++ b/docs/review-passes/pass130.md
@@ -1,0 +1,34 @@
+# Codex review pass 130 — S163
+
+One finding, accepted. **Eighth instance of S162c's class, in a new slice.**
+
+## [P2] The deploy stream survived navigation
+
+`onDestroy` does not fire when SvelteKit reuses the `[...path]` component across
+scenario routes — which is every client-side move between scenarios. So the
+websocket, `deployingScenario` and `deployProgress` all survived, and a previous
+scenario's progress kept rendering under the new one.
+
+**My own STATUS entry claimed the opposite**, in the same commit: *"the page
+discards lines whose subject is not the deploy it is showing"*. It does that check
+against `deployingScenario`, which still held the old scenario. The filter was
+correct and the state it filtered against was stale.
+
+## Why the fix is one function
+
+The navigation reset was a **hand-written list** of things to clear, and S163 added
+stream state without adding it to the list. That is not a new failure mode; it is
+the enumerate-the-readers problem in miniature, on a list that lives twenty lines
+from the state it is supposed to cover.
+
+`resetDeployState()` is now the single place, called from both `afterNavigate` and
+`onDestroy`. New deploy state has one obvious home.
+
+## And the state that had no subject
+
+The panel was gated on `deploying` — a bare boolean about no particular thing — so
+it stayed open on a page with nothing to do with the deploy still running.
+
+That is the same defect one level down from the finding: **state without a subject
+cannot be filtered by subject.** The panel now asks `deployingScenario`, which
+knows what it is about.

--- a/internal/api/deployment_actions.go
+++ b/internal/api/deployment_actions.go
@@ -1,6 +1,9 @@
 package api
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 // ActionStep is one thing an action did, in the shape a page can render.
 //
@@ -36,6 +39,17 @@ type ActionResult struct {
 // persists are different kinds of harm, gated by different flags. A
 // server holding one of these interfaces cannot be talked into the
 // other.
+//
+// # Streaming
+//
+// Deploy takes an `io.Writer` for progress. A deploy runs for minutes,
+// and minutes of silence reads as broken -- the reader cannot tell a
+// long apply from a hung one, and the difference matters when the thing
+// running is creating billable infrastructure.
+//
+// The writer is supplied by the caller rather than the deployer reaching
+// for a hub, so this package keeps deciding what goes on the wire and
+// `internal/cli` keeps not knowing there is one.
 type DeploymentDeployer interface {
 	// Deploy applies a scenario and leaves it running under a TTL.
 	//
@@ -43,7 +57,7 @@ type DeploymentDeployer interface {
 	// deliberately cannot be told which project to use -- run-owned
 	// projects are created by the harness (ADR-0025), and a request that
 	// could name one is a request that could name somebody else's.
-	Deploy(ctx context.Context, scenarioName, ttl string) (ActionResult, error)
+	Deploy(ctx context.Context, scenarioName, ttl string, progress io.Writer) (ActionResult, error)
 }
 
 // DeploymentActor performs the destructive half of live management.

--- a/internal/api/handlers_deploy_test.go
+++ b/internal/api/handlers_deploy_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -27,14 +28,20 @@ type fakeDeployer struct {
 	deadline time.Time
 	hadDl    bool
 	ctxErr   error
+	// progressLines is written to the progress writer, so a test can
+	// assert what a watching client would have seen.
+	progressLines string
 }
 
-func (f *fakeDeployer) Deploy(ctx context.Context, name, ttl string) (ActionResult, error) {
+func (f *fakeDeployer) Deploy(ctx context.Context, name, ttl string, progress io.Writer) (ActionResult, error) {
 	f.calls = append(f.calls, name)
 	f.ttls = append(f.ttls, ttl)
 	f.sawCtx = ctx
 	f.ctxErr = ctx.Err()
 	f.deadline, f.hadDl = ctx.Deadline()
+	if progress != nil && f.progressLines != "" {
+		_, _ = io.WriteString(progress, f.progressLines)
+	}
 	return f.result, f.err
 }
 
@@ -197,4 +204,63 @@ func TestDeployStillReportsARealFailureAsAServerError(t *testing.T) {
 	rec := postDeploy(t, srv, `{"scenario":"lb-serving-paris"}`)
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// Minutes of silence reads as broken: a reader cannot tell a long apply
+// from a hung one, and the difference matters when the thing running is
+// creating billable infrastructure.
+func TestDeployStreamsItsProgressToWatchers(t *testing.T) {
+	hub := NewHub()
+	client := &Client{send: make(chan []byte, 256)}
+	hub.Register(client)
+
+	srv := NewServer(ServerConfig{
+		Config: config.Default(), Deployments: &fakeDeployments{}, Hub: hub,
+		Deployer: &fakeDeployer{
+			result:        ActionResult{Clean: true},
+			progressLines: "Deploying lb-serving-paris\n  workdir: /tmp/x\n",
+		},
+	})
+
+	rec := postDeploy(t, srv, `{"scenario":"lb-serving-paris"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var lines []string
+	var subjects []string
+	for {
+		select {
+		case raw := <-client.send:
+			var e struct {
+				Type string            `json:"type"`
+				Data map[string]string `json:"data"`
+			}
+			require.NoError(t, json.Unmarshal(raw, &e))
+			assert.Equal(t, "deploy_progress", e.Type)
+			lines = append(lines, e.Data["line"])
+			subjects = append(subjects, e.Data["subject"])
+		default:
+			// Indentation is PRESERVED. The deploy command indents
+			// sub-steps on purpose, and flattening them here would
+			// throw away structure the reader uses to see where they
+			// are in a multi-minute apply.
+			require.Equal(t, []string{"Deploying lb-serving-paris", "  workdir: /tmp/x"}, lines)
+			for _, s := range subjects {
+				assert.Equal(t, "lb-serving-paris", s,
+					"a line arriving on a page the reader moved to must say what it is about")
+			}
+			return
+		}
+	}
+}
+
+// A deploy must not depend on anybody watching.
+func TestDeployWorksWithNoHubConfigured(t *testing.T) {
+	srv := NewServer(ServerConfig{
+		Config: config.Default(), Deployments: &fakeDeployments{},
+		Deployer: &fakeDeployer{result: ActionResult{Clean: true}, progressLines: "working\n"},
+	})
+
+	rec := postDeploy(t, srv, `{"scenario":"lb-serving-paris"}`)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
 }

--- a/internal/api/handlers_deployments.go
+++ b/internal/api/handlers_deployments.go
@@ -336,7 +336,13 @@ func deployHandler(state *serverState) http.HandlerFunc {
 		ctx, cancel := destructiveContext(r)
 		defer cancel()
 
-		result, err := state.deployer.Deploy(ctx, req.Scenario, req.TTL)
+		// Named with the scenario, so a line arriving on a page the
+		// reader has since navigated to says what it is about -- the
+		// rule S162c cost seven findings to learn.
+		progress := NewProgressSink(state.hub, "deploy_progress", req.Scenario)
+		defer progress.Close()
+
+		result, err := state.deployer.Deploy(ctx, req.Scenario, req.TTL, progress)
 		if errors.Is(err, os.ErrNotExist) {
 			// The caller named something that is not here. A client
 			// typo or a stale scenario list is not a server fault, and

--- a/internal/api/progress_sink.go
+++ b/internal/api/progress_sink.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"sync"
+)
+
+// ProgressSink turns a command's progress output into websocket events,
+// one per line (S163).
+//
+// # Why lines, and not writes
+//
+// `WebSocketSink` broadcasts each Write as it arrives. A command writing
+// with several Fprintf calls, or a subprocess flushing on a buffer
+// boundary, produces fragments -- and a page appending fragments shows
+// half a word, then the rest of it on the next row. Buffering to newline
+// costs nothing and makes the output mean what it says.
+//
+// # Why every event names its subject
+//
+// A deploy takes minutes and the reader can navigate during it, so these
+// events arrive on whatever page is open. An unattributed progress line
+// is a statement about something the reader may not be looking at --
+// exactly what cost S162c seven review findings. The subject travels
+// with every line so a client can filter, label, or ignore it.
+type ProgressSink struct {
+	hub     *Hub
+	kind    string
+	subject string
+
+	mu      sync.Mutex
+	partial bytes.Buffer
+}
+
+// NewProgressSink builds a sink. `kind` is the event type a client
+// switches on ("deploy_progress"); `subject` is what the events are
+// about.
+func NewProgressSink(hub *Hub, kind, subject string) *ProgressSink {
+	return &ProgressSink{hub: hub, kind: kind, subject: subject}
+}
+
+func (s *ProgressSink) Write(p []byte) (int, error) {
+	if s == nil {
+		return len(p), nil
+	}
+
+	s.mu.Lock()
+	s.partial.Write(p)
+
+	var lines []string
+	for {
+		buffered := s.partial.Bytes()
+		idx := bytes.IndexByte(buffered, '\n')
+		if idx < 0 {
+			break
+		}
+		lines = append(lines, string(bytes.TrimRight(buffered[:idx], "\r")))
+		s.partial.Next(idx + 1)
+	}
+	s.mu.Unlock()
+
+	for _, line := range lines {
+		s.emit(line)
+	}
+	return len(p), nil
+}
+
+// Close flushes whatever did not end in a newline.
+//
+// A command's last line often has no trailing newline, and it is
+// frequently the one that matters -- "Deployed as dep-…". Dropping it
+// would end the stream one line short of the conclusion.
+func (s *ProgressSink) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	tail := s.partial.String()
+	s.partial.Reset()
+	s.mu.Unlock()
+
+	if tail != "" {
+		s.emit(tail)
+	}
+	return nil
+}
+
+func (s *ProgressSink) emit(line string) {
+	if s.hub == nil || line == "" {
+		return
+	}
+	payload, err := json.Marshal(map[string]any{
+		"type": s.kind,
+		"data": map[string]string{"subject": s.subject, "line": line},
+	})
+	if err != nil {
+		return
+	}
+	s.hub.Broadcast(payload)
+}

--- a/internal/api/progress_sink_test.go
+++ b/internal/api/progress_sink_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordedEvent is what would go over the wire.
+type recordedEvent struct {
+	Type string            `json:"type"`
+	Data map[string]string `json:"data"`
+}
+
+// sinkFor wires a sink to a hub with one subscriber, and returns a
+// reader for whatever has been broadcast so far.
+//
+// The reader DRAINS: call it once per assertion block and keep the
+// result.
+//
+// The subscriber is a Client with only its send channel: Broadcast never
+// touches the connection, so a test does not need a real websocket to
+// observe what a client would receive.
+func sinkFor(t *testing.T, subject string) (*ProgressSink, func() []recordedEvent) {
+	t.Helper()
+
+	hub := NewHub()
+	client := &Client{send: make(chan []byte, 256)}
+	hub.Register(client)
+
+	sink := NewProgressSink(hub, "deploy_progress", subject)
+
+	return sink, func() []recordedEvent {
+		var out []recordedEvent
+		for {
+			select {
+			case raw := <-client.send:
+				var e recordedEvent
+				require.NoError(t, json.Unmarshal(raw, &e))
+				out = append(out, e)
+			default:
+				return out
+			}
+		}
+	}
+}
+
+// A command writing with several Fprintf calls produces fragments, and a
+// page appending fragments shows half a word then the rest of it on the
+// next row.
+func TestProgressSinkEmitsWholeLinesNotWrites(t *testing.T) {
+	sink, events := sinkFor(t, "lb-serving-paris")
+
+	_, _ = sink.Write([]byte("Deploying lb-"))
+	_, _ = sink.Write([]byte("serving-paris\nworkdir: /tmp/x\n"))
+
+	got := events()
+	require.Len(t, got, 2)
+	assert.Equal(t, "Deploying lb-serving-paris", got[0].Data["line"])
+	assert.Equal(t, "workdir: /tmp/x", got[1].Data["line"])
+}
+
+// A deploy takes minutes and the reader can navigate during it, so these
+// events arrive on whatever page is open. An unattributed line is a
+// statement about something they may not be looking at.
+func TestProgressSinkNamesItsSubjectOnEveryLine(t *testing.T) {
+	sink, events := sinkFor(t, "lb-serving-paris")
+
+	_, _ = sink.Write([]byte("one\ntwo\n"))
+
+	for _, e := range events() {
+		assert.Equal(t, "lb-serving-paris", e.Data["subject"])
+		assert.Equal(t, "deploy_progress", e.Type)
+	}
+}
+
+// A command's last line often has no trailing newline, and it is
+// frequently the one that matters.
+func TestProgressSinkFlushesTheLastLineOnClose(t *testing.T) {
+	sink, events := sinkFor(t, "lb-serving-paris")
+
+	_, _ = sink.Write([]byte("Deployed as dep-20260902"))
+	require.NoError(t, sink.Close())
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "Deployed as dep-20260902", got[0].Data["line"])
+}
+
+func TestProgressSinkCloseIsQuietWhenNothingIsBuffered(t *testing.T) {
+	sink, events := sinkFor(t, "x")
+
+	_, _ = sink.Write([]byte("done\n"))
+	require.NoError(t, sink.Close())
+
+	assert.Len(t, events(), 1, "close must not repeat the last line")
+}
+
+// Blank lines carry no information and would pad the stream.
+func TestProgressSinkDropsEmptyLines(t *testing.T) {
+	sink, events := sinkFor(t, "x")
+
+	_, _ = sink.Write([]byte("\n\nreal\n\n"))
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "real", got[0].Data["line"])
+}
+
+// Windows-style line endings must not leave a stray carriage return that
+// a browser renders as a box.
+func TestProgressSinkTrimsCarriageReturns(t *testing.T) {
+	sink, events := sinkFor(t, "x")
+
+	_, _ = sink.Write([]byte("line\r\n"))
+
+	// Captured once: the reader drains the channel, so calling it twice
+	// returns nothing the second time.
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "line", got[0].Data["line"])
+}
+
+// A nil sink is a no-op rather than a panic: the caller passes one when
+// there is no hub, and a deploy must not die because nobody is watching.
+func TestNilProgressSinkIsHarmless(t *testing.T) {
+	var sink *ProgressSink
+
+	n, err := sink.Write([]byte("anything"))
+
+	require.NoError(t, err)
+	assert.Equal(t, len("anything"), n)
+	require.NoError(t, sink.Close())
+}
+
+// Concurrent writers must not interleave inside a line.
+func TestProgressSinkIsSafeUnderConcurrentWrites(t *testing.T) {
+	sink, events := sinkFor(t, "x")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = sink.Write([]byte("aaaa\n"))
+		}()
+	}
+	wg.Wait()
+
+	got := events()
+	assert.Len(t, got, 20)
+	for _, e := range got {
+		assert.Equal(t, "aaaa", e.Data["line"], "a line must not be interleaved with another")
+	}
+}

--- a/internal/cli/live_service.go
+++ b/internal/cli/live_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -180,7 +181,7 @@ func NewLiveDeployer(scenarioRoot string, newRuntime func() (*CommandRuntime, er
 }
 
 // Deploy applies a scenario and leaves it running under a TTL.
-func (d *LiveDeployer) Deploy(ctx context.Context, scenarioName, ttl string) (api.ActionResult, error) {
+func (d *LiveDeployer) Deploy(ctx context.Context, scenarioName, ttl string, progress io.Writer) (api.ActionResult, error) {
 	// A NAME, resolved here, never a path from the caller. `deploy`
 	// takes a filesystem path, and accepting one over HTTP would let a
 	// request name any YAML on the machine -- including one outside the
@@ -206,16 +207,24 @@ func (d *LiveDeployer) Deploy(ctx context.Context, scenarioName, ttl string) (ap
 		}
 	}
 
-	// Output is captured rather than printed: this is an API call, and
-	// the command's stdout contract is not the response body.
-	var out, progress strings.Builder
+	// stdout is CAPTURED -- it carries the machine-output contract that
+	// deployOutcome parses, and is not the response body.
+	//
+	// stderr is TEE'd: the command's human progress goes to the caller's
+	// writer as it happens, and is also kept so a failure that produced
+	// no structured output can still be explained.
+	var out, progressCopy strings.Builder
 	cmd.SetOut(&out)
-	cmd.SetErr(&progress)
+	if progress != nil {
+		cmd.SetErr(io.MultiWriter(progress, &progressCopy))
+	} else {
+		cmd.SetErr(&progressCopy)
+	}
 	cmd.SetContext(ctx)
 
 	deployErr := runDeployCommand(cmd, []string{path}, runtime)
 
-	result := deployOutcome(out.String(), progress.String(), deployErr)
+	result := deployOutcome(out.String(), progressCopy.String(), deployErr)
 	if deployErr != nil && result.Failures == nil {
 		// The command failed before it produced structured output --
 		// a usage error, a missing scenario. Surfacing the raw error

--- a/internal/cli/live_service_test.go
+++ b/internal/cli/live_service_test.go
@@ -201,7 +201,7 @@ func TestDeployerBuildsAFreshRuntimeForEachDeploy(t *testing.T) {
 	})
 
 	for _, name := range []string{"first-scenario", "second-scenario"} {
-		_, err := deployer.Deploy(context.Background(), name, "")
+		_, err := deployer.Deploy(context.Background(), name, "", nil)
 		require.Error(t, err)
 	}
 
@@ -218,7 +218,7 @@ func TestDeployerRefusesAnUnknownScenarioBeforeBuildingAnything(t *testing.T) {
 		return nil, errors.New("should not be reached")
 	})
 
-	_, err := deployer.Deploy(context.Background(), "no-such-scenario", "")
+	_, err := deployer.Deploy(context.Background(), "no-such-scenario", "", nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no scenario named")
@@ -246,4 +246,19 @@ acceptance_criteria:
 		require.NoError(t, os.WriteFile(filepath.Join(root, name+".yaml"), body, 0o644))
 	}
 	return root
+}
+
+// A deploy must not depend on anybody watching: a nil progress writer is
+// the ordinary case for a caller that has no hub.
+func TestDeployerAcceptsANilProgressWriter(t *testing.T) {
+	deployer := NewLiveDeployer(twoScenarios(t), func() (*CommandRuntime, error) {
+		return nil, errors.New("not building a real runtime in a unit test")
+	})
+
+	_, err := deployer.Deploy(context.Background(), "first-scenario", "", nil)
+
+	// It reaches the runtime factory, which is as far as a unit test
+	// takes it. The point is that nil did not panic on the way.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not building a real runtime")
 }

--- a/ui/e2e/deploy.spec.ts
+++ b/ui/e2e/deploy.spec.ts
@@ -395,3 +395,83 @@ test.describe('Deploy from the scenario page', () => {
     await expect(outcome).toContainText('7c98d82e');
   });
 });
+
+test.describe('Deploy progress', () => {
+  // Minutes of silence reads as broken. The reader cannot tell a long
+  // apply from a hung one, and the difference matters when the thing
+  // running is creating billable infrastructure.
+  test('a deploy in flight shows something is happening', async ({ page }) => {
+    await page.route('**/api/deployments/preview**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          scenario: 'web-app-paris',
+          deployable: true,
+          expires_at: null,
+          internet_facing: false,
+          deploy_allowed: true,
+          cost: { components: [], eur_per_hour: 0, unpriced: [], complete: true, modelled: true }
+        })
+      })
+    );
+
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => (release = resolve));
+    await page.route('**/api/deployments', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      await held;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ clean: true, steps: [], failures: [] })
+      });
+    });
+
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+    await page.getByTestId('deploy-confirm-go').click();
+
+    // Before any line arrives, the page still says it is working.
+    await expect(page.getByTestId('deploy-progress')).toContainText('Starting…');
+
+    release();
+    await expect(page.getByTestId('deploy-outcome')).toBeVisible();
+  });
+
+  // SvelteKit REUSES the [...path] component across scenario routes, so
+  // leaving one scenario page for another destroys nothing and
+  // `onDestroy` never fires. Without resetting from the navigation path
+  // too, a previous scenario's progress keeps rendering under the new
+  // one.
+  test('progress does not follow you to another scenario', async ({ page }) => {
+    await servePreview(page);
+
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => (release = resolve));
+    await page.route('**/api/deployments', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      await held;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ clean: true, steps: [], failures: [] })
+      });
+    });
+
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+    await page.getByTestId('deploy-confirm-go').click();
+    await expect(page.getByTestId('deploy-progress')).toBeVisible();
+
+    // Client-side navigation, which reuses the component.
+    await page.getByTestId('sidebar-scenario-training/lb-serving-paris').click();
+    await expect(page.locator('main h1')).toContainText('lb-serving-paris');
+
+    await expect(page.getByTestId('deploy-progress')).toHaveCount(0);
+
+    release();
+    // And the finished deploy must not paint its result here either.
+    await expect(page.getByTestId('deploy-progress')).toHaveCount(0);
+  });
+});

--- a/ui/src/routes/scenarios/[...path]/+page.svelte
+++ b/ui/src/routes/scenarios/[...path]/+page.svelte
@@ -3,6 +3,7 @@
   import { onDestroy } from "svelte";
   import { page } from "$app/stores";
   import { api } from "$lib/api";
+  import { connectWS } from "$lib/ws";
   import {
     deployConfirmation,
     deployWarnings,
@@ -81,6 +82,10 @@
   // component (the validationVersion guard is per-instance).
   onDestroy(() => {
     if (validationTimer) clearTimeout(validationTimer);
+    // Leaving the page must not leave a socket open. The deploy itself
+    // is unaffected: it is detached from the request on the server, so
+    // it finishes whether or not anybody is watching.
+    resetDeployState();
   });
 
   $: scenarioPath = ($page.params.path || "").toString();
@@ -152,6 +157,59 @@
   // which is the move pass 126 argued for and pass 127 had to learn
   // twice. It also gives the reader feedback that the click landed.
   let previewing = false;
+
+  // A deploy runs for minutes, and minutes of silence reads as broken:
+  // a reader cannot tell a long apply from a hung one, and the
+  // difference matters when the thing running is creating billable
+  // infrastructure (S163).
+  //
+  // Every line names the scenario it belongs to, so lines from a deploy
+  // the reader has navigated away from are DISCARDED here rather than
+  // appended under the wrong heading.
+  let deployProgress: string[] = [];
+  let disconnectWS: (() => void) | undefined;
+
+  function onSocketMessage(msg: unknown) {
+    const event = msg as { type?: string; data?: { subject?: string; line?: string } };
+    if (event?.type !== "deploy_progress" || !event.data?.line) return;
+    if (event.data.subject !== deployingScenario) return;
+    deployProgress = [...deployProgress, event.data.line];
+  }
+
+  // The scenario whose progress this page is currently showing. Held
+  // separately from `preview` because `preview` is cleared on
+  // navigation while a deploy keeps running.
+  let deployingScenario = "";
+
+  /**
+   * resetDeployState puts this page back to knowing nothing about a
+   * deploy.
+   *
+   * ONE function, called from both navigation and destroy, because the
+   * reset used to be a hand-written list in `afterNavigate` -- and the
+   * moment S163 added stream state, the list did not grow with it. The
+   * websocket, `deployingScenario` and `deployProgress` survived a
+   * client-side route change, so progress for the previous scenario
+   * kept rendering under the new one.
+   *
+   * `onDestroy` does not cover that: SvelteKit REUSES this `[...path]`
+   * component across scenario routes, so leaving a scenario page for
+   * another one destroys nothing.
+   *
+   * The deploy itself is untouched. It is detached from the request on
+   * the server, so it finishes whether or not this page is watching.
+   */
+  function resetDeployState() {
+    disconnectWS?.();
+    disconnectWS = undefined;
+    deployingScenario = "";
+    deploying = false;
+    deployProgress = [];
+    confirmingDeploy = false;
+    preview = null;
+    previewError = "";
+    deployOutcomeMessage = "";
+  }
   let deploying = false;
   let deployOutcomeMessage = "";
   let deployOk = false;
@@ -196,6 +254,9 @@
     if (!target) return;
 
     deploying = true;
+    deployingScenario = target;
+    deployProgress = [];
+    if (!disconnectWS) disconnectWS = connectWS(onSocketMessage);
     try {
       const result = await api.deployScenario(target);
       const outcome = teardownOutcome(result);
@@ -220,6 +281,7 @@
     } finally {
       deploying = false;
       confirmingDeploy = false;
+      deployingScenario = "";
     }
   }
 
@@ -289,10 +351,7 @@
     // on screen, even though accepting it would now be harmless.
     // Leaving it visible invites the reader to trust a dialog about
     // something they are no longer looking at.
-    confirmingDeploy = false;
-    preview = null;
-    previewError = "";
-    deployOutcomeMessage = "";
+    resetDeployState();
     // `detail` is cleared too, and that is the STRUCTURAL half of this.
     //
     // The whole page is inside `{#if detail}`, so clearing it means
@@ -485,6 +544,26 @@
           on:click={() => (confirmingDeploy = false)}>Cancel</button
         >
       </div>
+    </div>
+  {/if}
+
+  <!-- Gated on `deployingScenario`, not on `deploying`.
+       `deploying` is a bare boolean about no particular thing, so it
+       survives navigation and would keep this panel open on a page that
+       has nothing to do with the deploy still running. The
+       subject-bearing state is the one to ask. -->
+  {#if deployingScenario || deployProgress.length > 0}
+    <div
+      class="mt-3 rounded border border-slate-300 bg-slate-900 px-3 py-2 font-mono text-xs text-slate-100"
+      data-testid="deploy-progress"
+    >
+      {#if deployProgress.length === 0}
+        <p class="text-slate-400">Starting…</p>
+      {:else}
+        {#each deployProgress as line}
+          <p>{line}</p>
+        {/each}
+      {/if}
     </div>
   {/if}
 


### PR DESCRIPTION
> **Not merged, and not convergeable right now.** Codex quota is exhausted until
> **7 September**. One finding was raised and fixed (pass 130); the confirming
> clean pass cannot run, and one clean pass is the merge precondition.

A deploy runs for minutes, and **minutes of silence reads as broken**: a reader
cannot tell a long apply from a hung one, and the difference matters when the
thing running is creating billable infrastructure.

**Lines, not writes.** The existing `WebSocketSink` broadcasts each `Write`, so a
command using several `Fprintf` calls produces fragments and a page appending them
shows half a word followed by the rest on the next row. `ProgressSink` buffers to
a newline and flushes on close — a command's last line often has no trailing
newline and is frequently the one that matters.

**Every event names its subject**, which is S162c's lesson applied *before* it
could cost anything: a deploy outlives the page it was started from, so these
arrive on whatever is open.

The writer is passed in by the API rather than the deployer reaching for a hub, so
`internal/cli` still does not know a websocket exists. stderr is tee'd rather than
redirected: the stream goes out live *and* is kept, so a failure that produced no
structured output can still be explained.

## The one finding was the eighth instance of S162c's class

`onDestroy` does not fire when SvelteKit reuses the `[...path]` component — which
is every client-side move between scenarios. So the websocket,
`deployingScenario` and `deployProgress` all survived, and a previous scenario's
progress kept rendering under the new one.

**My own STATUS entry claimed the opposite in the same commit**: *"the page
discards lines whose subject is not the deploy it is showing."* The filter was
right; the state it filtered against was stale.

Two things came out of the fix:

- The navigation reset was a **hand-written list**, twenty lines from the state it
  was supposed to cover, and this slice added stream state without adding it to
  the list. It is one `resetDeployState()` now, called from both `afterNavigate`
  and `onDestroy`.
- The progress panel was gated on `deploying` — a bare boolean about no particular
  thing — so it stayed open on a page with nothing to do with the running deploy.
  **State without a subject cannot be filtered by subject.**

ADR-0027 amended. 89 Playwright tests and the full Go suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD