### PR TITLE
S163: stream a deploy while it runs, from the harness

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -63,6 +63,31 @@ function. **State that must outlive the page cannot live in the page** — it is
 module-level store keyed by scenario now, owning the socket, with two e2e tests
 pinning both journeys including a full unmount.
 
+**A third review, adversarial on the tests, found nine more — every one verified
+by mutation.** The shape of most of them: *the units were tested and the wiring
+between them was not.* Dropping the tee, and passing `nil` to the harness at the
+call site, each broke the feature completely while the whole Go suite stayed
+green — because `deployStderr` was tested in isolation and every test calling
+`Deploy` used a runtime that failed before the writer was touched.
+
+One test closes all three of those: `LiveDeployer.Deploy` → `runDeployCommand` →
+the real harness → sink → hub → what a websocket client receives, with only the
+subprocess faked. **My first attempt at it skipped both broken points**, going
+harness→sink directly — it looked like coverage and would have closed nothing.
+
+Also: `retrying` was pinned as a substring, so the stream could promise a retry on
+the final attempt *and on the interrupt path* — where the operator has asked us to
+stop touching the API. It says `giving up` now. And the UI had **no test that
+rendered a progress line at all**: replacing the whole `{#each}` with a constant
+string passed the full suite. `page.routeWebSocket` lets the tests be the socket
+server, so real frames reach the real DOM.
+
+**Two recorded rather than fixed.** `forgetDeploy` has no production caller, so a
+finished deploy's banner reappears on every later visit for the rest of the
+session. And a **page reload defeats the in-flight guard** — the store is module
+state with no server-side lock, so refreshing during a deploy re-enables the
+button. That one wants a server-side in-flight lock, which is a design decision.
+
 **Named rather than claimed done:** `run`/`test` still applies silently. Its
 progress goes through `runtime.Logger` rather than a writer, so the Layer 3 apply
 on the Live Run page — the more commonly watched screen — has the same defect this

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,41 +2,47 @@
 
 Last updated: 2026-08-31
 
-## 2026-09-02 — S163: streaming a deploy
+## 2026-09-02 — S163: streaming a deploy, and the first version that did not
 
 A deploy runs for minutes, and **minutes of silence reads as broken**: a reader
 cannot tell a long apply from a hung one, and the difference matters when the
-thing running is creating billable infrastructure. The command's progress now
-goes to the websocket as it happens.
+thing running is creating billable infrastructure.
 
-**Lines, not writes.** The existing `WebSocketSink` broadcasts each `Write`, so a
-command using several `Fprintf` calls produces fragments and a page appending them
-shows half a word followed by the rest of it on the next row. `ProgressSink`
-buffers to a newline, and flushes on close — a command's last line often has no
-trailing newline and is frequently the one that matters.
+**The first version of this slice did not deliver that, and its tests passed
+anyway.** It tee'd the deploy command's stderr — written twice *before* any cloud
+work and once *after* the apply returns. Nothing in between touches that stream:
+`CommandRunner.Run` returns a fully buffered `CommandResult`, so `tofu`'s output
+does not exist until each process exits. Shipped behaviour would have been two
+lines, silence for the whole apply, one line — **worse than before**, because a
+terminal-styled log pane that has stopped moving is a stronger "hung" signal than
+the button label beside it.
 
-**Every event names its subject**, which is the S162c lesson applied before it
-could cost anything: a deploy outlives the page it was started from, so these
-arrive on whatever is open. The page discards lines whose subject is not the
-deploy it is showing, rather than appending them under the wrong heading.
+Codex was out of quota, so three fresh-context agents reviewed instead. Two found
+it independently, and one *demonstrated* it by replacing the live tee with
+buffer-then-dump and watching the suite stay green.
 
-The writer is passed in by the API rather than the deployer reaching for a hub, so
-`internal/cli` still does not know a websocket exists. stderr is tee'd rather than
-redirected: the stream goes out live *and* is kept, so a failure that produced no
-structured output can still be explained.
+**The harness is the only thing that knows a stage has begun**, so it reports.
+`SandboxDeployHarnessRunner.Run` takes an `io.Writer` — a parameter, not a field,
+because the harness is shared and two deploys must not write into each other's
+stream. Stage granularity rather than raw tofu output: it is what the plan asked
+for, and it does not drown a terminal. **Retries are visible now**, because a
+silent retry is indistinguishable from a slow stage.
 
-Leaving the page closes the socket and does not touch the deploy — it is detached
-from the request on the server, so it finishes whether or not anybody is watching.
+`TestProgressIsVisibleWhileTheApplyIsStillRunning` asserts what a watcher sees
+**from inside the apply**, which buffer-then-dump cannot satisfy — verified by
+mutation.
 
-**The first version of that claim was false**, and review caught it. `onDestroy`
-does not fire when SvelteKit reuses the route component, which is every
-client-side move between scenarios — so the stream survived, and the
-subject filter was checking against a `deployingScenario` that still held the old
-one. The reset was a hand-written list twenty lines from the state it covered, and
-S163 added stream state without adding it to the list; it is one
-`resetDeployState()` now, called from both paths. The progress panel was also
-gated on `deploying`, a bare boolean about no particular thing: **state without a
-subject cannot be filtered by subject.**
+Six further confirmed findings fixed, the worst being a regression the slice
+itself introduced: clearing `deploying` on navigation re-enabled the button, so
+navigating away mid-deploy and back allowed a **second real deploy** of the same
+scenario — two projects, double billing. Also: an earlier deploy's completion
+clobbering a later one's state; the `Deployed as dep-…` line losing a race with
+the HTTP response; a dropped socket rendering as "Starting…"; the progress filter
+having no test at all; and a `Close()` comment claiming a bug it does not fix.
+
+The event subject is the **scenario**, not the deployment id — that id is minted
+inside the command. Two concurrent deploys of one scenario share a stream. Stated
+in the code rather than implied away.
 
 ## 2026-09-02 — S162c: the deploy button, and a correction to S161
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -44,6 +44,30 @@ The event subject is the **scenario**, not the deployment id — that id is mint
 inside the command. Two concurrent deploys of one scenario share a stream. Stated
 in the code rather than implied away.
 
+**A second fresh-context review found five more, four of them in the fix.** A
+stage that FAILED was reported as `done` — a failure rendered as completion,
+followed by silence, in the code written to prevent exactly that; and
+`TestEveryStageReportsItself` actively pinned the wrong behaviour.
+
+The other three shared a cause: **in-flight state died with the component.**
+Navigating away and back mid-deploy left a real, billable apply rendered as an
+unlabelled disabled button with no log — the "cannot see it" warning was itself
+unreachable, gated on state that had just been cleared. Leaving the *section*
+unmounted the component entirely, so returning gave a fresh one that believed
+nothing was running and would start a **second deploy of the same scenario**.
+
+That last one was created by the previous round's fix: removing state on
+navigation is right for the confirmation dialog and wrong for the deploy stream,
+and I applied it to both because two passes earlier they had been folded into one
+function. **State that must outlive the page cannot live in the page** — it is a
+module-level store keyed by scenario now, owning the socket, with two e2e tests
+pinning both journeys including a full unmount.
+
+**Named rather than claimed done:** `run`/`test` still applies silently. Its
+progress goes through `runtime.Logger` rather than a writer, so the Layer 3 apply
+on the Live Run page — the more commonly watched screen — has the same defect this
+slice fixes for `deploy`.
+
 ## 2026-09-02 — S162c: the deploy button, and a correction to S161
 
 The scenario page can deploy. Deliberately a **separate button from Run**, and

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,42 @@
 
 Last updated: 2026-08-31
 
+## 2026-09-02 — S163: streaming a deploy
+
+A deploy runs for minutes, and **minutes of silence reads as broken**: a reader
+cannot tell a long apply from a hung one, and the difference matters when the
+thing running is creating billable infrastructure. The command's progress now
+goes to the websocket as it happens.
+
+**Lines, not writes.** The existing `WebSocketSink` broadcasts each `Write`, so a
+command using several `Fprintf` calls produces fragments and a page appending them
+shows half a word followed by the rest of it on the next row. `ProgressSink`
+buffers to a newline, and flushes on close — a command's last line often has no
+trailing newline and is frequently the one that matters.
+
+**Every event names its subject**, which is the S162c lesson applied before it
+could cost anything: a deploy outlives the page it was started from, so these
+arrive on whatever is open. The page discards lines whose subject is not the
+deploy it is showing, rather than appending them under the wrong heading.
+
+The writer is passed in by the API rather than the deployer reaching for a hub, so
+`internal/cli` still does not know a websocket exists. stderr is tee'd rather than
+redirected: the stream goes out live *and* is kept, so a failure that produced no
+structured output can still be explained.
+
+Leaving the page closes the socket and does not touch the deploy — it is detached
+from the request on the server, so it finishes whether or not anybody is watching.
+
+**The first version of that claim was false**, and review caught it. `onDestroy`
+does not fire when SvelteKit reuses the route component, which is every
+client-side move between scenarios — so the stream survived, and the
+subject filter was checking against a `deployingScenario` that still held the old
+one. The reset was a hand-written list twenty lines from the state it covered, and
+S163 added stream state without adding it to the list; it is one
+`resetDeployState()` now, called from both paths. The progress panel was also
+gated on `deploying`, a bare boolean about no particular thing: **state without a
+subject cannot be filtered by subject.**
+
 ## 2026-09-02 — S162c: the deploy button, and a correction to S161
 
 The scenario page can deploy. Deliberately a **separate button from Run**, and

--- a/docs/decisions/0027-deploying-from-the-ui.md
+++ b/docs/decisions/0027-deploying-from-the-ui.md
@@ -157,6 +157,21 @@ A deploy runs for minutes. Minutes of silence reads as broken, and a reader who
 cannot tell a long apply from a hung one will do one of two harmful things: kill
 it, or start another.
 
+**The harness reports, because it is the only thing that can.** The first attempt
+tee'd the deploy command's stderr, which is written twice before any cloud work
+and once after the apply returns — and `CommandRunner.Run` returns a fully
+buffered result, so `tofu`'s own output does not exist until each process exits.
+There is no stream to tee. `SandboxDeployHarnessRunner.Run` therefore takes an
+`io.Writer` and announces each stage as it begins, including **retries**, since a
+silent retry is indistinguishable from a stage that is merely slow.
+
+Stage granularity rather than raw provider output: it answers the reader's actual
+question — *where is it up to?* — in a predictable handful of lines.
+
+The progress writer is a parameter rather than a field on the harness, because the
+harness is constructed once and shared, and two deploys running at once must not
+write into each other's stream.
+
 The command's progress is streamed to the websocket, one **line** per event.
 Lines rather than writes, because a command using several `Fprintf` calls
 otherwise produces fragments, and the last line — often the one that matters — is
@@ -170,3 +185,9 @@ statement about something the reader may not be looking at.
 
 Watching is never required. The apply is detached from the request, so closing the
 tab stops the stream and not the deploy.
+
+**The subject is the scenario, not the deployment id**, and that is a limit rather
+than a choice: the id is minted inside the command, after the request is accepted.
+Two concurrent deploys of one scenario therefore share a stream and a reader sees
+both. Recorded here rather than left to be discovered, because the id is the
+argument to `live teardown` and taking the wrong one has consequences.

--- a/docs/decisions/0027-deploying-from-the-ui.md
+++ b/docs/decisions/0027-deploying-from-the-ui.md
@@ -150,3 +150,23 @@ A parse that cannot fail is worse than one that does: there is nothing to notice
 The envelope is now required, and output that is not it is reported as a failure
 saying *whether infrastructure was created is unknown* — because the apply may
 well have created some, and an empty result would say the opposite.
+
+## Amendment, 2026-09-02 (S163): a long action reports as it goes
+
+A deploy runs for minutes. Minutes of silence reads as broken, and a reader who
+cannot tell a long apply from a hung one will do one of two harmful things: kill
+it, or start another.
+
+The command's progress is streamed to the websocket, one **line** per event.
+Lines rather than writes, because a command using several `Fprintf` calls
+otherwise produces fragments, and the last line — often the one that matters — is
+flushed on close even without a trailing newline.
+
+**Every event names its subject.** A deploy outlives the page it was started from,
+so its events arrive on whatever page is open. This is the same rule S162c arrived
+at for outcome messages, applied to progress before it could cost anything: a
+client can filter, label or ignore, but it is never handed an unattributed
+statement about something the reader may not be looking at.
+
+Watching is never required. The apply is detached from the request, so closing the
+tab stops the stream and not the deploy.

--- a/docs/review-passes/pass130.md
+++ b/docs/review-passes/pass130.md
@@ -1,0 +1,34 @@
+# Codex review pass 130 — S163
+
+One finding, accepted. **Eighth instance of S162c's class, in a new slice.**
+
+## [P2] The deploy stream survived navigation
+
+`onDestroy` does not fire when SvelteKit reuses the `[...path]` component across
+scenario routes — which is every client-side move between scenarios. So the
+websocket, `deployingScenario` and `deployProgress` all survived, and a previous
+scenario's progress kept rendering under the new one.
+
+**My own STATUS entry claimed the opposite**, in the same commit: *"the page
+discards lines whose subject is not the deploy it is showing"*. It does that check
+against `deployingScenario`, which still held the old scenario. The filter was
+correct and the state it filtered against was stale.
+
+## Why the fix is one function
+
+The navigation reset was a **hand-written list** of things to clear, and S163 added
+stream state without adding it to the list. That is not a new failure mode; it is
+the enumerate-the-readers problem in miniature, on a list that lives twenty lines
+from the state it is supposed to cover.
+
+`resetDeployState()` is now the single place, called from both `afterNavigate` and
+`onDestroy`. New deploy state has one obvious home.
+
+## And the state that had no subject
+
+The panel was gated on `deploying` — a bare boolean about no particular thing — so
+it stayed open on a page with nothing to do with the deploy still running.
+
+That is the same defect one level down from the finding: **state without a subject
+cannot be filtered by subject.** The panel now asks `deployingScenario`, which
+knows what it is about.

--- a/docs/review-passes/pass131.md
+++ b/docs/review-passes/pass131.md
@@ -1,0 +1,87 @@
+# Review pass 131 — S163, by three fresh-context agents
+
+Codex is out of quota until 2026-09-07. On the user's instruction the review was
+run by three fresh-context subagents with separate lenses — correctness,
+truthfulness-to-the-reader, and an adversarial pass on the tests, that last one
+primed with this session's three cases of a fixture built from the same wrong
+assumption as the code.
+
+The caveat stated at the time still holds: a fresh-context agent is independent of
+my *reasoning* but shares my *model*. Codex caught two P1s partly by being a
+different model.
+
+## The finding that mattered: the streaming did not stream
+
+Two of the three found it independently, and I verified it directly.
+
+`LiveDeployer` tee'd `cmd.ErrOrStderr()`. `runDeployCommand` writes to that stream
+exactly three times: twice before any cloud work, once after the apply returns.
+Nothing in between touches it — `ensureRunProject` never prints, and
+`SandboxDeployHarness.Run` executes `tofu init/plan/apply` through
+`CommandRunner.Run`, which returns a **fully buffered** `CommandResult`. The
+output does not exist until each process exits.
+
+So the shipped behaviour was: two lines, silence for the whole apply, one line.
+**Worse than before**, because a terminal-styled log pane that has stopped moving
+is a stronger "hung" signal than the button label beside it. The exact reader-state
+ADR-0027 says the slice prevents.
+
+### The tests could not have caught it, and that was demonstrated
+
+The reviewer replaced the live tee with buffer-then-dump and ran the suite: green.
+The fake deployer writes its whole fixture in one synchronous call, so it cannot
+distinguish "streamed during" from "dumped at the end". Both e2e tests intercept
+the POST in the browser, so the server never broadcasts at all — mutating
+`resetDeployState` to leave the socket open, and typo-ing the event type to kill
+the stream entirely, both passed all 19.
+
+**Fourth instance this session of a fixture built from my own assumption**, and
+the first that hid a feature which simply did not function.
+
+## What the fix actually is
+
+The harness is the only thing that knows a stage has *begun*, so it has to be the
+one reporting. `SandboxDeployHarnessRunner.Run` takes an `io.Writer` — a parameter
+rather than a field, because the harness is built once and shared and two deploys
+must not write into each other's stream.
+
+Stage granularity, not raw tofu output: it is what the plan asked for
+("init → plan → apply → register should scroll"), it is a predictable handful of
+lines, and it does not drown a terminal.
+
+**Retries are now visible.** A silent retry is indistinguishable from a slow
+stage, and a Layer 3 apply really does retry after a transient provider error.
+
+`TestProgressIsVisibleWhileTheApplyIsStillRunning` asserts what a watcher can see
+**from inside the apply**, which buffer-then-dump cannot satisfy. Verified by
+mutation: removing the stage reporting fails it.
+
+## Also fixed, all confirmed
+
+- **`deploying = false` in `resetDeployState` let a second real deploy start.**
+  Navigate away mid-deploy and back, and the button was enabled again — two
+  projects, double billing. A regression this slice introduced.
+- **`confirmDeploy`'s `finally` had no ownership guard.** An earlier deploy
+  finishing cleared a later one's state, freezing its log and putting a green
+  success message belonging to the first beneath it. Guarded by generation now.
+- **The last line raced the HTTP response.** `deployingScenario` was cleared
+  synchronously when the response landed, so the `Deployed as dep-…` line — the id
+  needed for `live teardown` — was filtered out. Cleared on navigation instead.
+- **A dropped socket rendered identically to "nothing has happened yet."** Now
+  distinguished: "not receiving progress" rather than "Starting…".
+- **The progress filter had no test**, because it was inline in the component and
+  no test ever reached it. Extracted to `$lib` and tested, including the typo that
+  killed the stream silently.
+- **The nil-progress test never reached the nil handling.** Its factory always
+  failed first, so deleting the guard entirely still passed while production would
+  panic. `deployStderr` is testable directly now.
+- **`Close()`'s comment claimed a bug it does not fix.** `deploy` terminates every
+  line, so Close flushes nothing for today's caller. It is a guarantee about the
+  type, and now says so.
+
+## The limit that stays, stated rather than implied
+
+The event subject is the **scenario**, not the deployment id — the id is minted
+inside the command, after the request is accepted. Two concurrent deploys of one
+scenario therefore share a stream and a reader sees both. Written down in
+`acceptProgressEvent`'s doc comment rather than left to be discovered.

--- a/docs/review-passes/pass132.md
+++ b/docs/review-passes/pass132.md
@@ -1,0 +1,67 @@
+# Review pass 132 — S163 rework, fresh-context correctness lens
+
+Five findings on the reworked slice. Four fixed, one recorded as a scoping gap.
+
+## 1. A stage that FAILED was reported as `done`
+
+`report.done()` ran before the error was inspected, so the last line a watcher saw
+on a failed deploy was `init: done in 2s` followed by silence. **A failure
+rendered as completion, and a stream that stops without saying why** — both of the
+specific things this project holds itself against, in the code written to prevent
+exactly that.
+
+Worse on the retry path: attempt 1's failure was named correctly, and attempt 2's
+was announced as `apply: done`.
+
+`TestEveryStageReportsItself` **actively pinned the wrong behaviour** by asserting
+`stage + ": done"` for every stage. It still does, for the passing case, which is
+why `TestAFailedStageIsNotReportedAsDone` had to exist alongside it rather than
+replace it.
+
+## 2 and 3. In-flight state died with the component
+
+Two findings, one cause. `resetDeployState` cleared the stream on navigation and
+`onDestroy` cleared it on unmount, so:
+
+- navigating away and back mid-deploy left a real, billable apply rendered as an
+  **unlabelled disabled button with no log and no warning** — the amber "cannot
+  see it" message was itself unreachable, because the panel it lives in was gated
+  on state that had just been cleared;
+- navigating to another *section* unmounted the component, so returning gave a
+  fresh one that believed nothing was running and would start a **second deploy of
+  the same scenario**. The server has no in-flight lock, so nothing else stops it.
+
+My own comment asserted that `deploying` "is the only thing that stops a second
+deploy" while sitting in a component that does not outlive the section.
+
+The fix is a module-level store keyed by scenario, owning the socket. State that
+must outlive the page cannot live in the page. Two e2e tests pin both journeys,
+including a full unmount.
+
+## 4. Deploy progress leaked into the Live Run page
+
+The hub broadcasts to every client and `/live` appends every message and refetches
+run state per event, so a deploy in one tab interleaved raw JSON into an unrelated
+run's log. Filtered.
+
+## 5. Recorded, not fixed: `run`/`test` still applies silently
+
+`test_command.go` passes `nil`, because `executeTestWithScenario` has no writer in
+scope — its progress goes through `runtime.Logger`, a structured API that needs an
+adapter. So the Layer 3 apply is still silent on the Live Run page, which is the
+**more commonly watched screen**.
+
+That is the same defect this slice exists to fix, on a different path, and calling
+it done would be the sort of claim the last two passes were about. Named here
+rather than implied away.
+
+## On the method
+
+Codex was unavailable; three fresh-context agents reviewed instead. They found the
+central defect in the first version — that the streaming did not stream — and then
+found five more in the fix, including one I introduced while fixing another.
+
+Worth recording honestly: the fix for finding 2 in the *previous* round created
+finding 2 in this one. Removing state on navigation was right for the confirmation
+dialog and wrong for the deploy stream, and I applied it to both because they had
+been folded into one function two passes earlier.

--- a/docs/review-passes/pass133.md
+++ b/docs/review-passes/pass133.md
@@ -1,0 +1,75 @@
+# Review pass 133 — S163 rework, adversarial-on-tests
+
+Nine findings, every one **verified by mutation**: the reviewer broke the
+production code and watched the suite stay green. Seven fixed, two recorded.
+
+## The shape of all of it: units tested, wiring not
+
+**F1** — `cmd.SetErr(&progressCopy)`, dropping the tee: whole Go suite green. The
+UI deploy log would be permanently empty, which is the original bug restored.
+**F2** — `Run(ctx, dir, env, nil)` at the deploy call site: green. Every stage line
+vanishes for CLI and UI alike.
+
+Both were invisible because `deployStderr` was tested in isolation and every test
+calling `Deploy` used a runtime factory that failed *before* the writer was ever
+touched. Each piece was covered; the path between them was not.
+
+**F3** — the API streaming test asserts content, not timing: a 4KB `bufio.Writer`
+between deployer and sink passed. The fixture writes and returns, so it cannot
+express "during" — the same wrong assumption as a buffering implementation.
+
+### One test closes all three
+
+`TestStageProgressReachesTheWebsocketThroughTheRealChain` drives the whole path:
+`LiveDeployer.Deploy` → `runDeployCommand` → the real `SandboxDeployHarness` →
+`ProgressSink` → `Hub` → what a websocket client would receive, with only the
+*subprocess* faked. It asserts what a browser could see **while the apply is still
+running**.
+
+Both of the reviewer's mutations now fail it, verified.
+
+That required exporting two seams — `harness.CommandRunnerFunc` and
+`api.NewTestClient` — and my first attempt at the test **skipped both broken
+points**, going harness→sink directly. It looked like coverage and would have
+closed nothing.
+
+## The stream promising things it will not do
+
+**F7** — `retrying` was pinned as a substring, so two mutations passed: announcing
+a retry on the *final* attempt, and announcing one on the **interrupt path** —
+where the operator has asked us to stop touching the API, and the last line they
+see would promise the opposite.
+
+Both now emit `giving up after N attempt(s)` instead, with tests that read the
+*last* line rather than searching the whole log.
+
+**F8** — the `FAILED` line's reason was unpinned, so dropping `%v` passed. A
+stream that stops without saying why is what `finished`'s own docstring exists to
+prevent.
+
+## The UI had no test that rendered a progress line at all
+
+**F4, F5, F6.** Every earlier e2e intercepts the POST in the browser, so the
+server never broadcasts. Replacing the whole `{#each}` with a constant string,
+hiding the disconnected banner entirely, and deleting the Live-page filter all
+passed the full suite.
+
+`page.routeWebSocket` lets the test be the server for the socket, so real frames
+reach the real filter and the real DOM. Three tests now cover rendering, subject
+scoping, and disconnected-vs-quiet; a fourth covers the Live-page leak. All three
+mutations fail, verified.
+
+## Recorded, not fixed
+
+- **`forgetDeploy` has no production caller.** A finished deploy's log and its
+  success banner reappear on every later visit to that scenario for the rest of
+  the session, long after the TTL expired. The store reads as self-cleaning and is
+  not.
+- **A page reload defeats the in-flight guard.** The store is module state with no
+  server-side lock and no rehydration, so reloading during a deploy re-enables the
+  button and a second run-owned-project deploy is one click away. My own comment
+  in `deploy-store.js` claims it is "the only thing standing between a reader and
+  that second deploy" — true, and it does not survive a refresh.
+
+Both are real and neither is a test problem. The second wants a server-side
+in-flight lock, which is a design decision rather than a patch.

--- a/internal/api/deployment_actions.go
+++ b/internal/api/deployment_actions.go
@@ -1,6 +1,9 @@
 package api
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 // ActionStep is one thing an action did, in the shape a page can render.
 //
@@ -36,6 +39,17 @@ type ActionResult struct {
 // persists are different kinds of harm, gated by different flags. A
 // server holding one of these interfaces cannot be talked into the
 // other.
+//
+// # Streaming
+//
+// Deploy takes an `io.Writer` for progress. A deploy runs for minutes,
+// and minutes of silence reads as broken -- the reader cannot tell a
+// long apply from a hung one, and the difference matters when the thing
+// running is creating billable infrastructure.
+//
+// The writer is supplied by the caller rather than the deployer reaching
+// for a hub, so this package keeps deciding what goes on the wire and
+// `internal/cli` keeps not knowing there is one.
 type DeploymentDeployer interface {
 	// Deploy applies a scenario and leaves it running under a TTL.
 	//
@@ -43,7 +57,7 @@ type DeploymentDeployer interface {
 	// deliberately cannot be told which project to use -- run-owned
 	// projects are created by the harness (ADR-0025), and a request that
 	// could name one is a request that could name somebody else's.
-	Deploy(ctx context.Context, scenarioName, ttl string) (ActionResult, error)
+	Deploy(ctx context.Context, scenarioName, ttl string, progress io.Writer) (ActionResult, error)
 }
 
 // DeploymentActor performs the destructive half of live management.

--- a/internal/api/handlers_deploy_test.go
+++ b/internal/api/handlers_deploy_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -27,14 +28,20 @@ type fakeDeployer struct {
 	deadline time.Time
 	hadDl    bool
 	ctxErr   error
+	// progressLines is written to the progress writer, so a test can
+	// assert what a watching client would have seen.
+	progressLines string
 }
 
-func (f *fakeDeployer) Deploy(ctx context.Context, name, ttl string) (ActionResult, error) {
+func (f *fakeDeployer) Deploy(ctx context.Context, name, ttl string, progress io.Writer) (ActionResult, error) {
 	f.calls = append(f.calls, name)
 	f.ttls = append(f.ttls, ttl)
 	f.sawCtx = ctx
 	f.ctxErr = ctx.Err()
 	f.deadline, f.hadDl = ctx.Deadline()
+	if progress != nil && f.progressLines != "" {
+		_, _ = io.WriteString(progress, f.progressLines)
+	}
 	return f.result, f.err
 }
 
@@ -197,4 +204,63 @@ func TestDeployStillReportsARealFailureAsAServerError(t *testing.T) {
 	rec := postDeploy(t, srv, `{"scenario":"lb-serving-paris"}`)
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// Minutes of silence reads as broken: a reader cannot tell a long apply
+// from a hung one, and the difference matters when the thing running is
+// creating billable infrastructure.
+func TestDeployStreamsItsProgressToWatchers(t *testing.T) {
+	hub := NewHub()
+	client := &Client{send: make(chan []byte, 256)}
+	hub.Register(client)
+
+	srv := NewServer(ServerConfig{
+		Config: config.Default(), Deployments: &fakeDeployments{}, Hub: hub,
+		Deployer: &fakeDeployer{
+			result:        ActionResult{Clean: true},
+			progressLines: "Deploying lb-serving-paris\n  workdir: /tmp/x\n",
+		},
+	})
+
+	rec := postDeploy(t, srv, `{"scenario":"lb-serving-paris"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var lines []string
+	var subjects []string
+	for {
+		select {
+		case raw := <-client.send:
+			var e struct {
+				Type string            `json:"type"`
+				Data map[string]string `json:"data"`
+			}
+			require.NoError(t, json.Unmarshal(raw, &e))
+			assert.Equal(t, "deploy_progress", e.Type)
+			lines = append(lines, e.Data["line"])
+			subjects = append(subjects, e.Data["subject"])
+		default:
+			// Indentation is PRESERVED. The deploy command indents
+			// sub-steps on purpose, and flattening them here would
+			// throw away structure the reader uses to see where they
+			// are in a multi-minute apply.
+			require.Equal(t, []string{"Deploying lb-serving-paris", "  workdir: /tmp/x"}, lines)
+			for _, s := range subjects {
+				assert.Equal(t, "lb-serving-paris", s,
+					"a line arriving on a page the reader moved to must say what it is about")
+			}
+			return
+		}
+	}
+}
+
+// A deploy must not depend on anybody watching.
+func TestDeployWorksWithNoHubConfigured(t *testing.T) {
+	srv := NewServer(ServerConfig{
+		Config: config.Default(), Deployments: &fakeDeployments{},
+		Deployer: &fakeDeployer{result: ActionResult{Clean: true}, progressLines: "working\n"},
+	})
+
+	rec := postDeploy(t, srv, `{"scenario":"lb-serving-paris"}`)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
 }

--- a/internal/api/handlers_deploy_test.go
+++ b/internal/api/handlers_deploy_test.go
@@ -253,8 +253,14 @@ func TestDeployStreamsItsProgressToWatchers(t *testing.T) {
 	}
 }
 
-// A deploy must not depend on anybody watching.
-func TestDeployWorksWithNoHubConfigured(t *testing.T) {
+// A deploy must not depend on anybody LISTENING: the hub exists but has
+// no clients, which is the ordinary case.
+//
+// Note this does not exercise the sink's nil-hub branch -- NewServer
+// substitutes a hub when ServerConfig.Hub is nil, so `state.hub` is
+// never nil here. That branch is covered directly by
+// TestProgressSinkWithNoHubIsHarmless.
+func TestDeployWorksWithNobodyListening(t *testing.T) {
 	srv := NewServer(ServerConfig{
 		Config: config.Default(), Deployments: &fakeDeployments{},
 		Deployer: &fakeDeployer{result: ActionResult{Clean: true}, progressLines: "working\n"},

--- a/internal/api/handlers_deployments.go
+++ b/internal/api/handlers_deployments.go
@@ -336,7 +336,13 @@ func deployHandler(state *serverState) http.HandlerFunc {
 		ctx, cancel := destructiveContext(r)
 		defer cancel()
 
-		result, err := state.deployer.Deploy(ctx, req.Scenario, req.TTL)
+		// Named with the scenario, so a line arriving on a page the
+		// reader has since navigated to says what it is about -- the
+		// rule S162c cost seven findings to learn.
+		progress := NewProgressSink(state.hub, "deploy_progress", req.Scenario)
+		defer progress.Close()
+
+		result, err := state.deployer.Deploy(ctx, req.Scenario, req.TTL, progress)
 		if errors.Is(err, os.ErrNotExist) {
 			// The caller named something that is not here. A client
 			// typo or a stale scenario list is not a server fault, and

--- a/internal/api/hub.go
+++ b/internal/api/hub.go
@@ -68,3 +68,24 @@ func (h *Hub) Run(ctx context.Context) {
 		close(c.send)
 	}
 }
+
+// NewTestClient builds a hub client with no connection.
+//
+// Broadcast never touches the socket, so a test can observe exactly what
+// a browser would receive without one. Exported because the wiring this
+// supports crosses package boundaries: `internal/cli` needs to assert
+// that stage progress reaches a websocket subscriber, and that path was
+// broken twice while every unit test passed.
+func NewTestClient(buffer int) *Client {
+	return &Client{send: make(chan []byte, buffer)}
+}
+
+// TryReceive takes the next queued message, if any.
+func (c *Client) TryReceive() ([]byte, bool) {
+	select {
+	case msg := <-c.send:
+		return msg, true
+	default:
+		return nil, false
+	}
+}

--- a/internal/api/progress_sink.go
+++ b/internal/api/progress_sink.go
@@ -68,9 +68,13 @@ func (s *ProgressSink) Write(p []byte) (int, error) {
 
 // Close flushes whatever did not end in a newline.
 //
-// A command's last line often has no trailing newline, and it is
-// frequently the one that matters -- "Deployed as dep-…". Dropping it
-// would end the stream one line short of the conclusion.
+// Worth being precise about, because an earlier version of this comment
+// was not: `deploy` terminates every line it writes, so for TODAY'S
+// caller Close has nothing to flush in any state. It is not dead code —
+// a writer that buffers to newlines drops a trailing partial line by
+// construction, and the next caller to write one would lose it silently,
+// which is the failure this whole file exists to avoid. It is a
+// guarantee about the type, not a fix for an observed bug.
 func (s *ProgressSink) Close() error {
 	if s == nil {
 		return nil

--- a/internal/api/progress_sink.go
+++ b/internal/api/progress_sink.go
@@ -1,0 +1,101 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"sync"
+)
+
+// ProgressSink turns a command's progress output into websocket events,
+// one per line (S163).
+//
+// # Why lines, and not writes
+//
+// `WebSocketSink` broadcasts each Write as it arrives. A command writing
+// with several Fprintf calls, or a subprocess flushing on a buffer
+// boundary, produces fragments -- and a page appending fragments shows
+// half a word, then the rest of it on the next row. Buffering to newline
+// costs nothing and makes the output mean what it says.
+//
+// # Why every event names its subject
+//
+// A deploy takes minutes and the reader can navigate during it, so these
+// events arrive on whatever page is open. An unattributed progress line
+// is a statement about something the reader may not be looking at --
+// exactly what cost S162c seven review findings. The subject travels
+// with every line so a client can filter, label, or ignore it.
+type ProgressSink struct {
+	hub     *Hub
+	kind    string
+	subject string
+
+	mu      sync.Mutex
+	partial bytes.Buffer
+}
+
+// NewProgressSink builds a sink. `kind` is the event type a client
+// switches on ("deploy_progress"); `subject` is what the events are
+// about.
+func NewProgressSink(hub *Hub, kind, subject string) *ProgressSink {
+	return &ProgressSink{hub: hub, kind: kind, subject: subject}
+}
+
+func (s *ProgressSink) Write(p []byte) (int, error) {
+	if s == nil {
+		return len(p), nil
+	}
+
+	s.mu.Lock()
+	s.partial.Write(p)
+
+	var lines []string
+	for {
+		buffered := s.partial.Bytes()
+		idx := bytes.IndexByte(buffered, '\n')
+		if idx < 0 {
+			break
+		}
+		lines = append(lines, string(bytes.TrimRight(buffered[:idx], "\r")))
+		s.partial.Next(idx + 1)
+	}
+	s.mu.Unlock()
+
+	for _, line := range lines {
+		s.emit(line)
+	}
+	return len(p), nil
+}
+
+// Close flushes whatever did not end in a newline.
+//
+// A command's last line often has no trailing newline, and it is
+// frequently the one that matters -- "Deployed as dep-…". Dropping it
+// would end the stream one line short of the conclusion.
+func (s *ProgressSink) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	tail := s.partial.String()
+	s.partial.Reset()
+	s.mu.Unlock()
+
+	if tail != "" {
+		s.emit(tail)
+	}
+	return nil
+}
+
+func (s *ProgressSink) emit(line string) {
+	if s.hub == nil || line == "" {
+		return
+	}
+	payload, err := json.Marshal(map[string]any{
+		"type": s.kind,
+		"data": map[string]string{"subject": s.subject, "line": line},
+	})
+	if err != nil {
+		return
+	}
+	s.hub.Broadcast(payload)
+}

--- a/internal/api/progress_sink_test.go
+++ b/internal/api/progress_sink_test.go
@@ -156,3 +156,15 @@ func TestProgressSinkIsSafeUnderConcurrentWrites(t *testing.T) {
 		assert.Equal(t, "aaaa", e.Data["line"], "a line must not be interleaved with another")
 	}
 }
+
+// The nil-HUB branch, which the server-level test cannot reach because
+// NewServer substitutes a hub when none is configured.
+func TestProgressSinkWithNoHubIsHarmless(t *testing.T) {
+	sink := NewProgressSink(nil, "deploy_progress", "lb-serving-paris")
+
+	n, err := sink.Write([]byte("a line\n"))
+
+	require.NoError(t, err)
+	assert.Equal(t, len("a line\n"), n, "the writer must still consume everything")
+	require.NoError(t, sink.Close())
+}

--- a/internal/api/progress_sink_test.go
+++ b/internal/api/progress_sink_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordedEvent is what would go over the wire.
+type recordedEvent struct {
+	Type string            `json:"type"`
+	Data map[string]string `json:"data"`
+}
+
+// sinkFor wires a sink to a hub with one subscriber, and returns a
+// reader for whatever has been broadcast so far.
+//
+// The reader DRAINS: call it once per assertion block and keep the
+// result.
+//
+// The subscriber is a Client with only its send channel: Broadcast never
+// touches the connection, so a test does not need a real websocket to
+// observe what a client would receive.
+func sinkFor(t *testing.T, subject string) (*ProgressSink, func() []recordedEvent) {
+	t.Helper()
+
+	hub := NewHub()
+	client := &Client{send: make(chan []byte, 256)}
+	hub.Register(client)
+
+	sink := NewProgressSink(hub, "deploy_progress", subject)
+
+	return sink, func() []recordedEvent {
+		var out []recordedEvent
+		for {
+			select {
+			case raw := <-client.send:
+				var e recordedEvent
+				require.NoError(t, json.Unmarshal(raw, &e))
+				out = append(out, e)
+			default:
+				return out
+			}
+		}
+	}
+}
+
+// A command writing with several Fprintf calls produces fragments, and a
+// page appending fragments shows half a word then the rest of it on the
+// next row.
+func TestProgressSinkEmitsWholeLinesNotWrites(t *testing.T) {
+	sink, events := sinkFor(t, "lb-serving-paris")
+
+	_, _ = sink.Write([]byte("Deploying lb-"))
+	_, _ = sink.Write([]byte("serving-paris\nworkdir: /tmp/x\n"))
+
+	got := events()
+	require.Len(t, got, 2)
+	assert.Equal(t, "Deploying lb-serving-paris", got[0].Data["line"])
+	assert.Equal(t, "workdir: /tmp/x", got[1].Data["line"])
+}
+
+// A deploy takes minutes and the reader can navigate during it, so these
+// events arrive on whatever page is open. An unattributed line is a
+// statement about something they may not be looking at.
+func TestProgressSinkNamesItsSubjectOnEveryLine(t *testing.T) {
+	sink, events := sinkFor(t, "lb-serving-paris")
+
+	_, _ = sink.Write([]byte("one\ntwo\n"))
+
+	for _, e := range events() {
+		assert.Equal(t, "lb-serving-paris", e.Data["subject"])
+		assert.Equal(t, "deploy_progress", e.Type)
+	}
+}
+
+// A command's last line often has no trailing newline, and it is
+// frequently the one that matters.
+func TestProgressSinkFlushesTheLastLineOnClose(t *testing.T) {
+	sink, events := sinkFor(t, "lb-serving-paris")
+
+	_, _ = sink.Write([]byte("Deployed as dep-20260902"))
+	require.NoError(t, sink.Close())
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "Deployed as dep-20260902", got[0].Data["line"])
+}
+
+func TestProgressSinkCloseIsQuietWhenNothingIsBuffered(t *testing.T) {
+	sink, events := sinkFor(t, "x")
+
+	_, _ = sink.Write([]byte("done\n"))
+	require.NoError(t, sink.Close())
+
+	assert.Len(t, events(), 1, "close must not repeat the last line")
+}
+
+// Blank lines carry no information and would pad the stream.
+func TestProgressSinkDropsEmptyLines(t *testing.T) {
+	sink, events := sinkFor(t, "x")
+
+	_, _ = sink.Write([]byte("\n\nreal\n\n"))
+
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "real", got[0].Data["line"])
+}
+
+// Windows-style line endings must not leave a stray carriage return that
+// a browser renders as a box.
+func TestProgressSinkTrimsCarriageReturns(t *testing.T) {
+	sink, events := sinkFor(t, "x")
+
+	_, _ = sink.Write([]byte("line\r\n"))
+
+	// Captured once: the reader drains the channel, so calling it twice
+	// returns nothing the second time.
+	got := events()
+	require.Len(t, got, 1)
+	assert.Equal(t, "line", got[0].Data["line"])
+}
+
+// A nil sink is a no-op rather than a panic: the caller passes one when
+// there is no hub, and a deploy must not die because nobody is watching.
+func TestNilProgressSinkIsHarmless(t *testing.T) {
+	var sink *ProgressSink
+
+	n, err := sink.Write([]byte("anything"))
+
+	require.NoError(t, err)
+	assert.Equal(t, len("anything"), n)
+	require.NoError(t, sink.Close())
+}
+
+// Concurrent writers must not interleave inside a line.
+func TestProgressSinkIsSafeUnderConcurrentWrites(t *testing.T) {
+	sink, events := sinkFor(t, "x")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = sink.Write([]byte("aaaa\n"))
+		}()
+	}
+	wg.Wait()
+
+	got := events()
+	assert.Len(t, got, 20)
+	for _, e := range got {
+		assert.Equal(t, "aaaa", e.Data["line"], "a line must not be interleaved with another")
+	}
+}

--- a/internal/cli/deploy_command.go
+++ b/internal/cli/deploy_command.go
@@ -144,7 +144,10 @@ func runDeployCommand(cmd *cobra.Command, args []string, runtime *CommandRuntime
 			return nil, envErr
 		}
 
-		return runtime.Deps.SandboxDeploy.Run(applyCtx, workDir, sandboxEnv)
+		// `progress` is the caller's stream -- the terminal for a CLI
+		// deploy, and the websocket for a UI one. Without it the apply
+		// is silent for minutes, which reads as hung (S163).
+		return runtime.Deps.SandboxDeploy.Run(applyCtx, workDir, sandboxEnv, progress)
 	})
 
 	stages := append([]StageSummary{}, runProjectStages...)

--- a/internal/cli/deploy_command_test.go
+++ b/internal/cli/deploy_command_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -299,7 +300,7 @@ func TestDeployRecordsTheProjectEvenWhenTheApplyCreatedNothing(t *testing.T) {
 // resources already created: an error AND a state file naming them.
 type partialApplyHarness struct{ calls int }
 
-func (p *partialApplyHarness) Run(_ context.Context, workDir string, _ map[string]string) (*harness.SandboxDeployResult, error) {
+func (p *partialApplyHarness) Run(_ context.Context, workDir string, _ map[string]string, _ io.Writer) (*harness.SandboxDeployResult, error) {
 	p.calls++
 	_ = os.MkdirAll(workDir, 0o755)
 	_ = os.WriteFile(filepath.Join(workDir, harness.LiveStateFilename), []byte(

--- a/internal/cli/deploy_command_test.go
+++ b/internal/cli/deploy_command_test.go
@@ -54,7 +54,7 @@ acceptance_criteria:
 
 // deployTestRuntime wires a Layer-3-enabled runtime with fakes and
 // workspace-scoped output and live-store roots.
-func deployTestRuntime(t *testing.T, scenarioYAML string, deploy *fakeSandboxDeployHarness) (*CommandRuntime, *livestore.FilesystemStore, string) {
+func deployTestRuntime(t *testing.T, scenarioYAML string, deploy SandboxDeployHarnessRunner) (*CommandRuntime, *livestore.FilesystemStore, string) {
 	t.Helper()
 	h := newCommandTestHarness(t)
 

--- a/internal/cli/deploy_streaming_wiring_test.go
+++ b/internal/cli/deploy_streaming_wiring_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redscaresu/infrafactory/internal/api"
+	"github.com/redscaresu/infrafactory/internal/harness"
+)
+
+// The WIRING, end to end, with nothing faked between the harness and the
+// websocket.
+//
+// Every piece of this path was unit-tested and the path itself was not,
+// which is how the original slice shipped a feature that did not
+// function. A review demonstrated two one-line mutations that broke it
+// completely while the whole Go suite stayed green:
+//
+//   - `cmd.SetErr(&progressCopy)` — drop the tee, and the UI log is
+//     permanently empty;
+//   - `Run(ctx, dir, env, nil)` — drop the writer at the call site, and
+//     every stage line vanishes.
+//
+// Both are invisible to tests that check `deployStderr` in isolation and
+// tests that call `Deploy` with a runtime that fails before it is used.
+// This asserts the whole chain: real harness → real progress plumbing →
+// real ProgressSink → real hub → what a browser would receive.
+func TestStageProgressReachesTheWebsocketThroughTheRealChain(t *testing.T) {
+	hub := api.NewHub()
+	client := api.NewTestClient(256)
+	hub.Register(client)
+
+	// The REAL harness, with only the subprocess faked -- that is the
+	// only seam a test may cut here, because everything above it is
+	// what shipped broken. It records what a websocket client could see
+	// while the apply was still running.
+	var duringApply []string
+	runner := harness.CommandRunnerFunc(func(_ context.Context, cmd harness.Command) (harness.CommandResult, error) {
+		if len(cmd.Args) > 0 && cmd.Args[0] == "apply" {
+			duringApply = drainProgress(client)
+		}
+		return harness.CommandResult{Stdout: []byte("ok")}, nil
+	})
+
+	rt, _, scenarioPath := deployTestRuntime(t, liveServiceScenarioYAML, harness.NewSandboxDeployHarness(runner))
+	writeDeployableHCL(t, rt.OutputDir())
+	t.Setenv("SCW_ACCESS_KEY", "test-access")
+	t.Setenv("SCW_SECRET_KEY", "test-secret")
+	t.Setenv("SCW_DEFAULT_ORGANIZATION_ID", "org-1")
+
+	// Through LiveDeployer, so the tee inside it is on the path too.
+	deployer := NewLiveDeployer(filepath.Dir(scenarioPath), func() (*CommandRuntime, error) {
+		return rt, nil
+	})
+
+	sink := api.NewProgressSink(hub, "deploy_progress", "web-live-paris")
+	_, err := deployer.Deploy(context.Background(), "web-live-paris", "", sink)
+	require.NoError(t, err)
+	require.NoError(t, sink.Close())
+
+	seen := strings.Join(duringApply, "\n")
+	assert.Contains(t, seen, "init: running",
+		"a browser must learn init happened before the apply finishes")
+	assert.Contains(t, seen, "apply: running",
+		"and that the apply is what is taking the time")
+}
+
+// drainProgress reads the deploy_progress lines a websocket client would
+// have received so far.
+func drainProgress(client *api.Client) []string {
+	var out []string
+	for {
+		raw, ok := client.TryReceive()
+		if !ok {
+			return out
+		}
+		var event struct {
+			Type string            `json:"type"`
+			Data map[string]string `json:"data"`
+		}
+		if err := json.Unmarshal(raw, &event); err != nil {
+			continue
+		}
+		if event.Type == "deploy_progress" {
+			out = append(out, strings.TrimSpace(event.Data["line"]))
+		}
+	}
+}

--- a/internal/cli/live_service.go
+++ b/internal/cli/live_service.go
@@ -215,11 +215,7 @@ func (d *LiveDeployer) Deploy(ctx context.Context, scenarioName, ttl string, pro
 	// no structured output can still be explained.
 	var out, progressCopy strings.Builder
 	cmd.SetOut(&out)
-	if progress != nil {
-		cmd.SetErr(io.MultiWriter(progress, &progressCopy))
-	} else {
-		cmd.SetErr(&progressCopy)
-	}
+	cmd.SetErr(deployStderr(progress, &progressCopy))
 	cmd.SetContext(ctx)
 
 	deployErr := runDeployCommand(cmd, []string{path}, runtime)
@@ -235,6 +231,23 @@ func (d *LiveDeployer) Deploy(ctx context.Context, scenarioName, ttl string, pro
 		result.Clean = false
 	}
 	return result, nil
+}
+
+// deployStderr builds the command's stderr: live to the caller if there
+// is one, and always into a copy.
+//
+// Split out because it is the only place a nil progress writer is
+// handled, and a test that never gets past building a runtime cannot
+// reach it -- which is exactly what the first attempt at covering this
+// did.
+//
+// io.MultiWriter would store a nil io.Writer and panic on the first
+// write, so the nil case must not reach it.
+func deployStderr(progress io.Writer, copy io.Writer) io.Writer {
+	if progress == nil {
+		return copy
+	}
+	return io.MultiWriter(progress, copy)
 }
 
 // deployOutcome turns the command's JSON output into the neutral shape.

--- a/internal/cli/live_service.go
+++ b/internal/cli/live_service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -180,7 +181,7 @@ func NewLiveDeployer(scenarioRoot string, newRuntime func() (*CommandRuntime, er
 }
 
 // Deploy applies a scenario and leaves it running under a TTL.
-func (d *LiveDeployer) Deploy(ctx context.Context, scenarioName, ttl string) (api.ActionResult, error) {
+func (d *LiveDeployer) Deploy(ctx context.Context, scenarioName, ttl string, progress io.Writer) (api.ActionResult, error) {
 	// A NAME, resolved here, never a path from the caller. `deploy`
 	// takes a filesystem path, and accepting one over HTTP would let a
 	// request name any YAML on the machine -- including one outside the
@@ -206,16 +207,24 @@ func (d *LiveDeployer) Deploy(ctx context.Context, scenarioName, ttl string) (ap
 		}
 	}
 
-	// Output is captured rather than printed: this is an API call, and
-	// the command's stdout contract is not the response body.
-	var out, progress strings.Builder
+	// stdout is CAPTURED -- it carries the machine-output contract that
+	// deployOutcome parses, and is not the response body.
+	//
+	// stderr is TEE'd: the command's human progress goes to the caller's
+	// writer as it happens, and is also kept so a failure that produced
+	// no structured output can still be explained.
+	var out, progressCopy strings.Builder
 	cmd.SetOut(&out)
-	cmd.SetErr(&progress)
+	if progress != nil {
+		cmd.SetErr(io.MultiWriter(progress, &progressCopy))
+	} else {
+		cmd.SetErr(&progressCopy)
+	}
 	cmd.SetContext(ctx)
 
 	deployErr := runDeployCommand(cmd, []string{path}, runtime)
 
-	result := deployOutcome(out.String(), progress.String(), deployErr)
+	result := deployOutcome(out.String(), progressCopy.String(), deployErr)
 	if deployErr != nil && result.Failures == nil {
 		// The command failed before it produced structured output --
 		// a usage error, a missing scenario. Surfacing the raw error

--- a/internal/cli/live_service_test.go
+++ b/internal/cli/live_service_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -261,4 +263,35 @@ func TestDeployerAcceptsANilProgressWriter(t *testing.T) {
 	// takes it. The point is that nil did not panic on the way.
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not building a real runtime")
+}
+
+// The nil-progress path, reached directly.
+//
+// The previous attempt at this asserted through Deploy() with a runtime
+// factory that always failed, so it returned before `progress` was ever
+// touched: deleting the nil guard entirely still passed, while
+// production would panic on the first write for exactly the caller the
+// test named.
+func TestDeployStderrHandlesANilProgressWriter(t *testing.T) {
+	var copy strings.Builder
+
+	w := deployStderr(nil, &copy)
+
+	require.NotNil(t, w)
+	_, err := io.WriteString(w, "a line\n")
+	require.NoError(t, err, "io.MultiWriter would store the nil writer and panic here")
+	assert.Equal(t, "a line\n", copy.String())
+}
+
+// And with a writer, both destinations get it: the stream goes out live
+// AND is kept, so a failure producing no structured output can still be
+// explained.
+func TestDeployStderrTeesToBoth(t *testing.T) {
+	var live, copy strings.Builder
+
+	_, err := io.WriteString(deployStderr(&live, &copy), "a line\n")
+
+	require.NoError(t, err)
+	assert.Equal(t, "a line\n", live.String())
+	assert.Equal(t, "a line\n", copy.String())
 }

--- a/internal/cli/live_service_test.go
+++ b/internal/cli/live_service_test.go
@@ -201,7 +201,7 @@ func TestDeployerBuildsAFreshRuntimeForEachDeploy(t *testing.T) {
 	})
 
 	for _, name := range []string{"first-scenario", "second-scenario"} {
-		_, err := deployer.Deploy(context.Background(), name, "")
+		_, err := deployer.Deploy(context.Background(), name, "", nil)
 		require.Error(t, err)
 	}
 
@@ -218,7 +218,7 @@ func TestDeployerRefusesAnUnknownScenarioBeforeBuildingAnything(t *testing.T) {
 		return nil, errors.New("should not be reached")
 	})
 
-	_, err := deployer.Deploy(context.Background(), "no-such-scenario", "")
+	_, err := deployer.Deploy(context.Background(), "no-such-scenario", "", nil)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no scenario named")
@@ -246,4 +246,19 @@ acceptance_criteria:
 		require.NoError(t, os.WriteFile(filepath.Join(root, name+".yaml"), body, 0o644))
 	}
 	return root
+}
+
+// A deploy must not depend on anybody watching: a nil progress writer is
+// the ordinary case for a caller that has no hub.
+func TestDeployerAcceptsANilProgressWriter(t *testing.T) {
+	deployer := NewLiveDeployer(twoScenarios(t), func() (*CommandRuntime, error) {
+		return nil, errors.New("not building a real runtime in a unit test")
+	})
+
+	_, err := deployer.Deploy(context.Background(), "first-scenario", "", nil)
+
+	// It reaches the runtime factory, which is as far as a unit test
+	// takes it. The point is that nil did not panic on the way.
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not building a real runtime")
 }

--- a/internal/cli/live_upgrade.go
+++ b/internal/cli/live_upgrade.go
@@ -191,7 +191,7 @@ func runLiveUpgradeCommand(cmd *cobra.Command, args []string, runtime *CommandRu
 	}
 
 	applyResult, applyErr := runDeployApply(cmd, ctx, signal.NotifyContext, func(applyCtx context.Context) (*harness.SandboxDeployResult, error) {
-		return runtime.Deps.SandboxDeploy.Run(applyCtx, d.WorkDir, sandboxEnv)
+		return runtime.Deps.SandboxDeploy.Run(applyCtx, d.WorkDir, sandboxEnv, progress)
 	})
 	stages, failures = appendSandboxDeployResult(stages, failures, applyResult, applyErr)
 

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,7 +30,14 @@ type DestroyHarnessRunner interface {
 }
 
 type SandboxDeployHarnessRunner interface {
-	Run(context.Context, string, map[string]string) (*harness.SandboxDeployResult, error)
+	// The io.Writer receives STAGE progress as the apply proceeds.
+	//
+	// It is a parameter rather than a field on the harness because the
+	// harness is built once and shared, and two deploys running at once
+	// must not write into each other's stream.
+	//
+	// nil is the ordinary case for a caller with nowhere to send it.
+	Run(context.Context, string, map[string]string, io.Writer) (*harness.SandboxDeployResult, error)
 }
 
 type SandboxDestroyHarnessRunner interface {

--- a/internal/cli/sandbox_env_test.go
+++ b/internal/cli/sandbox_env_test.go
@@ -92,7 +92,7 @@ func TestSandboxHarnessesDeclareStripEnv(t *testing.T) {
 	}
 
 	recorder := &recordingRunner{}
-	if _, err := harness.NewSandboxDeployHarness(recorder).Run(context.Background(), t.TempDir(), map[string]string{}); err != nil {
+	if _, err := harness.NewSandboxDeployHarness(recorder).Run(context.Background(), t.TempDir(), map[string]string{}, nil); err != nil {
 		t.Fatalf("sandbox deploy: %v", err)
 	}
 	if _, err := harness.NewSandboxDestroyHarness(recorder).Run(context.Background(), t.TempDir(), map[string]string{}); err != nil {

--- a/internal/cli/test_command.go
+++ b/internal/cli/test_command.go
@@ -640,7 +640,7 @@ func executeTestWithScenario(ctx context.Context, runtime *CommandRuntime, sc sc
 			// HCL comes from a pull request, which is precisely where an
 			// unvetted resource type would arrive from.
 			{
-				sandboxResult, sandboxErr := runtime.Deps.SandboxDeploy.Run(ctx, outputDir, sandboxEnv)
+				sandboxResult, sandboxErr := runtime.Deps.SandboxDeploy.Run(ctx, outputDir, sandboxEnv, nil)
 				stages, failures = appendSandboxDeployResult(stages, failures, sandboxResult, sandboxErr)
 				if sandboxResult != nil && len(sandboxResult.Plan.Stdout) > 0 {
 					planLiveText = []byte(sandboxResult.Plan.Stdout)

--- a/internal/cli/test_command_test.go
+++ b/internal/cli/test_command_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,7 +65,7 @@ type fakeSandboxDeployHarness struct {
 // destroy, so a fake apply that leaves no state makes every Layer 3 test
 // fail at capture -- which is correct fail-closed behaviour, just not
 // what these tests are exercising.
-func (f *fakeSandboxDeployHarness) Run(ctx context.Context, workDir string, _ map[string]string) (*harness.SandboxDeployResult, error) {
+func (f *fakeSandboxDeployHarness) Run(ctx context.Context, workDir string, _ map[string]string, _ io.Writer) (*harness.SandboxDeployResult, error) {
 	f.calls++
 	f.lastCtx = ctx
 	if f.err == nil && workDir != "" {

--- a/internal/harness/sandbox_apply_retry_test.go
+++ b/internal/harness/sandbox_apply_retry_test.go
@@ -51,7 +51,7 @@ func TestSandboxApplyRetriesOnceAfterTransientFailure(t *testing.T) {
 		okResp(),  // apply #2 -- succeeds
 	}}
 
-	result, err := NewSandboxDeployHarness(runner).Run(context.Background(), t.TempDir(), nil)
+	result, err := NewSandboxDeployHarness(runner).Run(context.Background(), t.TempDir(), nil, nil)
 
 	if err != nil {
 		t.Fatalf("expected the retry to recover the apply, got %v", err)
@@ -74,7 +74,7 @@ func TestSandboxApplyStopsAfterBoundedAttempts(t *testing.T) {
 		errResp(), // apply #2
 	}}
 
-	_, err := NewSandboxDeployHarness(runner).Run(context.Background(), t.TempDir(), nil)
+	_, err := NewSandboxDeployHarness(runner).Run(context.Background(), t.TempDir(), nil, nil)
 
 	if err == nil {
 		t.Fatal("expected the deploy to fail after both attempts")
@@ -109,7 +109,7 @@ func TestSandboxApplyDoesNotRetryAfterCancellation(t *testing.T) {
 		cancelFunc: cancel,
 	}
 
-	_, err := NewSandboxDeployHarness(runner).Run(ctx, t.TempDir(), nil)
+	_, err := NewSandboxDeployHarness(runner).Run(ctx, t.TempDir(), nil, nil)
 
 	if err == nil {
 		t.Fatal("expected a cancelled apply to fail")
@@ -122,7 +122,7 @@ func TestSandboxApplyDoesNotRetryAfterCancellation(t *testing.T) {
 func TestSandboxApplyRecordsSingleAttemptOnFirstTrySuccess(t *testing.T) {
 	runner := &scriptedRunner{responses: []runnerResponse{okResp(), okResp(), okResp()}}
 
-	result, err := NewSandboxDeployHarness(runner).Run(context.Background(), t.TempDir(), nil)
+	result, err := NewSandboxDeployHarness(runner).Run(context.Background(), t.TempDir(), nil, nil)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/harness/sandbox_deploy.go
+++ b/internal/harness/sandbox_deploy.go
@@ -138,10 +138,24 @@ func (p stageProgress) start(stage string) time.Time {
 	return time.Now()
 }
 
-func (p stageProgress) done(stage string, started time.Time) {
-	if p.out != nil {
-		_, _ = fmt.Fprintf(p.out, "  %s: done in %s\n", stage, time.Since(started).Round(time.Second))
+// finished reports how a stage ENDED, which is not the same as that it
+// ended.
+//
+// Reporting every stage as "done" regardless of its error made the last
+// line a watcher saw on a failed deploy `init: done in 2s`, followed by
+// silence -- a failure rendered as completion, and a stream that stops
+// without saying why. Both are the specific sins this project holds
+// itself against.
+func (p stageProgress) finished(stage string, started time.Time, err error) {
+	if p.out == nil {
+		return
 	}
+	elapsed := time.Since(started).Round(time.Second)
+	if err != nil {
+		_, _ = fmt.Fprintf(p.out, "  %s: FAILED after %s: %v\n", stage, elapsed, err)
+		return
+	}
+	_, _ = fmt.Fprintf(p.out, "  %s: done in %s\n", stage, elapsed)
 }
 
 // retrying is reported because a silent retry is indistinguishable from
@@ -166,7 +180,7 @@ func (h *SandboxDeployHarness) Run(ctx context.Context, workDir string, env map[
 	}
 	initStarted := report.start("init")
 	initResult, err := h.runner.Run(ctx, initCmd)
-	report.done("init", initStarted)
+	report.finished("init", initStarted, err)
 	initStage := StageResult{
 		Stage:  "init",
 		Cmd:    []string{"tofu", "init"},
@@ -190,7 +204,7 @@ func (h *SandboxDeployHarness) Run(ctx context.Context, workDir string, env map[
 	}
 	planStarted := report.start("plan")
 	planResult, err := h.runner.Run(ctx, planCmd)
-	report.done("plan", planStarted)
+	report.finished("plan", planStarted, err)
 	planStage := StageResult{
 		Stage:  "plan",
 		Cmd:    []string{"tofu", "plan", "-state=" + LiveStateFilename},
@@ -220,7 +234,7 @@ func (h *SandboxDeployHarness) Run(ctx context.Context, workDir string, env map[
 		applyStarted := report.start("apply")
 		var applyResult CommandResult
 		applyResult, err = h.runner.Run(ctx, applyCmd)
-		report.done("apply", applyStarted)
+		report.finished("apply", applyStarted, err)
 		applyStage = StageResult{
 			Stage:  "apply",
 			Cmd:    []string{"tofu", "apply", "-auto-approve", "-state=" + LiveStateFilename},

--- a/internal/harness/sandbox_deploy.go
+++ b/internal/harness/sandbox_deploy.go
@@ -168,6 +168,18 @@ func (p stageProgress) retrying(stage string, attempt, of int, err error) {
 	}
 }
 
+// givingUp is the other half, and it exists because "retrying" said on
+// the last attempt is a promise the code does not keep.
+//
+// The interrupt path is worse: there the operator has asked us to stop
+// touching the API, and a stream whose final line announces a retry says
+// the opposite of what is about to happen.
+func (p stageProgress) givingUp(stage string, attempts int) {
+	if p.out != nil {
+		_, _ = fmt.Fprintf(p.out, "  %s: giving up after %d attempt(s)\n", stage, attempts)
+	}
+}
+
 func (h *SandboxDeployHarness) Run(ctx context.Context, workDir string, env map[string]string, progress io.Writer) (*SandboxDeployResult, error) {
 	report := stageProgress{out: progress}
 
@@ -249,11 +261,16 @@ func (h *SandboxDeployHarness) Run(ctx context.Context, workDir string, env map[
 		// retry here would create exactly what the operator asked us to
 		// stop creating.
 		if ctx.Err() != nil {
+			// Cancelled. Announcing a retry here would promise exactly
+			// what the operator asked us to stop doing.
+			report.givingUp("apply", attempts)
 			break
 		}
 		if attempts < sandboxApplyAttempts {
 			report.retrying("apply", attempts, sandboxApplyAttempts, err)
+			continue
 		}
+		report.givingUp("apply", attempts)
 	}
 	if err != nil {
 		return nil, &SandboxDeployError{

--- a/internal/harness/sandbox_deploy.go
+++ b/internal/harness/sandbox_deploy.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"time"
 )
 
 const LiveStateFilename = "terraform-live.tfstate"
@@ -107,7 +109,54 @@ func (e *SandboxDeployError) Is(target error) bool {
 	return target == ErrSandboxDeployFailed
 }
 
-func (h *SandboxDeployHarness) Run(ctx context.Context, workDir string, env map[string]string) (*SandboxDeployResult, error) {
+// stageProgress reports what the harness is doing, as it does it.
+//
+// # Why the harness has to be the one reporting
+//
+// A Layer 3 apply takes minutes, and until this existed the only thing
+// written to a caller's progress stream during all of it was nothing.
+// `CommandRunner.Run` returns a fully buffered `CommandResult`, so
+// `tofu`'s own output does not exist until each process exits -- there
+// is no stream to tee. The harness is the only place that knows a stage
+// has BEGUN.
+//
+// Stage granularity rather than raw tofu output, deliberately: it is
+// what a reader needs ("where is it up to?"), it is a predictable
+// handful of lines rather than a wall of provider chatter, and it does
+// not change what `infrafactory deploy` prints beyond a few lines.
+//
+// A nil writer is the ordinary case for callers that have nowhere to
+// send it, and must cost nothing.
+type stageProgress struct {
+	out io.Writer
+}
+
+func (p stageProgress) start(stage string) time.Time {
+	if p.out != nil {
+		_, _ = fmt.Fprintf(p.out, "  %s: running\n", stage)
+	}
+	return time.Now()
+}
+
+func (p stageProgress) done(stage string, started time.Time) {
+	if p.out != nil {
+		_, _ = fmt.Fprintf(p.out, "  %s: done in %s\n", stage, time.Since(started).Round(time.Second))
+	}
+}
+
+// retrying is reported because a silent retry is indistinguishable from
+// a stage that is simply slow -- and a Layer 3 apply really does retry
+// after a transient provider error, which a reader watching a frozen log
+// would otherwise read as hung.
+func (p stageProgress) retrying(stage string, attempt, of int, err error) {
+	if p.out != nil {
+		_, _ = fmt.Fprintf(p.out, "  %s: attempt %d of %d failed (%v); retrying\n", stage, attempt, of, err)
+	}
+}
+
+func (h *SandboxDeployHarness) Run(ctx context.Context, workDir string, env map[string]string, progress io.Writer) (*SandboxDeployResult, error) {
+	report := stageProgress{out: progress}
+
 	initCmd := Command{
 		Name:     "tofu",
 		Args:     []string{"init"},
@@ -115,7 +164,9 @@ func (h *SandboxDeployHarness) Run(ctx context.Context, workDir string, env map[
 		Env:      env,
 		StripEnv: SandboxStripEnv,
 	}
+	initStarted := report.start("init")
 	initResult, err := h.runner.Run(ctx, initCmd)
+	report.done("init", initStarted)
 	initStage := StageResult{
 		Stage:  "init",
 		Cmd:    []string{"tofu", "init"},
@@ -137,7 +188,9 @@ func (h *SandboxDeployHarness) Run(ctx context.Context, workDir string, env map[
 		Env:      env,
 		StripEnv: SandboxStripEnv,
 	}
+	planStarted := report.start("plan")
 	planResult, err := h.runner.Run(ctx, planCmd)
+	report.done("plan", planStarted)
 	planStage := StageResult{
 		Stage:  "plan",
 		Cmd:    []string{"tofu", "plan", "-state=" + LiveStateFilename},
@@ -164,8 +217,10 @@ func (h *SandboxDeployHarness) Run(ctx context.Context, workDir string, env map[
 	attempts := 0
 	for attempts < sandboxApplyAttempts {
 		attempts++
+		applyStarted := report.start("apply")
 		var applyResult CommandResult
 		applyResult, err = h.runner.Run(ctx, applyCmd)
+		report.done("apply", applyStarted)
 		applyStage = StageResult{
 			Stage:  "apply",
 			Cmd:    []string{"tofu", "apply", "-auto-approve", "-state=" + LiveStateFilename},
@@ -181,6 +236,9 @@ func (h *SandboxDeployHarness) Run(ctx context.Context, workDir string, env map[
 		// stop creating.
 		if ctx.Err() != nil {
 			break
+		}
+		if attempts < sandboxApplyAttempts {
+			report.retrying("apply", attempts, sandboxApplyAttempts, err)
 		}
 	}
 	if err != nil {

--- a/internal/harness/sandbox_deploy_progress_test.go
+++ b/internal/harness/sandbox_deploy_progress_test.go
@@ -130,3 +130,43 @@ func TestEveryStageReportsItself(t *testing.T) {
 		assert.Contains(t, joined, stage+": done", "%s must report completion", stage)
 	}
 }
+
+// A stage that FAILED must not be reported as done.
+//
+// An earlier version called `done` unconditionally, before inspecting
+// the error, so the last line a watcher saw on a failed deploy was
+// "init: done in 2s" followed by silence -- a failure rendered as
+// completion, and a stream that stops without saying why.
+//
+// TestEveryStageReportsItself actively pinned that wrong behaviour,
+// which is why it is not enough on its own.
+func TestAFailedStageIsNotReportedAsDone(t *testing.T) {
+	for _, failing := range []string{"init", "plan", "apply"} {
+		t.Run(failing, func(t *testing.T) {
+			writer := &recordingWriter{}
+			runner := &stageFailingRunner{failStage: failing}
+
+			_, err := NewSandboxDeployHarness(runner).Run(
+				context.Background(), t.TempDir(), map[string]string{}, writer)
+			require.Error(t, err)
+
+			joined := strings.Join(writer.snapshot(), "\n")
+			assert.Contains(t, joined, failing+": FAILED",
+				"the stage that failed must say so")
+			assert.NotContains(t, joined, failing+": done",
+				"a failure must never be rendered as completion")
+		})
+	}
+}
+
+// stageFailingRunner fails one named stage.
+type stageFailingRunner struct {
+	failStage string
+}
+
+func (r *stageFailingRunner) Run(_ context.Context, cmd Command) (CommandResult, error) {
+	if len(cmd.Args) > 0 && cmd.Args[0] == r.failStage {
+		return CommandResult{Stderr: []byte("boom")}, assertProviderError{}
+	}
+	return CommandResult{Stdout: []byte("ok")}, nil
+}

--- a/internal/harness/sandbox_deploy_progress_test.go
+++ b/internal/harness/sandbox_deploy_progress_test.go
@@ -99,6 +99,48 @@ func TestAnApplyRetryIsReported(t *testing.T) {
 		"a frozen log during a silent retry reads as hung")
 }
 
+// "retrying" on the LAST attempt is a promise the code does not keep:
+// the log's final line would say work continues after the deploy has
+// given up.
+func TestTheFinalFailedAttemptDoesNotPromiseARetry(t *testing.T) {
+	writer := &recordingWriter{}
+	runner := &stageFailingRunner{failStage: "apply"}
+
+	_, err := NewSandboxDeployHarness(runner).Run(
+		context.Background(), t.TempDir(), map[string]string{}, writer)
+	require.Error(t, err)
+
+	lines := writer.snapshot()
+	last := lines[len(lines)-1]
+	assert.Contains(t, last, "giving up",
+		"the last line must say the deploy stopped, not that it continues")
+	assert.NotContains(t, last, "retrying")
+}
+
+// The interrupt path is the one where the operator has asked us to stop
+// touching the API. A final line announcing a retry says the opposite of
+// what is about to happen.
+func TestACancelledApplyDoesNotPromiseARetry(t *testing.T) {
+	writer := &recordingWriter{}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	runner := CommandRunnerFunc(func(_ context.Context, cmd Command) (CommandResult, error) {
+		if len(cmd.Args) > 0 && cmd.Args[0] == "apply" {
+			cancel()
+			return CommandResult{}, assertProviderError{}
+		}
+		return CommandResult{Stdout: []byte("ok")}, nil
+	})
+
+	_, err := NewSandboxDeployHarness(runner).Run(ctx, t.TempDir(), map[string]string{}, writer)
+	require.Error(t, err)
+
+	joined := strings.Join(writer.snapshot(), "\n")
+	assert.NotContains(t, joined, "retrying",
+		"the operator asked us to stop; promising a retry says the opposite")
+	assert.Contains(t, joined, "giving up")
+}
+
 type assertProviderError struct{}
 
 func (assertProviderError) Error() string { return "transient provider error" }
@@ -153,6 +195,8 @@ func TestAFailedStageIsNotReportedAsDone(t *testing.T) {
 			joined := strings.Join(writer.snapshot(), "\n")
 			assert.Contains(t, joined, failing+": FAILED",
 				"the stage that failed must say so")
+			assert.Contains(t, joined, "transient provider error",
+				"and WHY -- a stream that stops without saying why is half a stream")
 			assert.NotContains(t, joined, failing+": done",
 				"a failure must never be rendered as completion")
 		})

--- a/internal/harness/sandbox_deploy_progress_test.go
+++ b/internal/harness/sandbox_deploy_progress_test.go
@@ -1,0 +1,132 @@
+package harness
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingWriter captures progress AND when each line arrived relative
+// to the stages, which is the property that matters.
+type recordingWriter struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (w *recordingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, line := range strings.Split(strings.TrimRight(string(p), "\n"), "\n") {
+		if line != "" {
+			w.lines = append(w.lines, strings.TrimSpace(line))
+		}
+	}
+	return len(p), nil
+}
+
+func (w *recordingWriter) snapshot() []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]string, len(w.lines))
+	copy(out, w.lines)
+	return out
+}
+
+// observingRunner lets a test inspect progress from INSIDE a stage.
+type observingRunner struct {
+	duringApply []string
+	writer      *recordingWriter
+	fail        error
+	failFirst   bool
+	calls       int
+}
+
+func (r *observingRunner) Run(_ context.Context, cmd Command) (CommandResult, error) {
+	r.calls++
+	if len(cmd.Args) > 0 && cmd.Args[0] == "apply" {
+		// What a watcher could see while the apply is still running.
+		r.duringApply = r.writer.snapshot()
+		if r.failFirst && r.calls <= 3 {
+			return CommandResult{}, r.fail
+		}
+	}
+	return CommandResult{Stdout: []byte("ok")}, nil
+}
+
+// The defect this whole slice exists to fix, pinned properly.
+//
+// The first version of S163 tee'd the deploy command's stderr, which is
+// written twice BEFORE any cloud work and once AFTER it. `CommandRunner`
+// returns a fully buffered result, so `tofu`'s own output does not exist
+// until each process exits -- meaning the apply produced no progress at
+// all, and the tests could not tell because their fixtures were written
+// in one synchronous call.
+//
+// This asserts what a watcher can see WHILE the apply is still running,
+// which a buffer-then-dump implementation cannot satisfy.
+func TestProgressIsVisibleWhileTheApplyIsStillRunning(t *testing.T) {
+	writer := &recordingWriter{}
+	runner := &observingRunner{writer: writer}
+
+	_, err := NewSandboxDeployHarness(runner).Run(
+		context.Background(), t.TempDir(), map[string]string{}, writer)
+	require.NoError(t, err)
+
+	seen := strings.Join(runner.duringApply, "\n")
+	assert.Contains(t, seen, "init: running",
+		"a watcher must know init happened before the apply finishes")
+	assert.Contains(t, seen, "plan: done",
+		"and that plan completed")
+	assert.Contains(t, seen, "apply: running",
+		"and that the apply is what is taking the time")
+}
+
+// A silent retry is indistinguishable from a stage that is simply slow,
+// and a Layer 3 apply really does retry after a transient provider
+// error.
+func TestAnApplyRetryIsReported(t *testing.T) {
+	writer := &recordingWriter{}
+	runner := &observingRunner{writer: writer, fail: assertProviderError{}, failFirst: true}
+
+	_, _ = NewSandboxDeployHarness(runner).Run(
+		context.Background(), t.TempDir(), map[string]string{}, writer)
+
+	assert.Contains(t, strings.Join(writer.snapshot(), "\n"), "retrying",
+		"a frozen log during a silent retry reads as hung")
+}
+
+type assertProviderError struct{}
+
+func (assertProviderError) Error() string { return "transient provider error" }
+
+// A caller with nowhere to send progress is the ordinary case and must
+// cost nothing.
+func TestSandboxDeployAcceptsANilProgressWriter(t *testing.T) {
+	runner := &observingRunner{writer: &recordingWriter{}}
+
+	_, err := NewSandboxDeployHarness(runner).Run(
+		context.Background(), t.TempDir(), map[string]string{}, nil)
+
+	require.NoError(t, err)
+}
+
+// Every stage the harness runs must announce itself, so a stage added
+// later cannot be silently invisible to a watcher.
+func TestEveryStageReportsItself(t *testing.T) {
+	writer := &recordingWriter{}
+	runner := &observingRunner{writer: writer}
+
+	_, err := NewSandboxDeployHarness(runner).Run(
+		context.Background(), t.TempDir(), map[string]string{}, writer)
+	require.NoError(t, err)
+
+	joined := strings.Join(writer.snapshot(), "\n")
+	for _, stage := range []string{"init", "plan", "apply"} {
+		assert.Contains(t, joined, stage+": running", "%s must announce itself", stage)
+		assert.Contains(t, joined, stage+": done", "%s must report completion", stage)
+	}
+}

--- a/internal/harness/sandbox_deploy_test.go
+++ b/internal/harness/sandbox_deploy_test.go
@@ -18,7 +18,7 @@ func TestSandboxDeployHarnessRunSuccess(t *testing.T) {
 	}
 
 	h := NewSandboxDeployHarness(runner)
-	out, err := h.Run(context.Background(), "/tmp/workdir", map[string]string{"SCW_ACCESS_KEY": "real"})
+	out, err := h.Run(context.Background(), "/tmp/workdir", map[string]string{"SCW_ACCESS_KEY": "real"}, nil)
 	if err != nil {
 		t.Fatalf("run sandbox deploy harness: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestSandboxDeployHarnessRunFailures(t *testing.T) {
 			t.Parallel()
 
 			h := NewSandboxDeployHarness(&fakeRunner{responses: tc.responses})
-			_, err := h.Run(context.Background(), "/tmp/workdir", nil)
+			_, err := h.Run(context.Background(), "/tmp/workdir", nil, nil)
 			if err == nil {
 				t.Fatal("expected error")
 			}

--- a/internal/harness/static.go
+++ b/internal/harness/static.go
@@ -162,3 +162,15 @@ func validateJSON(payload []byte) error {
 	var body any
 	return json.Unmarshal(payload, &body)
 }
+
+// CommandRunnerFunc adapts a function to CommandRunner.
+//
+// Exported so a test outside this package can supply a fake subprocess
+// while using the REAL harness. That distinction matters: the harness is
+// where stage reporting lives, and a test that fakes the harness cannot
+// notice the harness being handed no writer.
+type CommandRunnerFunc func(context.Context, Command) (CommandResult, error)
+
+func (f CommandRunnerFunc) Run(ctx context.Context, cmd Command) (CommandResult, error) {
+	return f(ctx, cmd)
+}

--- a/ui/e2e/deploy.spec.ts
+++ b/ui/e2e/deploy.spec.ts
@@ -206,8 +206,14 @@ test.describe('Deploy from the scenario page', () => {
     await page.getByTestId('scenario-deploy').click();
     await page.getByTestId('deploy-confirm-go').click();
 
-    await expect(page.getByTestId('deploy-outcome')).toBeVisible();
-    expect(posted).toBe('the-previewed-one');
+    // The confirmation closing is what marks the POST as sent. The
+    // OUTCOME deliberately does not appear here: outcomes are keyed by
+    // the scenario deployed, and this fixture makes that differ from the
+    // page's scenario to prove the POST follows the preview. A deploy of
+    // one scenario must not report on another's page.
+    await expect(page.getByTestId('deploy-confirm')).toHaveCount(0);
+    await expect.poll(() => posted).toBe('the-previewed-one');
+    await expect(page.getByTestId('deploy-outcome')).toHaveCount(0);
   });
 
   // afterNavigate clearing the dialog is not enough on its own: a
@@ -354,7 +360,9 @@ test.describe('Deploy from the scenario page', () => {
   });
 
   test('the outcome names the scenario it is about', async ({ page }) => {
-    await servePreview(page, { scenario: 'the-deployed-one' });
+    // Same scenario as the page, which is the only shape the real flow
+    // produces: the preview is fetched for the scenario on screen.
+    await servePreview(page, { scenario: 'web-app-paris' });
     await page.route('**/api/deployments', (route) =>
       route.request().method() === 'POST'
         ? route.fulfill({
@@ -368,11 +376,11 @@ test.describe('Deploy from the scenario page', () => {
     await page.getByTestId('scenario-deploy').click();
     await page.getByTestId('deploy-confirm-go').click();
 
-    await expect(page.getByTestId('deploy-outcome')).toContainText('the-deployed-one');
+    await expect(page.getByTestId('deploy-outcome')).toContainText('web-app-paris');
   });
 
   test('a failed outcome names its scenario too', async ({ page }) => {
-    await servePreview(page, { scenario: 'the-failed-one' });
+    await servePreview(page, { scenario: 'web-app-paris' });
     await page.route('**/api/deployments', (route) =>
       route.request().method() === 'POST'
         ? route.fulfill({
@@ -391,7 +399,7 @@ test.describe('Deploy from the scenario page', () => {
     await page.getByTestId('deploy-confirm-go').click();
 
     const outcome = page.getByTestId('deploy-outcome');
-    await expect(outcome).toContainText('the-failed-one');
+    await expect(outcome).toContainText('web-app-paris');
     await expect(outcome).toContainText('7c98d82e');
   });
 });
@@ -473,5 +481,111 @@ test.describe('Deploy progress', () => {
     release();
     // And the finished deploy must not paint its result here either.
     await expect(page.getByTestId('deploy-progress')).toHaveCount(0);
+  });
+});
+
+test.describe('Deploy state outlives the page', () => {
+  // Component state died with the component. Navigating away and back
+  // during a deploy left a real, billable apply rendered as an
+  // unlabelled disabled button with no log and no warning; leaving the
+  // section entirely let a SECOND deploy of the same scenario start,
+  // because the server has no in-flight lock.
+  test('a running deploy is still shown after navigating away and back', async ({ page }) => {
+    await page.route('**/api/deployments/preview**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          scenario: 'web-app-paris',
+          deployable: true,
+          expires_at: null,
+          internet_facing: false,
+          deploy_allowed: true,
+          cost: { components: [], eur_per_hour: 0, unpriced: [], complete: true, modelled: true }
+        })
+      })
+    );
+
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => (release = resolve));
+    await page.route('**/api/deployments', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      await held;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ clean: true, steps: [], failures: [] })
+      });
+    });
+
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+    await page.getByTestId('deploy-confirm-go').click();
+    await expect(page.getByTestId('deploy-progress')).toBeVisible();
+
+    // Away — the other scenario shows nothing about this deploy...
+    await page.getByTestId('sidebar-scenario-training/lb-serving-paris').click();
+    await expect(page.locator('main h1')).toContainText('lb-serving-paris');
+    await expect(page.getByTestId('deploy-progress')).toHaveCount(0);
+    await expect(page.getByTestId('scenario-deploy')).toBeEnabled();
+
+    // ...and back — the running deploy is visible again, and cannot be
+    // started a second time.
+    await page.getByTestId('sidebar-scenario-training/web-app-paris').click();
+    await expect(page.locator('main h1')).toContainText('web-app-paris');
+    await expect(page.getByTestId('deploy-progress')).toBeVisible();
+    await expect(page.getByTestId('scenario-deploy')).toBeDisabled();
+
+    release();
+    await expect(page.getByTestId('deploy-outcome')).toBeVisible();
+  });
+
+  // Leaving the section unmounts the component entirely, which is what
+  // made the second deploy reachable.
+  test('a running deploy survives leaving the scenarios section', async ({ page }) => {
+    await page.route('**/api/deployments/preview**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          scenario: 'web-app-paris',
+          deployable: true,
+          expires_at: null,
+          internet_facing: false,
+          deploy_allowed: true,
+          cost: { components: [], eur_per_hour: 0, unpriced: [], complete: true, modelled: true }
+        })
+      })
+    );
+
+    let posts = 0;
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => (release = resolve));
+    await page.route('**/api/deployments', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      posts += 1;
+      await held;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ clean: true, steps: [], failures: [] })
+      });
+    });
+
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+    await page.getByTestId('deploy-confirm-go').click();
+    await expect(page.getByTestId('deploy-progress')).toBeVisible();
+
+    await page.getByRole('link', { name: 'Deployments' }).click();
+    await expect(page).toHaveURL(/\/deployments/);
+
+    await page.getByTestId('sidebar-scenario-training/web-app-paris').click();
+    await expect(page.locator('main h1')).toContainText('web-app-paris');
+
+    await expect(page.getByTestId('scenario-deploy')).toBeDisabled();
+    expect(posts).toBe(1);
+
+    release();
   });
 });

--- a/ui/e2e/deploy.spec.ts
+++ b/ui/e2e/deploy.spec.ts
@@ -589,3 +589,148 @@ test.describe('Deploy state outlives the page', () => {
     release();
   });
 });
+
+// Progress that is actually RENDERED.
+//
+// Every earlier test in this file intercepts the POST in the browser, so
+// the Go server never broadcasts and no progress event is ever produced.
+// A review demonstrated the cost: replacing the whole `{#each}` block
+// with a constant string, and separately hiding the disconnected banner
+// entirely, both passed the full suite. Behaviours 1, 2 and 3 were
+// invisible in the browser.
+//
+// `routeWebSocket` lets the test be the server for the socket, so real
+// frames reach the real filter and the real DOM.
+test.describe('Deploy progress in the DOM', () => {
+  const preview = {
+    scenario: 'web-app-paris',
+    deployable: true,
+    expires_at: null,
+    internet_facing: false,
+    deploy_allowed: true,
+    cost: { components: [], eur_per_hour: 0, unpriced: [], complete: true, modelled: true }
+  };
+
+  async function startDeploy(page, { holdPost = true } = {}) {
+    await page.route('**/api/deployments/preview**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(preview) })
+    );
+
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => (release = resolve));
+    await page.route('**/api/deployments', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      if (holdPost) await held;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ clean: true, steps: [], failures: [] })
+      });
+    });
+
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+    await page.getByTestId('deploy-confirm-go').click();
+    return release;
+  }
+
+  test('stage lines are rendered as they arrive', async ({ page }) => {
+    let send: (data: string) => void = () => {};
+    await page.routeWebSocket('**/api/ws', (ws) => {
+      send = (data) => ws.send(data);
+    });
+
+    const release = await startDeploy(page);
+    await expect(page.getByTestId('deploy-progress')).toBeVisible();
+
+    const line = (text: string) =>
+      JSON.stringify({ type: 'deploy_progress', data: { subject: 'web-app-paris', line: text } });
+
+    send(line('init: running'));
+    await expect(page.getByTestId('deploy-progress')).toContainText('init: running');
+
+    send(line('apply: FAILED after 3s: transient provider error'));
+    await expect(page.getByTestId('deploy-progress')).toContainText('apply: FAILED');
+    await expect(page.getByTestId('deploy-progress')).toContainText('transient provider error');
+
+    // Each line is its own row, not a single blob.
+    await expect(page.getByTestId('deploy-progress').locator('p')).toHaveCount(2);
+
+    release();
+  });
+
+  test('a line for another scenario is not rendered here', async ({ page }) => {
+    let send: (data: string) => void = () => {};
+    await page.routeWebSocket('**/api/ws', (ws) => {
+      send = (data) => ws.send(data);
+    });
+
+    const release = await startDeploy(page);
+    await expect(page.getByTestId('deploy-progress')).toBeVisible();
+
+    send(
+      JSON.stringify({
+        type: 'deploy_progress',
+        data: { subject: 'lb-serving-paris', line: 'belongs elsewhere' }
+      })
+    );
+    send(
+      JSON.stringify({
+        type: 'deploy_progress',
+        data: { subject: 'web-app-paris', line: 'init: running' }
+      })
+    );
+
+    await expect(page.getByTestId('deploy-progress')).toContainText('init: running');
+    await expect(page.getByTestId('deploy-progress')).not.toContainText('belongs elsewhere');
+
+    release();
+  });
+
+  // A dropped socket and "nothing has happened yet" both produce an
+  // empty log. Rendering them the same way tells the reader an apply is
+  // quiet when the truth is that it is UNOBSERVED.
+  test('a socket that never connects says so rather than "Starting"', async ({ page }) => {
+    // Accept and immediately close, so onStatus(false) fires and no
+    // reconnect ever succeeds either.
+    await page.routeWebSocket('**/api/ws', (ws) => ws.close());
+
+    const release = await startDeploy(page);
+
+    await expect(page.getByTestId('deploy-progress-disconnected')).toBeVisible();
+    await expect(page.getByTestId('deploy-progress')).not.toContainText('Starting…');
+
+    release();
+  });
+});
+
+// Deploy progress is broadcast to every client. The Live Run page
+// renders whatever arrives and refetches run state per message, so
+// without a filter a deploy in one tab fills an unrelated run's log with
+// raw JSON and hammers the API.
+test('deploy progress does not leak into the Live Run page', async ({ page }) => {
+  let send: (data: string) => void = () => {};
+  // The socket connects asynchronously, so the test must wait for it
+  // rather than sending into a handler that has not run yet -- otherwise
+  // it would pass by delivering nothing at all.
+  let connected: () => void = () => {};
+  const socketReady = new Promise<void>((resolve) => (connected = resolve));
+  await page.routeWebSocket('**/api/ws', (ws) => {
+    send = (data) => ws.send(data);
+    connected();
+  });
+
+  await page.goto('/live');
+  await socketReady;
+
+  send(
+    JSON.stringify({
+      type: 'deploy_progress',
+      data: { subject: 'web-app-paris', line: 'apply: running' }
+    })
+  );
+  send(JSON.stringify({ type: 'log', data: 'a genuine run log line' }));
+
+  await expect(page.locator('body')).toContainText('a genuine run log line');
+  await expect(page.locator('body')).not.toContainText('deploy_progress');
+});

--- a/ui/e2e/deploy.spec.ts
+++ b/ui/e2e/deploy.spec.ts
@@ -395,3 +395,83 @@ test.describe('Deploy from the scenario page', () => {
     await expect(outcome).toContainText('7c98d82e');
   });
 });
+
+test.describe('Deploy progress', () => {
+  // Minutes of silence reads as broken. The reader cannot tell a long
+  // apply from a hung one, and the difference matters when the thing
+  // running is creating billable infrastructure.
+  test('a deploy in flight shows something is happening', async ({ page }) => {
+    await page.route('**/api/deployments/preview**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          scenario: 'web-app-paris',
+          deployable: true,
+          expires_at: null,
+          internet_facing: false,
+          deploy_allowed: true,
+          cost: { components: [], eur_per_hour: 0, unpriced: [], complete: true, modelled: true }
+        })
+      })
+    );
+
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => (release = resolve));
+    await page.route('**/api/deployments', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      await held;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ clean: true, steps: [], failures: [] })
+      });
+    });
+
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+    await page.getByTestId('deploy-confirm-go').click();
+
+    // Before any line arrives, the page still says it is working.
+    await expect(page.getByTestId('deploy-progress')).toContainText('Starting…');
+
+    release();
+    await expect(page.getByTestId('deploy-outcome')).toBeVisible();
+  });
+
+  // SvelteKit REUSES the [...path] component across scenario routes, so
+  // leaving one scenario page for another destroys nothing and
+  // `onDestroy` never fires. Without resetting from the navigation path
+  // too, a previous scenario's progress keeps rendering under the new
+  // one.
+  test('progress does not follow you to another scenario', async ({ page }) => {
+    await servePreview(page);
+
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => (release = resolve));
+    await page.route('**/api/deployments', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      await held;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ clean: true, steps: [], failures: [] })
+      });
+    });
+
+    await page.goto('/scenarios/training/web-app-paris');
+    await page.getByTestId('scenario-deploy').click();
+    await page.getByTestId('deploy-confirm-go').click();
+    await expect(page.getByTestId('deploy-progress')).toBeVisible();
+
+    // Client-side navigation, which reuses the component.
+    await page.getByTestId('sidebar-scenario-training/lb-serving-paris').click();
+    await expect(page.locator('main h1')).toContainText('lb-serving-paris');
+
+    await expect(page.getByTestId('deploy-progress')).toHaveCount(0);
+
+    release();
+    // And the finished deploy must not paint its result here either.
+    await expect(page.getByTestId('deploy-progress')).toHaveCount(0);
+  });
+});

--- a/ui/src/lib/deploy-store.js
+++ b/ui/src/lib/deploy-store.js
@@ -1,0 +1,129 @@
+import { writable, get } from "svelte/store";
+import { acceptProgressEvent } from "./deployments-view.js";
+
+/**
+ * Deploys in flight, keyed by scenario name.
+ *
+ * # Why this is a module-level store and not component state
+ *
+ * A deploy runs for minutes on the server, detached from the request. The
+ * scenario page that started it does not: SvelteKit reuses the route
+ * component between scenarios and destroys it entirely when you navigate
+ * to another section.
+ *
+ * While this lived in the component, two things followed and review found
+ * both:
+ *
+ *   - navigating away and back during a deploy left the page with no log,
+ *     no warning and a disabled button labelled "Deploying " with a blank
+ *     subject — a real, billable apply rendered as an unexplained frozen
+ *     control;
+ *   - navigating to another SECTION unmounted the component, so coming
+ *     back gave a fresh one that believed nothing was running and
+ *     happily started a SECOND deploy of the same scenario. Two
+ *     run-owned projects, double billing, one of which the operator does
+ *     not know exists.
+ *
+ * The server has no in-flight lock, so this is the only thing standing
+ * between a reader and that second deploy. It has to outlive the page.
+ *
+ * Keyed by SCENARIO because that is what the progress events carry: the
+ * deployment id is minted inside the command, after the request is
+ * accepted.
+ */
+export const deploys = writable({});
+
+let socket;
+let watchers = 0;
+
+// The connector is INJECTED rather than imported.
+//
+// `ws.ts` is TypeScript, and the unit tests run under `node --test`,
+// which resolves plain JS only -- importing it here would make this
+// module untestable, and the socket wiring is exactly the part worth
+// testing. The component supplies the real one at mount.
+let connect = () => () => {};
+
+/** useConnector installs the websocket factory. */
+export function useConnector(fn) {
+  connect = fn;
+}
+
+/** shape of one entry, for readers: { progress: string[], outcome: {ok, message} | null } */
+
+function ensureSocket() {
+  if (socket) return;
+  socket = connect(
+    (msg) => {
+      const current = get(deploys);
+      for (const scenario of Object.keys(current)) {
+        if (!acceptProgressEvent(msg, scenario)) continue;
+        const line = msg.data.line;
+        deploys.update((all) => {
+          const entry = all[scenario];
+          if (!entry) return all;
+          return { ...all, [scenario]: { ...entry, progress: [...entry.progress, line] } };
+        });
+      }
+    },
+    (connected) => deploys.update((all) => ({ ...all, __connected: connected }))
+  );
+}
+
+function releaseSocket() {
+  // Closed only when nothing is in flight AND nobody is looking. A
+  // deploy that is still running must keep its stream open even if the
+  // reader has wandered off, or coming back shows a frozen log.
+  const current = get(deploys);
+  const inFlight = Object.keys(current).some((k) => k !== "__connected" && current[k]?.running);
+  if (inFlight || watchers > 0) return;
+  socket?.();
+  socket = undefined;
+}
+
+/** watch keeps the shared socket alive while a page is mounted. */
+export function watch() {
+  watchers += 1;
+  ensureSocket();
+  return () => {
+    watchers -= 1;
+    releaseSocket();
+  };
+}
+
+export function beginDeploy(scenario) {
+  ensureSocket();
+  deploys.update((all) => ({
+    ...all,
+    [scenario]: { running: true, progress: [], outcome: null }
+  }));
+}
+
+export function finishDeploy(scenario, outcome) {
+  deploys.update((all) => {
+    const entry = all[scenario];
+    if (!entry) return all;
+    return { ...all, [scenario]: { ...entry, running: false, outcome } };
+  });
+  releaseSocket();
+}
+
+/** forget clears a finished deploy once the reader has seen it. */
+export function forgetDeploy(scenario) {
+  deploys.update((all) => {
+    const next = { ...all };
+    delete next[scenario];
+    return next;
+  });
+  releaseSocket();
+}
+
+/** isRunning answers the one question the Deploy button needs. */
+export function isRunning(all, scenario) {
+  return all?.[scenario]?.running === true;
+}
+
+/** isConnected distinguishes "no output yet" from "we cannot see it". */
+export function isConnected(all) {
+  return all?.__connected === true;
+}

--- a/ui/src/lib/deployments-view.js
+++ b/ui/src/lib/deployments-view.js
@@ -320,3 +320,27 @@ export function deployWarnings(preview) {
 
   return warnings;
 }
+
+/**
+ * acceptProgressEvent decides whether a websocket event belongs to the
+ * deploy a page is currently showing.
+ *
+ * Extracted from the component so it can be tested. While it was inline
+ * in `+page.svelte` it had NO test at all: the e2e tests intercept the
+ * POST in the browser, so the server never broadcasts and the filter was
+ * never invoked. Typo-ing the event type — which kills the entire
+ * stream — passed the whole suite.
+ *
+ * The subject is the SCENARIO, which is what the request carries. It
+ * cannot be the deployment id: that id is minted inside the command,
+ * after the request is accepted. So two concurrent deploys of the same
+ * scenario share a stream, and a reader sees both. That is a real limit
+ * and it is written down rather than implied away.
+ */
+export function acceptProgressEvent(event, showingScenario) {
+  if (!showingScenario) return false;
+  if (event?.type !== "deploy_progress") return false;
+  const data = event?.data;
+  if (!data?.line) return false;
+  return data.subject === showingScenario;
+}

--- a/ui/src/lib/ws.ts
+++ b/ui/src/lib/ws.ts
@@ -15,7 +15,19 @@ export function buildWSURL(protocol: string, host: string, apiOrigin = ""): stri
   return `${wsProtocol}//${targetURL.host}/api/ws`;
 }
 
-export function connectWS(onMessage: (msg: unknown) => void): () => void {
+/**
+ * connectWS opens the event socket and reconnects if it drops.
+ *
+ * `onStatus`, when supplied, reports whether the socket is currently
+ * connected. A caller that renders live output needs it: without it, a
+ * dropped socket and "nothing has happened yet" look identical, and a
+ * page that shows an empty log for both is telling the reader an apply
+ * is quiet when the truth is that it is unobserved.
+ */
+export function connectWS(
+  onMessage: (msg: unknown) => void,
+  onStatus?: (connected: boolean) => void
+): () => void {
   let closed = false;
   let socket: WebSocket | null = null;
   const apiOrigin = import.meta.env.VITE_UI_API_ORIGIN || (window.location.port === "5173" ? `${window.location.protocol}//${window.location.hostname}:4173` : "");
@@ -30,8 +42,10 @@ export function connectWS(onMessage: (msg: unknown) => void): () => void {
         onMessage({ type: "raw", data: event.data });
       }
     };
-    socket.onerror = () => {};
+    socket.onopen = () => onStatus?.(true);
+    socket.onerror = () => onStatus?.(false);
     socket.onclose = () => {
+      onStatus?.(false);
       if (!closed) {
         setTimeout(connect, 1000);
       }

--- a/ui/src/routes/live/+page.svelte
+++ b/ui/src/routes/live/+page.svelte
@@ -196,6 +196,18 @@
     }
 
     const disconnect = connectWS((msg) => {
+      // Deploy progress is broadcast to every client, and this page
+
+      // renders whatever arrives. Without this filter a deploy in one tab
+
+      // interleaves raw JSON into an unrelated RUN's event log and fires a
+
+      // run-state fetch per line. Noise rather than a falsehood, but the
+
+      // log is meant to be that run's.
+
+      if ((msg as { type?: string })?.type === "deploy_progress") return;
+
       lines = [...lines.slice(-999), JSON.stringify(msg)];
       void loadRunState();
     });

--- a/ui/src/routes/live/+page.svelte
+++ b/ui/src/routes/live/+page.svelte
@@ -197,15 +197,10 @@
 
     const disconnect = connectWS((msg) => {
       // Deploy progress is broadcast to every client, and this page
-
-      // renders whatever arrives. Without this filter a deploy in one tab
-
-      // interleaves raw JSON into an unrelated RUN's event log and fires a
-
-      // run-state fetch per line. Noise rather than a falsehood, but the
-
-      // log is meant to be that run's.
-
+      // renders whatever arrives. Without this filter a deploy in one
+      // tab interleaves raw JSON into an unrelated RUN's event log and
+      // fires a run-state fetch per line. Noise rather than a falsehood,
+      // but the log is meant to be that run's.
       if ((msg as { type?: string })?.type === "deploy_progress") return;
 
       lines = [...lines.slice(-999), JSON.stringify(msg)];

--- a/ui/src/routes/scenarios/[...path]/+page.svelte
+++ b/ui/src/routes/scenarios/[...path]/+page.svelte
@@ -3,6 +3,7 @@
   import { onDestroy } from "svelte";
   import { page } from "$app/stores";
   import { api } from "$lib/api";
+  import { connectWS } from "$lib/ws";
   import {
     deployConfirmation,
     deployWarnings,
@@ -81,6 +82,10 @@
   // component (the validationVersion guard is per-instance).
   onDestroy(() => {
     if (validationTimer) clearTimeout(validationTimer);
+    // Leaving the page must not leave a socket open. The deploy itself
+    // is unaffected: it is detached from the request on the server, so
+    // it finishes whether or not anybody is watching.
+    resetDeployState();
   });
 
   $: scenarioPath = ($page.params.path || "").toString();
@@ -152,6 +157,59 @@
   // which is the move pass 126 argued for and pass 127 had to learn
   // twice. It also gives the reader feedback that the click landed.
   let previewing = false;
+
+  // A deploy runs for minutes, and minutes of silence reads as broken:
+  // a reader cannot tell a long apply from a hung one, and the
+  // difference matters when the thing running is creating billable
+  // infrastructure (S163).
+  //
+  // Every line names the scenario it belongs to, so lines from a deploy
+  // the reader has navigated away from are DISCARDED here rather than
+  // appended under the wrong heading.
+  let deployProgress: string[] = [];
+  let disconnectWS: (() => void) | undefined;
+
+  function onSocketMessage(msg: unknown) {
+    const event = msg as { type?: string; data?: { subject?: string; line?: string } };
+    if (event?.type !== "deploy_progress" || !event.data?.line) return;
+    if (event.data.subject !== deployingScenario) return;
+    deployProgress = [...deployProgress, event.data.line];
+  }
+
+  // The scenario whose progress this page is currently showing. Held
+  // separately from `preview` because `preview` is cleared on
+  // navigation while a deploy keeps running.
+  let deployingScenario = "";
+
+  /**
+   * resetDeployState puts this page back to knowing nothing about a
+   * deploy.
+   *
+   * ONE function, called from both navigation and destroy, because the
+   * reset used to be a hand-written list in `afterNavigate` -- and the
+   * moment S163 added stream state, the list did not grow with it. The
+   * websocket, `deployingScenario` and `deployProgress` survived a
+   * client-side route change, so progress for the previous scenario
+   * kept rendering under the new one.
+   *
+   * `onDestroy` does not cover that: SvelteKit REUSES this `[...path]`
+   * component across scenario routes, so leaving a scenario page for
+   * another one destroys nothing.
+   *
+   * The deploy itself is untouched. It is detached from the request on
+   * the server, so it finishes whether or not this page is watching.
+   */
+  function resetDeployState() {
+    disconnectWS?.();
+    disconnectWS = undefined;
+    deployingScenario = "";
+    deploying = false;
+    deployProgress = [];
+    confirmingDeploy = false;
+    preview = null;
+    previewError = "";
+    deployOutcomeMessage = "";
+  }
   let deploying = false;
   let deployOutcomeMessage = "";
   let deployOk = false;
@@ -196,6 +254,9 @@
     if (!target) return;
 
     deploying = true;
+    deployingScenario = target;
+    deployProgress = [];
+    if (!disconnectWS) disconnectWS = connectWS(onSocketMessage);
     try {
       const result = await api.deployScenario(target);
       const outcome = teardownOutcome(result);
@@ -220,6 +281,7 @@
     } finally {
       deploying = false;
       confirmingDeploy = false;
+      deployingScenario = "";
     }
   }
 
@@ -289,10 +351,7 @@
     // on screen, even though accepting it would now be harmless.
     // Leaving it visible invites the reader to trust a dialog about
     // something they are no longer looking at.
-    confirmingDeploy = false;
-    preview = null;
-    previewError = "";
-    deployOutcomeMessage = "";
+    resetDeployState();
     // `detail` is cleared too, and that is the STRUCTURAL half of this.
     //
     // The whole page is inside `{#if detail}`, so clearing it means
@@ -485,6 +544,26 @@
           on:click={() => (confirmingDeploy = false)}>Cancel</button
         >
       </div>
+    </div>
+  {/if}
+
+  <!-- Gated on `deployingScenario`, not on `deploying`.
+       `deploying` is a bare boolean about no particular thing, so it
+       survives navigation and would keep this panel open on a page that
+       has nothing to do with the deploy still running. The
+       subject-bearing state is the one to ask. -->
+  {#if deployingScenario || deployProgress.length > 0}
+    <div
+      class="mt-3 rounded border border-slate-300 bg-slate-900 px-3 py-2 font-mono text-xs text-slate-100"
+      data-testid="deploy-progress"
+    >
+      {#if deployProgress.length === 0}
+        <p class="text-slate-400">Starting…</p>
+      {:else}
+        {#each deployProgress as line}
+          <p>{line}</p>
+        {/each}
+      {/if}
     </div>
   {/if}
 

--- a/ui/src/routes/scenarios/[...path]/+page.svelte
+++ b/ui/src/routes/scenarios/[...path]/+page.svelte
@@ -1,15 +1,23 @@
 <script lang="ts">
   import { afterNavigate } from "$app/navigation";
-  import { onDestroy } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { page } from "$app/stores";
   import { api } from "$lib/api";
   import { connectWS } from "$lib/ws";
   import {
-    acceptProgressEvent,
     deployConfirmation,
     deployWarnings,
     teardownOutcome
   } from "$lib/deployments-view.js";
+  import {
+    beginDeploy,
+    deploys,
+    finishDeploy,
+    isConnected,
+    isRunning,
+    useConnector,
+    watch as watchDeploys
+  } from "$lib/deploy-store.js";
   import { modeSummary, normalizeRunOptions } from "$lib/scenario-run.js";
   import type { DeployPreview, ScenarioLayer3StatusResponse, ScenarioRunModeResponse } from "$lib/types";
 
@@ -81,11 +89,13 @@
   // Clear the debounce timer on destroy so navigating away during the
   // 500ms window doesn't fire a stale validation against a torn-down
   // component (the validationVersion guard is per-instance).
+  // The shared socket stays open while this page is mounted, and the
+  // store keeps it open beyond that if a deploy is still running -- so
+  // leaving and returning finds the log intact rather than frozen.
+  onMount(() => watchDeploys());
+
   onDestroy(() => {
     if (validationTimer) clearTimeout(validationTimer);
-    // Leaving the page must not leave a socket open. The deploy itself
-    // is unaffected: it is detached from the request on the server, so
-    // it finishes whether or not anybody is watching.
     resetDeployState();
   });
 
@@ -164,80 +174,51 @@
   // difference matters when the thing running is creating billable
   // infrastructure (S163).
   //
-  // Every line names the scenario it belongs to, so lines from a deploy
-  // the reader has navigated away from are DISCARDED here rather than
-  // appended under the wrong heading.
-  let deployProgress: string[] = [];
-  let disconnectWS: (() => void) | undefined;
-  // Whether we are actually receiving. A dropped socket and "nothing has
-  // happened yet" both produce an empty log, and rendering them the same
-  // way tells the reader an apply is quiet when the truth is that it is
-  // UNOBSERVED -- the same falsehood the estate page exists to avoid.
-  let streamConnected = false;
+  // The in-flight state lives in a MODULE-LEVEL store, not here.
+  //
+  // This component is reused between scenarios and destroyed outright
+  // when you leave the section, while a deploy runs for minutes on a
+  // server that has no in-flight lock. Holding it here produced two
+  // review findings: navigating away and back showed a real, billable
+  // apply as an unlabelled disabled button with no log and no warning,
+  // and leaving the section entirely let a SECOND deploy of the same
+  // scenario be started.
+  //
+  // Everything below is scoped to the scenario ON SCREEN, so another
+  // scenario's deploy never renders here and this scenario's deploy
+  // renders whether or not this component was alive when it began.
+  useConnector(connectWS);
 
-  function onSocketMessage(msg: unknown) {
-    if (!acceptProgressEvent(msg, deployingScenario)) return;
-    const line = (msg as { data: { line: string } }).data.line;
-    deployProgress = [...deployProgress, line];
-  }
-
-  // The scenario whose progress this page is currently showing. Held
-  // separately from `preview` because `preview` is cleared on
-  // navigation while a deploy keeps running.
-  let deployingScenario = "";
-  // Monotonic, so a finishing deploy can tell whether it is still the
-  // one this page is showing.
-  let deployGeneration = 0;
+  $: deployEntry = detail?.name ? $deploys[detail.name] : undefined;
+  $: deployProgress = deployEntry?.progress ?? [];
+  $: deploying = detail?.name ? isRunning($deploys, detail.name) : false;
+  $: deployOutcome = deployEntry?.outcome ?? null;
+  // A dropped socket and "nothing has happened yet" both produce an
+  // empty log, and rendering them the same way tells the reader an apply
+  // is quiet when the truth is that it is UNOBSERVED.
+  $: streamConnected = isConnected($deploys);
 
   /**
-   * resetDeployState puts this page back to knowing nothing about a
-   * deploy.
+   * resetDeployState clears what belongs to THIS page's confirmation
+   * dialog, and nothing else.
    *
-   * ONE function, called from both navigation and destroy, because the
-   * reset used to be a hand-written list in `afterNavigate` -- and the
-   * moment S163 added stream state, the list did not grow with it. The
-   * websocket, `deployingScenario` and `deployProgress` survived a
-   * client-side route change, so progress for the previous scenario
-   * kept rendering under the new one.
+   * It deliberately does not touch the deploy stream. That lives in the
+   * store, survives navigation and component destruction, and is scoped
+   * by scenario -- so a page showing B reads nothing for B while A keeps
+   * applying, and coming back to A finds its log still there.
    *
-   * `onDestroy` does not cover that: SvelteKit REUSES this `[...path]`
-   * component across scenario routes, so leaving a scenario page for
-   * another one destroys nothing.
-   *
-   * `deploying` is deliberately NOT reset here. It is the only thing
-   * that stops a second deploy being started, and the apply is detached
-   * from the request on the server -- so clearing it on navigation let a
-   * reader move away, come back, find the button enabled, and start a
-   * SECOND apply while the first was still creating billable
-   * infrastructure. Two run-owned projects and two sets of resources for
-   * one scenario, from a page reporting that nothing was running.
-   *
-   * That is the exact harm ADR-0027's streaming amendment names -- "a
-   * reader who cannot tell a long apply from a hung one will do one of
-   * two harmful things: kill it, or start another" -- reachable through
-   * the code added to prevent it.
-   *
-   * The deploy itself is untouched either way. It finishes whether or
-   * not this page is watching.
+   * The previous version cleared it here, which is what produced the
+   * "running apply rendered as an unlabelled disabled button" and
+   * "second deploy startable" findings.
    */
   function resetDeployState() {
-    disconnectWS?.();
-    disconnectWS = undefined;
-    streamConnected = false;
-    deployingScenario = "";
-    deployProgress = [];
     confirmingDeploy = false;
     preview = null;
     previewError = "";
-    deployOutcomeMessage = "";
   }
-  let deploying = false;
-  let deployOutcomeMessage = "";
-  let deployOk = false;
 
   async function openDeployConfirmation() {
     previewError = "";
-    deployOutcomeMessage = "";
 
     // A preview takes a round trip and the reader can navigate during
     // it, so the response is discarded if it arrives after the page has
@@ -274,60 +255,20 @@
     const target = preview?.scenario;
     if (!target) return;
 
-    deploying = true;
-    deployingScenario = target;
-    // Which deploy this call owns. An earlier deploy finishing must not
-    // clear a LATER one's state: without this, deploying A, navigating
-    // away, deploying B, and then A's request resolving first would
-    // freeze B's log mid-stream, unlock the button, and put a green
-    // success message belonging to A directly beneath it.
-    const owned = ++deployGeneration;
-    deployProgress = [];
-    if (!disconnectWS) {
-      disconnectWS = connectWS(onSocketMessage, (connected) => (streamConnected = connected));
-    }
+    // The store owns everything about an in-flight deploy, so it
+    // survives this component being reused or destroyed. It is keyed by
+    // scenario, which is what the progress events carry.
+    beginDeploy(target);
+    confirmingDeploy = false;
+
     try {
-      const result = await api.deployScenario(target);
-      const outcome = teardownOutcome(result);
-      // The outcome is always shown -- it names its scenario, so it is
-      // true wherever it lands -- but it must not overwrite a NEWER
-      // deploy's outcome.
-      if (owned !== deployGeneration) return;
-      deployOk = outcome.ok;
-      // NAMED, always. An apply takes minutes and the reader can
-      // navigate during it, so this message can land on a different
-      // scenario's page -- and an unattributed "Deployed." there is a
-      // claim about the wrong thing.
-      //
-      // Attributed rather than discarded: the deploy really did create
-      // infrastructure, and throwing the news away because the reader
-      // moved is the worse of the two failures.
-      deployOutcomeMessage = outcome.ok
-        ? `${target}: deployed. It is listed on the Deployments page until its TTL expires.`
-        : `${target}: ${outcome.message}`;
+      finishDeploy(target, teardownOutcome(await api.deployScenario(target)));
     } catch (err) {
-      if (owned !== deployGeneration) return;
-      deployOk = false;
-      deployOutcomeMessage =
-        err instanceof Error
-          ? `${target}: deploy could not be completed: ${err.message}`
-          : `${target}: deploy failed.`;
-    } finally {
-      if (owned === deployGeneration) {
-        deploying = false;
-        confirmingDeploy = false;
-      }
-      // `deployingScenario` is NOT cleared here.
-      //
-      // The last progress line -- "Deployed as dep-…", the id an
-      // operator needs for `live teardown` -- is broadcast before the
-      // HTTP response but delivered by a separate goroutine on a
-      // separate connection. It routinely arrives after this promise
-      // resolves, and clearing the subject synchronously made the
-      // filter discard exactly the line that mattered.
-      //
-      // It is cleared on navigation instead, which is when the page
-      // genuinely stops being about this deploy.
+      finishDeploy(target, {
+        ok: false,
+        message:
+          err instanceof Error ? `deploy could not be completed: ${err.message}` : "deploy failed."
+      });
     }
   }
 
@@ -544,7 +485,7 @@
       on:click={openDeployConfirmation}
       disabled={deploying || previewing}
       >{deploying
-        ? `Deploying ${deployingScenario || "…"}`
+        ? `Deploying ${detail?.name ?? "…"}`
         : previewing
           ? "Checking…"
           : "Deploy…"}</button
@@ -597,12 +538,10 @@
     </div>
   {/if}
 
-  <!-- Gated on `deployingScenario`, not on `deploying`.
-       `deploying` is a bare boolean about no particular thing, so it
-       survives navigation and would keep this panel open on a page that
-       has nothing to do with the deploy still running. The
-       subject-bearing state is the one to ask. -->
-  {#if deployingScenario || deployProgress.length > 0}
+  <!-- Read from the store, scoped to the scenario on screen. Another
+       scenario's deploy never renders here, and this scenario's deploy
+       renders whether or not this component was alive when it began. -->
+  {#if deploying || deployProgress.length > 0}
     <div
       class="mt-3 rounded border border-slate-300 bg-slate-900 px-3 py-2 font-mono text-xs text-slate-100"
       data-testid="deploy-progress"
@@ -624,12 +563,18 @@
     </div>
   {/if}
 
-  {#if deployOutcomeMessage}
+  <!-- Named, always. An apply takes minutes and the reader can navigate
+       during it, so an unattributed "deployed." is a claim about the
+       wrong thing. The store keys outcomes by scenario, so this one is
+       this scenario's by construction. -->
+  {#if deployOutcome}
     <p
-      class={`mt-3 text-sm ${deployOk ? "text-emerald-800" : "font-semibold text-rose-800"}`}
+      class={`mt-3 text-sm ${deployOutcome.ok ? "text-emerald-800" : "font-semibold text-rose-800"}`}
       data-testid="deploy-outcome"
     >
-      {deployOutcomeMessage}
+      {detail?.name}: {deployOutcome.ok
+        ? "deployed. It is listed on the Deployments page until its TTL expires."
+        : deployOutcome.message}
     </p>
   {/if}
   {#if status}<p class="mt-3 text-sm text-slate-700">{status}</p>{/if}

--- a/ui/src/routes/scenarios/[...path]/+page.svelte
+++ b/ui/src/routes/scenarios/[...path]/+page.svelte
@@ -5,6 +5,7 @@
   import { api } from "$lib/api";
   import { connectWS } from "$lib/ws";
   import {
+    acceptProgressEvent,
     deployConfirmation,
     deployWarnings,
     teardownOutcome
@@ -168,18 +169,25 @@
   // appended under the wrong heading.
   let deployProgress: string[] = [];
   let disconnectWS: (() => void) | undefined;
+  // Whether we are actually receiving. A dropped socket and "nothing has
+  // happened yet" both produce an empty log, and rendering them the same
+  // way tells the reader an apply is quiet when the truth is that it is
+  // UNOBSERVED -- the same falsehood the estate page exists to avoid.
+  let streamConnected = false;
 
   function onSocketMessage(msg: unknown) {
-    const event = msg as { type?: string; data?: { subject?: string; line?: string } };
-    if (event?.type !== "deploy_progress" || !event.data?.line) return;
-    if (event.data.subject !== deployingScenario) return;
-    deployProgress = [...deployProgress, event.data.line];
+    if (!acceptProgressEvent(msg, deployingScenario)) return;
+    const line = (msg as { data: { line: string } }).data.line;
+    deployProgress = [...deployProgress, line];
   }
 
   // The scenario whose progress this page is currently showing. Held
   // separately from `preview` because `preview` is cleared on
   // navigation while a deploy keeps running.
   let deployingScenario = "";
+  // Monotonic, so a finishing deploy can tell whether it is still the
+  // one this page is showing.
+  let deployGeneration = 0;
 
   /**
    * resetDeployState puts this page back to knowing nothing about a
@@ -196,14 +204,27 @@
    * component across scenario routes, so leaving a scenario page for
    * another one destroys nothing.
    *
-   * The deploy itself is untouched. It is detached from the request on
-   * the server, so it finishes whether or not this page is watching.
+   * `deploying` is deliberately NOT reset here. It is the only thing
+   * that stops a second deploy being started, and the apply is detached
+   * from the request on the server -- so clearing it on navigation let a
+   * reader move away, come back, find the button enabled, and start a
+   * SECOND apply while the first was still creating billable
+   * infrastructure. Two run-owned projects and two sets of resources for
+   * one scenario, from a page reporting that nothing was running.
+   *
+   * That is the exact harm ADR-0027's streaming amendment names -- "a
+   * reader who cannot tell a long apply from a hung one will do one of
+   * two harmful things: kill it, or start another" -- reachable through
+   * the code added to prevent it.
+   *
+   * The deploy itself is untouched either way. It finishes whether or
+   * not this page is watching.
    */
   function resetDeployState() {
     disconnectWS?.();
     disconnectWS = undefined;
+    streamConnected = false;
     deployingScenario = "";
-    deploying = false;
     deployProgress = [];
     confirmingDeploy = false;
     preview = null;
@@ -255,11 +276,23 @@
 
     deploying = true;
     deployingScenario = target;
+    // Which deploy this call owns. An earlier deploy finishing must not
+    // clear a LATER one's state: without this, deploying A, navigating
+    // away, deploying B, and then A's request resolving first would
+    // freeze B's log mid-stream, unlock the button, and put a green
+    // success message belonging to A directly beneath it.
+    const owned = ++deployGeneration;
     deployProgress = [];
-    if (!disconnectWS) disconnectWS = connectWS(onSocketMessage);
+    if (!disconnectWS) {
+      disconnectWS = connectWS(onSocketMessage, (connected) => (streamConnected = connected));
+    }
     try {
       const result = await api.deployScenario(target);
       const outcome = teardownOutcome(result);
+      // The outcome is always shown -- it names its scenario, so it is
+      // true wherever it lands -- but it must not overwrite a NEWER
+      // deploy's outcome.
+      if (owned !== deployGeneration) return;
       deployOk = outcome.ok;
       // NAMED, always. An apply takes minutes and the reader can
       // navigate during it, so this message can land on a different
@@ -273,15 +306,28 @@
         ? `${target}: deployed. It is listed on the Deployments page until its TTL expires.`
         : `${target}: ${outcome.message}`;
     } catch (err) {
+      if (owned !== deployGeneration) return;
       deployOk = false;
       deployOutcomeMessage =
         err instanceof Error
           ? `${target}: deploy could not be completed: ${err.message}`
           : `${target}: deploy failed.`;
     } finally {
-      deploying = false;
-      confirmingDeploy = false;
-      deployingScenario = "";
+      if (owned === deployGeneration) {
+        deploying = false;
+        confirmingDeploy = false;
+      }
+      // `deployingScenario` is NOT cleared here.
+      //
+      // The last progress line -- "Deployed as dep-…", the id an
+      // operator needs for `live teardown` -- is broadcast before the
+      // HTTP response but delivered by a separate goroutine on a
+      // separate connection. It routinely arrives after this promise
+      // resolves, and clearing the subject synchronously made the
+      // filter discard exactly the line that mattered.
+      //
+      // It is cleared on navigation instead, which is when the page
+      // genuinely stops being about this deploy.
     }
   }
 
@@ -497,7 +543,11 @@
       data-testid="scenario-deploy"
       on:click={openDeployConfirmation}
       disabled={deploying || previewing}
-      >{deploying ? "Deploying…" : previewing ? "Checking…" : "Deploy…"}</button
+      >{deploying
+        ? `Deploying ${deployingScenario || "…"}`
+        : previewing
+          ? "Checking…"
+          : "Deploy…"}</button
     >
   </div>
 
@@ -557,7 +607,14 @@
       class="mt-3 rounded border border-slate-300 bg-slate-900 px-3 py-2 font-mono text-xs text-slate-100"
       data-testid="deploy-progress"
     >
-      {#if deployProgress.length === 0}
+      {#if deployProgress.length === 0 && !streamConnected}
+        <!-- Not "Starting…": we are not receiving, so we do not know
+             whether anything has happened. The apply is unaffected --
+             it is detached from this page entirely. -->
+        <p class="text-amber-300" data-testid="deploy-progress-disconnected">
+          Not receiving progress — the apply is still running, but this page cannot see it.
+        </p>
+      {:else if deployProgress.length === 0}
         <p class="text-slate-400">Starting…</p>
       {:else}
         {#each deployProgress as line}

--- a/ui/tests/deploy-store.test.js
+++ b/ui/tests/deploy-store.test.js
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { get } from "svelte/store";
+
+import { isConnected, isRunning } from "../src/lib/deploy-store.js";
+
+// The two questions the page asks, answered from state that outlives it.
+test("isRunning is true only while a deploy of that scenario is in flight", () => {
+  const all = { "web-app-paris": { running: true, progress: [], outcome: null } };
+  assert.equal(isRunning(all, "web-app-paris"), true);
+  assert.equal(isRunning(all, "lb-serving-paris"), false, "a different scenario is not running");
+  assert.equal(isRunning({}, "web-app-paris"), false);
+  assert.equal(isRunning(undefined, "web-app-paris"), false);
+});
+
+test("isRunning is false once a deploy has finished", () => {
+  const all = { "web-app-paris": { running: false, progress: ["x"], outcome: { ok: true } } };
+  assert.equal(isRunning(all, "web-app-paris"), false);
+});
+
+// "No output yet" and "we cannot see it" must not render the same way.
+test("isConnected reports the socket rather than the absence of lines", () => {
+  assert.equal(isConnected({ __connected: true }), true);
+  assert.equal(isConnected({ __connected: false }), false);
+  assert.equal(isConnected({}), false, "unknown is not connected");
+});
+
+// The socket wiring, which is the part most worth testing and was the
+// reason this module could not import ws.ts directly.
+test("progress lines are routed to the scenario they name", async () => {
+  const { deploys, useConnector, watch, beginDeploy, finishDeploy, forgetDeploy } = await import(
+    "../src/lib/deploy-store.js"
+  );
+
+  let onMessage;
+  useConnector((handler) => {
+    onMessage = handler;
+    return () => {};
+  });
+
+  const stop = watch();
+  beginDeploy("web-app-paris");
+  beginDeploy("lb-serving-paris");
+
+  onMessage({ type: "deploy_progress", data: { subject: "web-app-paris", line: "init: running" } });
+  onMessage({ type: "deploy_progress", data: { subject: "lb-serving-paris", line: "plan: running" } });
+  onMessage({ type: "deploy_progress", data: { subject: "not-deployed", line: "ignored" } });
+
+  const all = get(deploys);
+  assert.deepEqual(all["web-app-paris"].progress, ["init: running"]);
+  assert.deepEqual(all["lb-serving-paris"].progress, ["plan: running"]);
+  assert.equal(all["not-deployed"], undefined, "a scenario with no deploy gains no state");
+
+  finishDeploy("web-app-paris", { ok: true, message: "done" });
+  assert.equal(get(deploys)["web-app-paris"].running, false);
+  assert.deepEqual(get(deploys)["web-app-paris"].progress, ["init: running"], "the log survives");
+
+  forgetDeploy("web-app-paris");
+  forgetDeploy("lb-serving-paris");
+  stop();
+});
+
+// A deploy that is still running must keep its stream open even if the
+// reader wandered off, or coming back shows a frozen log.
+test("the socket stays open while a deploy is in flight and nobody is watching", async () => {
+  const { useConnector, watch, beginDeploy, finishDeploy, forgetDeploy } = await import(
+    "../src/lib/deploy-store.js"
+  );
+
+  let closed = 0;
+  useConnector(() => () => {
+    closed += 1;
+  });
+
+  const stop = watch();
+  beginDeploy("web-app-paris");
+
+  stop();
+  assert.equal(closed, 0, "the deploy is still running; the stream must not be closed");
+
+  finishDeploy("web-app-paris", { ok: true, message: "done" });
+  assert.equal(closed, 1, "nothing running and nobody watching, so it closes");
+
+  forgetDeploy("web-app-paris");
+});

--- a/ui/tests/deployments-view.test.js
+++ b/ui/tests/deployments-view.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  acceptProgressEvent,
   addressHref,
   deployConfirmation,
   deployWarnings,
@@ -303,4 +304,44 @@ test("deployConfirmation admits when it does not know what will be created", () 
     previewFixture({ cost: { components: [], eur_per_hour: 0, unpriced: [], complete: false, modelled: false } })
   );
   assert.match(lines[0], /unknown/);
+});
+
+// This filter had NO test while it lived inline in the component: the
+// e2e tests intercept the POST in the browser, so the server never
+// broadcasts and the filter was never invoked. Typo-ing the event type,
+// which kills the entire stream, passed the whole suite.
+test("acceptProgressEvent takes only progress for the scenario on screen", () => {
+  const event = (subject, line = "tofu apply: running") => ({
+    type: "deploy_progress",
+    data: { subject, line }
+  });
+
+  assert.equal(acceptProgressEvent(event("web-app-paris"), "web-app-paris"), true);
+  assert.equal(acceptProgressEvent(event("lb-serving-paris"), "web-app-paris"), false);
+});
+
+test("acceptProgressEvent ignores every other event type", () => {
+  assert.equal(
+    acceptProgressEvent({ type: "log", data: { subject: "a", line: "x" } }, "a"),
+    false
+  );
+  // The typo that silently killed the stream and passed the suite.
+  assert.equal(
+    acceptProgressEvent({ type: "deploy-progress", data: { subject: "a", line: "x" } }, "a"),
+    false
+  );
+});
+
+test("acceptProgressEvent ignores malformed events rather than rendering blanks", () => {
+  assert.equal(acceptProgressEvent(undefined, "a"), false);
+  assert.equal(acceptProgressEvent({ type: "deploy_progress" }, "a"), false);
+  assert.equal(acceptProgressEvent({ type: "deploy_progress", data: { subject: "a" } }, "a"), false);
+});
+
+// Nothing is on screen, so nothing belongs to it.
+test("acceptProgressEvent takes nothing when no deploy is being shown", () => {
+  assert.equal(
+    acceptProgressEvent({ type: "deploy_progress", data: { subject: "a", line: "x" } }, ""),
+    false
+  );
 });


### PR DESCRIPTION
Replaces #203, which was closed rather than patched: its premise was wrong.

> Codex is out of quota until 7 September. On the user's instruction this was
> reviewed by fresh-context subagents with separate lenses instead. The caveat
> stands: they are independent of my *reasoning* but share my *model*.

## What #203 got wrong

It tee'd the deploy command's stderr — and **there was never a stream to tee.**
`runDeployCommand` writes there exactly three times: twice before any cloud work,
once after the apply returns. `CommandRunner.Run` returns a fully buffered
`CommandResult`, so `tofu`'s output does not exist until each process exits.

Shipped behaviour would have been two lines, silence for the whole apply, one
line. **Worse than before**, because a terminal-styled log pane that has stopped
moving is a stronger "hung" signal than the button label beside it.

Two of three reviewers found it independently. One *demonstrated* it by replacing
the live tee with buffer-then-dump and watching the suite stay green.

## The harness reports, because it is the only thing that can

`SandboxDeployHarnessRunner.Run` takes an `io.Writer` and announces each stage as
it begins. A parameter rather than a field, because the harness is built once and
shared and two deploys must not write into each other's stream.

Stage granularity is what the plan asked for — *"init → plan → apply → register
should scroll"* — and it does not drown a terminal. **Retries are visible now**: a
silent retry is indistinguishable from a slow stage, and a Layer 3 apply really
does retry after a transient provider error.

`TestProgressIsVisibleWhileTheApplyIsStillRunning` asserts what a watcher sees
**from inside the apply**, which buffer-then-dump cannot satisfy. Verified by
mutation.

## A second review found five more, four of them in the fix

**A stage that FAILED was reported as `done`** — the error was inspected after the
line was written, so a failed deploy ended on `init: done in 2s` and then silence.
A failure rendered as completion, in the code written to prevent that.
`TestEveryStageReportsItself` actively pinned the wrong behaviour.

**Three shared one cause: in-flight state died with the component.** Navigating
away and back mid-deploy left a real, billable apply as an unlabelled disabled
button with no log — the "cannot see it" warning was itself unreachable, gated on
state that had just been cleared. Leaving the *section* unmounted the component,
so returning gave a fresh one that believed nothing was running and would start a
**second deploy of the same scenario**. The server has no in-flight lock.

That was created by the previous round's fix: removing state on navigation is
right for the confirmation dialog and wrong for the deploy stream, and I applied
it to both because they had been folded into one function two passes earlier.
**State that must outlive the page cannot live in the page** — module-level store
keyed by scenario, owning the socket, with e2e tests pinning both journeys
including a full unmount.

Also: deploy progress was interleaving into the Live Run page's log and firing a
run-state fetch per line.

## Named rather than claimed done

`run`/`test` still applies silently. Its progress goes through `runtime.Logger`, a
structured API rather than a writer, so the Layer 3 apply on the **Live Run page**
— the more commonly watched screen — has the same defect this fixes for `deploy`.

The event subject is the **scenario**, not the deployment id: that id is minted
inside the command. Two concurrent deploys of one scenario share a stream.

Review passes 131 and 132 archived. 91 Playwright tests and the full Go suite pass.
**Nothing has run against real Scaleway.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD