### PR TITLE
S163c: the guard against a second deploy moves to the server

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -26,6 +26,19 @@ what it was showing. **Advisory only** — the refusal is the guard, and a clien
 that ignores the field still cannot start two. Always a list, never `null`: an
 unconfigured deployer and an idle one are both "nothing is deploying" to a reader.
 
+**Mutation testing disproved a claim rather than finding a bug.** Moving the
+claim before name resolution passes every test, because the deferred release fires
+on the resolution failure too — so the comment asserting "a typo cannot lock a name
+nothing will ever deploy" was false. The lock is self-correcting either way; the
+*release* is load-bearing and the ordering is tidiness. Both the comment and the
+test's docstring now say so.
+
+Also fixed: the test **deadlocked** under the no-lock mutation rather than failing,
+because its fake runtime factory blocked unconditionally. A test that hangs on
+regression is barely better than one that passes — CI reports a timeout, and nobody
+reads a timeout as "the lock is gone". Only the first call blocks now, and the
+mutation fails in half a second.
+
 Also closed: a finished deploy's success banner used to reappear on every later
 visit to that scenario for the rest of the session — a claim about infrastructure
 whose TTL may long since have expired.

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,34 @@
 
 Last updated: 2026-08-31
 
+## 2026-09-03 — S163c: the deploy guard moves to the server
+
+Two deploys of one scenario mean **two run-owned projects and two sets of billable
+resources for one thing**. Until now the only thing preventing that was
+client-side state — and three review findings across two rounds were variants of
+the same hole, each fix moving the client state around rather than noticing it was
+client state. A refresh wipes it, a second tab never had it, `curl` never
+consulted it.
+
+`LiveDeployer` holds a per-scenario lock. A second deploy of one already in flight
+returns `ErrDeployInProgress`, answered **409** and naming the scenario, because a
+bare "conflict" leaves a reader wondering which of their tabs is responsible.
+
+Per scenario rather than global — two different scenarios at once is ordinary.
+Claimed *after* name resolution so a typo cannot lock a name nothing will deploy,
+and released on every exit including failure: a scenario stuck marked-as-deploying
+could never be deployed again without restarting the server, which is worse than
+what the lock prevents.
+
+`GET /api/deployments` now reports `deploying: []` so a reloaded page can restore
+what it was showing. **Advisory only** — the refusal is the guard, and a client
+that ignores the field still cannot start two. Always a list, never `null`: an
+unconfigured deployer and an idle one are both "nothing is deploying" to a reader.
+
+Also closed: a finished deploy's success banner used to reappear on every later
+visit to that scenario for the rest of the session — a claim about infrastructure
+whose TTL may long since have expired.
+
 ## 2026-09-02 — S163: streaming a deploy, and the first version that did not
 
 A deploy runs for minutes, and **minutes of silence reads as broken**: a reader

--- a/docs/decisions/0027-deploying-from-the-ui.md
+++ b/docs/decisions/0027-deploying-from-the-ui.md
@@ -211,10 +211,16 @@ is responsible.
 **Per scenario, not global.** Two different scenarios deploying at once is
 ordinary, and blocking it would make the UI worse for no safety gain.
 
-**Claimed after resolution and released on every exit.** A typo must not lock a
-name nothing will ever deploy, and a scenario stuck marked-as-deploying could
-never be deployed again without restarting the server — a worse failure than the
-one being prevented.
+**Released on every exit, including failure.** A scenario stuck marked-as-deploying
+could never be deployed again without restarting the server — a worse failure than
+the one being prevented.
+
+The claim happens after name resolution, and that ordering is **tidiness rather
+than safety**. An earlier version of this ADR said a typo could otherwise "lock a
+name nothing will ever deploy"; mutation testing disproved it, because the
+deferred release fires on the resolution failure too. Recorded because a false
+safety claim is what the next reader reasons from — the release is the guarantee,
+the ordering is not.
 
 ### The listing says what is deploying, and that is advisory only
 

--- a/docs/decisions/0027-deploying-from-the-ui.md
+++ b/docs/decisions/0027-deploying-from-the-ui.md
@@ -191,3 +191,42 @@ than a choice: the id is minted inside the command, after the request is accepte
 Two concurrent deploys of one scenario therefore share a stream and a reader sees
 both. Recorded here rather than left to be discovered, because the id is the
 argument to `live teardown` and taking the wrong one has consequences.
+
+## Amendment, 2026-09-03 (S163c): the guard against a second deploy is server-side
+
+Two deploys of one scenario produce **two run-owned projects and two sets of
+billable resources for one thing**, and until now the only thing preventing it was
+client-side state.
+
+A page is exactly the wrong place for that guard. A refresh wipes it, a second tab
+never had it, and `curl` never consulted it. Three review findings across two
+rounds were variants of the same hole, and each fix moved the client state around
+without addressing that it was client state.
+
+`LiveDeployer` holds the lock. A second `Deploy` of a scenario already in flight
+returns `ErrDeployInProgress`, which the endpoint answers **409** — naming the
+scenario, because a bare "conflict" leaves a reader wondering which of their tabs
+is responsible.
+
+**Per scenario, not global.** Two different scenarios deploying at once is
+ordinary, and blocking it would make the UI worse for no safety gain.
+
+**Claimed after resolution and released on every exit.** A typo must not lock a
+name nothing will ever deploy, and a scenario stuck marked-as-deploying could
+never be deployed again without restarting the server — a worse failure than the
+one being prevented.
+
+### The listing says what is deploying, and that is advisory only
+
+`GET /api/deployments` reports `deploying: []`, so a reloaded page can restore
+what it was showing rather than presenting an enabled button that the server will
+refuse. The refusal is the guard; this only stops the reader being invited to trip
+it. A client that ignores the field still cannot start two.
+
+The field is always a list, never `null`: an unconfigured deployer and an idle one
+are both "nothing is deploying" to a reader.
+
+### A finished deploy's banner is forgotten when its page is left
+
+It used to reappear on every later visit for the rest of the session — a success
+message for infrastructure whose TTL may long since have expired.

--- a/docs/plans/s156e-validation-run.md
+++ b/docs/plans/s156e-validation-run.md
@@ -1,0 +1,81 @@
+# S156e — the validation run
+
+Planned 2026-09-03. This is not a code slice. It is the experiment the whole
+live-learning arc exists to justify, and it is the only thing that can tell the
+difference between "the machinery runs" and "the machinery works".
+
+## What must be shown
+
+> One live-sourced pitfall that is **prescriptive**, **attributable**, and
+> **demonstrably prevents a repeat** — proven by generating the scenario with the
+> pitfall absent and observing the failure, then with it present and observing the
+> failure gone.
+
+Everything from S154 to S163 is machinery in service of that sentence. None of it
+has been shown to work end to end against reality.
+
+## What would falsify it, written before the run
+
+The run **fails** — and that is a real result, not a setback — if any of these
+hold:
+
+1. **The failure never promotes.** The probe records it but the gate does not
+   reach its threshold, or normalisation splits one failure into several.
+2. **Nothing attributable comes out.** `live learn` writes a rule with no resource,
+   or refuses because the deployments do not agree on one.
+3. **The rule is descriptive only.** The upgrade produces no attributable diff, so
+   the corpus gains a symptom and no remedy — which is S156c's output, not
+   S156e's bar.
+4. **The rule changes nothing.** Generation with it present produces the same HCL
+   as without. This is the most likely failure and the most important to report
+   honestly: a corpus entry that does not alter generation is a corpus entry that
+   costs prompt tokens and buys nothing.
+5. **It cannot be told from noise.** The LLM produces different HCL on every run
+   anyway, so "different with the pitfall" proves nothing unless the difference is
+   the specific one the rule describes, reproducibly.
+
+(5) is the one that most needs guarding against. Generation is non-deterministic,
+so a single pair of runs is an anecdote. The comparison has to be repeated, and
+the *shape* of the difference has to match the rule.
+
+## The failure to manufacture
+
+A live failure, not a terraform failure — the distinction the whole arc rests on.
+The apply must SUCCEED and the service must still be wrong, because that is the
+class nothing else in this project can see.
+
+The chosen shape: a service whose **health path does not exist**. The load
+balancer comes up, the instance runs, `tofu apply` reports success and the orphan
+sweep is clean — and the service answers 404 on the path the scenario declared.
+Every existing signal calls that green.
+
+That is deliberately a shape the generator *can* get right when told, which is
+what makes step 4 meaningful.
+
+## Sequence
+
+1. A scenario with a health path the served application does not answer.
+2. `deploy`, then `live observe` until the promotion gate has enough evidence
+   (3 consecutive probes on one deployment, or 2 deployments).
+3. `live learn` — inspect what it wrote. Stop here and report if it is not
+   attributable.
+4. `live upgrade` onto configuration that serves the declared path, observe it
+   healthy, `live learn` again for the **prescriptive** rule.
+5. Generate the scenario **without** the corpus entry, N times. Record how often
+   the declared health path is served.
+6. Generate **with** it, N times. Compare.
+7. Tear down; verify the account is clean; report the cost.
+
+## Cost
+
+Bounded-TTL deployments of the `lb-serving-paris` shape at €0.042/hour, minutes
+each. Under the standing authorisation's no-ask threshold. The generation half
+costs LLM tokens rather than cloud money.
+
+## What gets written down either way
+
+The result, and the falsification condition it was measured against. **A negative
+result closes the arc as honestly as a positive one** — if a live-sourced pitfall
+does not change generation, that is the single most useful thing this arc could
+discover, and burying it would make every future slice built on the assumption
+worse.

--- a/docs/review-passes/pass134.md
+++ b/docs/review-passes/pass134.md
@@ -1,0 +1,55 @@
+# Review pass 134 — S163c, mutation matrix run directly
+
+Three fresh-context reviewers were launched for this slice and **all three died on
+API connection errors**, one of them leaving a mutation applied in the working
+tree. Rather than relaunch a fourth, the mutation matrix was run directly. That
+loses independence of judgement and keeps the part that matters here, which is
+mechanical: does a test fail when the code is broken?
+
+| mutation | result |
+|---|---|
+| the lock never claims | **caught** |
+| the lock is never released | **caught** |
+| `InFlight` always returns empty | **caught** |
+| the listing reports `null` instead of `[]` | **caught** |
+| **claim moved BEFORE name resolution** | **MISSED** |
+| removing the 409 branch in `deployHandler` | **caught** (found by the reviewer before it died) |
+
+## The miss is a wrong claim, not a wrong behaviour
+
+I wrote: *"Claimed AFTER resolution, so a typo cannot lock a name nothing will ever
+deploy."* Moving the claim before resolution passes every test — because the
+deferred release fires on the resolution failure too. **The lock is
+self-correcting either way, and the ordering buys nothing.**
+
+The comment asserted a safety property that does not exist. Both it and the test's
+docstring now say what is actually true: the ordering is tidiness, the *release*
+is what is load-bearing, and that is what the test catches.
+
+This is mutation testing earning its keep in an unusual way — not by finding
+broken code, but by disproving a claim *about* correct code. The code was fine;
+the explanation next to it was false, and a false explanation is what the next
+person will reason from.
+
+## And a test that hung instead of failing
+
+The first attempt at running this matrix appeared to hang. Two causes, both mine:
+
+- `timeout` does not exist on macOS, so several "runs" never executed and reported
+  nothing — I read empty output as a hang.
+- `TestDeployerRefusesASecondDeployOfTheSameScenario` genuinely did deadlock under
+  the no-claim mutation: its fake runtime factory blocked unconditionally, so the
+  second `Deploy` waited on a release the test had not sent. Go's default timeout
+  is ten minutes.
+
+**A test that hangs on regression is barely better than one that passes** — CI
+reports a timeout rather than a name, and nobody reads a timeout as "the lock is
+gone". Only the first factory call blocks now, and the mutation fails in 0.5s.
+
+## Process, recorded because it nearly cost something
+
+While a reviewer was mutation-testing, I ran `git add -A` on the same tree and
+staged its half-applied mutation. Caught before committing. **A reviewer that
+mutates owns the working tree**: no `add -A`, no branch switches, no commits until
+it hands back. The previous round's reviewer warned about exactly this from the
+other side, and I noted it and then did it anyway.

--- a/internal/api/deployment_actions.go
+++ b/internal/api/deployment_actions.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"io"
 )
 
@@ -58,7 +59,29 @@ type DeploymentDeployer interface {
 	// projects are created by the harness (ADR-0025), and a request that
 	// could name one is a request that could name somebody else's.
 	Deploy(ctx context.Context, scenarioName, ttl string, progress io.Writer) (ActionResult, error)
+
+	// InFlight names the scenarios currently deploying.
+	//
+	// Reported so a page that has just been RELOADED can know what is
+	// running. Until this existed the only thing preventing a second
+	// deploy of one scenario was client-side state, which a refresh
+	// wipes -- and the server had no lock, so the second click went
+	// through and created a second run-owned project.
+	//
+	// The list is advisory to the UI and load-bearing nowhere: the
+	// refusal happens in Deploy, so a client that ignores this still
+	// cannot start two.
+	InFlight() []string
 }
+
+// ErrDeployInProgress is returned when a scenario is already deploying.
+//
+// Per scenario rather than globally: two different scenarios deploying
+// at once is ordinary, and blocking it would make the UI worse for no
+// safety gain. Two deploys of the SAME scenario produce two run-owned
+// projects and two sets of billable resources for one thing, which is
+// never what was meant.
+var ErrDeployInProgress = errors.New("a deploy of this scenario is already running")
 
 // DeploymentActor performs the destructive half of live management.
 //

--- a/internal/api/handlers_deploy_test.go
+++ b/internal/api/handlers_deploy_test.go
@@ -31,7 +31,10 @@ type fakeDeployer struct {
 	// progressLines is written to the progress writer, so a test can
 	// assert what a watching client would have seen.
 	progressLines string
+	inFlight      []string
 }
+
+func (f *fakeDeployer) InFlight() []string { return f.inFlight }
 
 func (f *fakeDeployer) Deploy(ctx context.Context, name, ttl string, progress io.Writer) (ActionResult, error) {
 	f.calls = append(f.calls, name)
@@ -269,4 +272,53 @@ func TestDeployWorksWithNobodyListening(t *testing.T) {
 	rec := postDeploy(t, srv, `{"scenario":"lb-serving-paris"}`)
 
 	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// The page cannot be the guard: a refresh wipes its state, a second tab
+// never had it, and a `curl` never consulted it. Two deploys of one
+// scenario are two run-owned projects and two sets of billable resources
+// for one thing.
+func TestASecondDeployOfTheSameScenarioIsRefused(t *testing.T) {
+	srv := deployServer(t, &fakeDeployer{err: ErrDeployInProgress})
+
+	rec := postDeploy(t, srv, `{"scenario":"web-app-paris"}`)
+
+	assert.Equal(t, http.StatusConflict, rec.Code, "reasonable request, unreasonable moment")
+	assert.Contains(t, rec.Body.String(), "web-app-paris",
+		"a bare conflict leaves a reader wondering which of their tabs is responsible")
+}
+
+// So a page that has just been reloaded can restore what it was showing.
+func TestTheListingNamesWhatIsCurrentlyDeploying(t *testing.T) {
+	srv := NewServer(ServerConfig{
+		Config: config.Default(), Deployments: &fakeDeployments{},
+		Deployer: &fakeDeployer{inFlight: []string{"web-app-paris"}},
+	})
+
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/deployments", nil))
+
+	var payload deploymentsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	assert.Equal(t, []string{"web-app-paris"}, payload.Deploying)
+}
+
+// A nil slice marshals as `null`, which a client reads as unknown or
+// crashes on.
+func TestTheListingReportsAnEmptyDeployingListRatherThanNull(t *testing.T) {
+	for name, deployer := range map[string]DeploymentDeployer{
+		"no deployer configured":       nil,
+		"deployer with none in flight": &fakeDeployer{inFlight: nil},
+	} {
+		t.Run(name, func(t *testing.T) {
+			srv := NewServer(ServerConfig{
+				Config: config.Default(), Deployments: &fakeDeployments{}, Deployer: deployer,
+			})
+			rec := httptest.NewRecorder()
+			srv.Handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/deployments", nil))
+
+			assert.Contains(t, rec.Body.String(), `"deploying":[]`)
+			assert.NotContains(t, rec.Body.String(), `"deploying":null`)
+		})
+	}
 }

--- a/internal/api/handlers_deployments.go
+++ b/internal/api/handlers_deployments.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"sort"
@@ -88,6 +89,13 @@ type deploymentsResponse struct {
 	// and it cannot make the endpoint exist.
 	DeployAllowed bool `json:"deploy_allowed"`
 
+	// Deploying names the scenarios currently applying.
+	//
+	// Carried so a page that has just been reloaded can restore what it
+	// was showing. The guard itself is server-side; this only stops the
+	// UI offering a button that would be refused.
+	Deploying []string `json:"deploying"`
+
 	// TeardownAllowed reports whether this server was started with
 	// --allow-teardown.
 	//
@@ -137,6 +145,7 @@ func deploymentsHandler(state *serverState) http.HandlerFunc {
 			Unreadable:      make([]string, 0, len(unreadable)),
 			TeardownAllowed: state.deploymentActor != nil,
 			DeployAllowed:   state.deployer != nil,
+			Deploying:       deployingScenarios(state),
 		}
 		for _, d := range deployments {
 			payload.Deployments = append(payload.Deployments, deploymentJSON{
@@ -343,6 +352,15 @@ func deployHandler(state *serverState) http.HandlerFunc {
 		defer progress.Close()
 
 		result, err := state.deployer.Deploy(ctx, req.Scenario, req.TTL, progress)
+		if errors.Is(err, ErrDeployInProgress) {
+			// 409, not 500: the caller asked for something reasonable at
+			// an unreasonable moment. Naming the scenario matters -- a
+			// bare "conflict" leaves a reader wondering which of their
+			// tabs is responsible.
+			writeJSONError(w, http.StatusConflict,
+				fmt.Sprintf("%s is already deploying; wait for it to finish or tear it down", req.Scenario))
+			return
+		}
 		if errors.Is(err, os.ErrNotExist) {
 			// The caller named something that is not here. A client
 			// typo or a stale scenario list is not a server fault, and
@@ -353,4 +371,20 @@ func deployHandler(state *serverState) http.HandlerFunc {
 		}
 		writeActionResult(w, result, err)
 	}
+}
+
+// deployingScenarios asks the deployer what is in flight, and always
+// answers with a list rather than nil.
+//
+// A nil slice marshals as `null`, which a client reads as "unknown" or
+// crashes on. An empty estate and an unconfigured deployer are both
+// "nothing is deploying" from a reader's point of view.
+func deployingScenarios(state *serverState) []string {
+	if state.deployer == nil {
+		return []string{}
+	}
+	if inFlight := state.deployer.InFlight(); inFlight != nil {
+		return inFlight
+	}
+	return []string{}
 }

--- a/internal/cli/live_service.go
+++ b/internal/cli/live_service.go
@@ -239,8 +239,16 @@ func (d *LiveDeployer) Deploy(ctx context.Context, scenarioName, ttl string, pro
 		return api.ActionResult{}, err
 	}
 
-	// Claimed AFTER resolution, so a typo cannot lock a name nothing
-	// will ever deploy, and BEFORE anything touches the cloud.
+	// Claimed after resolution and before anything touches the cloud.
+	//
+	// The ordering is tidiness, not safety, and an earlier version of
+	// this comment claimed otherwise: "a typo cannot lock a name nothing
+	// will ever deploy". Mutation testing showed that claiming BEFORE
+	// resolution passes every test, because the deferred release fires
+	// on the resolution failure too. The lock is self-correcting either
+	// way.
+	//
+	// What IS load-bearing is the release, not the ordering.
 	if !d.claim(scenarioName) {
 		return api.ActionResult{}, api.ErrDeployInProgress
 	}

--- a/internal/cli/live_service.go
+++ b/internal/cli/live_service.go
@@ -9,7 +9,9 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -171,13 +173,59 @@ type LiveDeployer struct {
 	// scenarioRoot is where a scenario NAME is resolved from. Held so a
 	// caller cannot pass a path.
 	scenarioRoot string
+
+	// inFlight is the server-side guard against deploying one scenario
+	// twice at once.
+	//
+	// It lives HERE, not in the browser. The page used to be the only
+	// thing stopping a second deploy, and a page is exactly the wrong
+	// place for that: a refresh wipes it, a second tab never had it, and
+	// a `curl` never consulted it. Two deploys of one scenario mean two
+	// run-owned projects and two sets of billable resources for one
+	// thing.
+	mu        sync.Mutex
+	deploying map[string]bool
 }
 
 // NewLiveDeployer builds the deployer from a runtime factory.
 //
 // A factory rather than a runtime: see the caching note above.
 func NewLiveDeployer(scenarioRoot string, newRuntime func() (*CommandRuntime, error)) *LiveDeployer {
-	return &LiveDeployer{newRuntime: newRuntime, scenarioRoot: scenarioRoot}
+	return &LiveDeployer{
+		newRuntime:   newRuntime,
+		scenarioRoot: scenarioRoot,
+		deploying:    map[string]bool{},
+	}
+}
+
+// InFlight names the scenarios currently deploying, sorted.
+func (d *LiveDeployer) InFlight() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	out := make([]string, 0, len(d.deploying))
+	for scenario := range d.deploying {
+		out = append(out, scenario)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// claim reserves a scenario, reporting whether it was free.
+func (d *LiveDeployer) claim(scenario string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.deploying[scenario] {
+		return false
+	}
+	d.deploying[scenario] = true
+	return true
+}
+
+func (d *LiveDeployer) release(scenario string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.deploying, scenario)
 }
 
 // Deploy applies a scenario and leaves it running under a TTL.
@@ -190,6 +238,17 @@ func (d *LiveDeployer) Deploy(ctx context.Context, scenarioName, ttl string, pro
 	if err != nil {
 		return api.ActionResult{}, err
 	}
+
+	// Claimed AFTER resolution, so a typo cannot lock a name nothing
+	// will ever deploy, and BEFORE anything touches the cloud.
+	if !d.claim(scenarioName) {
+		return api.ActionResult{}, api.ErrDeployInProgress
+	}
+	// Released whatever happens, including a panic in the command: a
+	// scenario stuck marked-as-deploying can never be deployed again
+	// without restarting the server, which is a worse failure than the
+	// one this prevents.
+	defer d.release(scenarioName)
 
 	// Fresh per deploy. A reused runtime has a scenario cached in it and
 	// refuses every other one.

--- a/internal/cli/live_service_test.go
+++ b/internal/cli/live_service_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -306,11 +307,23 @@ func TestDeployerRefusesASecondDeployOfTheSameScenario(t *testing.T) {
 
 	// Blocks inside the runtime factory, so the first deploy is
 	// genuinely in flight while the second is attempted.
-	entered := make(chan struct{})
+	//
+	// Only the FIRST call blocks. Every later one returns at once.
+	//
+	// If the factory blocked unconditionally, a regression that removes
+	// the lock would make the second Deploy reach it and wait for a
+	// release that the test has not sent yet -- deadlocking for Go's
+	// full timeout instead of failing. A test that hangs on regression
+	// is barely better than one that passes, and this test exists to
+	// catch exactly that regression.
+	entered := make(chan struct{}, 8)
 	release := make(chan struct{})
+	var calls atomic.Int32
 	deployer := NewLiveDeployer(root, func() (*CommandRuntime, error) {
 		entered <- struct{}{}
-		<-release
+		if calls.Add(1) == 1 {
+			<-release
+		}
 		return nil, errors.New("stop here; the lock is what is under test")
 	})
 
@@ -322,14 +335,15 @@ func TestDeployerRefusesASecondDeployOfTheSameScenario(t *testing.T) {
 	assert.Equal(t, []string{"first-scenario"}, deployer.InFlight())
 
 	_, err := deployer.Deploy(context.Background(), "first-scenario", "", nil)
-	require.ErrorIs(t, err, api.ErrDeployInProgress)
+	require.ErrorIs(t, err, api.ErrDeployInProgress,
+		"a second deploy of a scenario already in flight must be refused")
 
-	// A DIFFERENT scenario is ordinary and must not be blocked.
+	// A DIFFERENT scenario is ordinary and must not be blocked. It
+	// returns immediately, so wait for it to appear rather than racing.
 	go func() {
 		_, _ = deployer.Deploy(context.Background(), "second-scenario", "", nil)
 	}()
 	<-entered
-	assert.Equal(t, []string{"first-scenario", "second-scenario"}, deployer.InFlight())
 
 	close(release)
 }
@@ -353,8 +367,12 @@ func TestTheLockIsReleasedWhenADeployFails(t *testing.T) {
 	require.NotErrorIs(t, err, api.ErrDeployInProgress)
 }
 
-// Claimed after resolution, so a typo cannot lock a name nothing will
-// ever deploy.
+// A name that resolves to nothing must leave no lock behind.
+//
+// Note what this does NOT pin: mutation testing showed that claiming
+// before resolution also passes, because the deferred release fires on
+// the resolution failure too. The ordering is tidiness; the RELEASE is
+// the thing that matters, and that is what this catches.
 func TestAnUnknownScenarioDoesNotHoldTheLock(t *testing.T) {
 	deployer := NewLiveDeployer(twoScenarios(t), func() (*CommandRuntime, error) {
 		return nil, errors.New("should not be reached")

--- a/internal/cli/live_service_test.go
+++ b/internal/cli/live_service_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/redscaresu/infrafactory/internal/api"
 )
 
 // A NAME, resolved here, never a path from the caller. `deploy` takes a
@@ -294,4 +296,72 @@ func TestDeployStderrTeesToBoth(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "a line\n", live.String())
 	assert.Equal(t, "a line\n", copy.String())
+}
+
+// The lock lives on the server because the page cannot hold it: a
+// refresh wipes client state, a second tab never had it, and a `curl`
+// never consulted it.
+func TestDeployerRefusesASecondDeployOfTheSameScenario(t *testing.T) {
+	root := twoScenarios(t)
+
+	// Blocks inside the runtime factory, so the first deploy is
+	// genuinely in flight while the second is attempted.
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	deployer := NewLiveDeployer(root, func() (*CommandRuntime, error) {
+		entered <- struct{}{}
+		<-release
+		return nil, errors.New("stop here; the lock is what is under test")
+	})
+
+	go func() {
+		_, _ = deployer.Deploy(context.Background(), "first-scenario", "", nil)
+	}()
+	<-entered
+
+	assert.Equal(t, []string{"first-scenario"}, deployer.InFlight())
+
+	_, err := deployer.Deploy(context.Background(), "first-scenario", "", nil)
+	require.ErrorIs(t, err, api.ErrDeployInProgress)
+
+	// A DIFFERENT scenario is ordinary and must not be blocked.
+	go func() {
+		_, _ = deployer.Deploy(context.Background(), "second-scenario", "", nil)
+	}()
+	<-entered
+	assert.Equal(t, []string{"first-scenario", "second-scenario"}, deployer.InFlight())
+
+	close(release)
+}
+
+// A scenario stuck marked-as-deploying could never be deployed again
+// without restarting the server -- a worse failure than the one the lock
+// prevents.
+func TestTheLockIsReleasedWhenADeployFails(t *testing.T) {
+	deployer := NewLiveDeployer(twoScenarios(t), func() (*CommandRuntime, error) {
+		return nil, errors.New("the runtime could not be built")
+	})
+
+	_, err := deployer.Deploy(context.Background(), "first-scenario", "", nil)
+	require.Error(t, err)
+
+	assert.Empty(t, deployer.InFlight(), "a failed deploy must not hold the name forever")
+
+	// And the scenario is deployable again.
+	_, err = deployer.Deploy(context.Background(), "first-scenario", "", nil)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, api.ErrDeployInProgress)
+}
+
+// Claimed after resolution, so a typo cannot lock a name nothing will
+// ever deploy.
+func TestAnUnknownScenarioDoesNotHoldTheLock(t *testing.T) {
+	deployer := NewLiveDeployer(twoScenarios(t), func() (*CommandRuntime, error) {
+		return nil, errors.New("should not be reached")
+	})
+
+	_, err := deployer.Deploy(context.Background(), "no-such-scenario", "", nil)
+	require.Error(t, err)
+
+	assert.Empty(t, deployer.InFlight())
 }

--- a/ui/e2e/deploy.spec.ts
+++ b/ui/e2e/deploy.spec.ts
@@ -734,3 +734,110 @@ test('deploy progress does not leak into the Live Run page', async ({ page }) =>
   await expect(page.locator('body')).toContainText('a genuine run log line');
   await expect(page.locator('body')).not.toContainText('deploy_progress');
 });
+
+test.describe('A reload cannot start a second deploy', () => {
+  // The page was the only guard, and a page is exactly the wrong place
+  // for one: a refresh wipes it, a second tab never had it, and a curl
+  // never consulted it.
+  test('a reloaded page shows the deploy the server says is running', async ({ page }) => {
+    await page.route('**/api/deployments', (route) => {
+      if (route.request().method() !== 'GET') return route.continue();
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          schema: 'infrafactory.api.deployments.v1',
+          deployments: [],
+          unreadable: [],
+          teardown_allowed: false,
+          deploy_allowed: true,
+          deploying: ['web-app-paris']
+        })
+      });
+    });
+    await page.route('**/api/deployments/preview**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          scenario: 'web-app-paris',
+          deployable: true,
+          expires_at: null,
+          internet_facing: false,
+          deploy_allowed: true,
+          cost: { components: [], eur_per_hour: 0, unpriced: [], complete: true, modelled: true }
+        })
+      })
+    );
+
+    await page.goto('/scenarios/training/web-app-paris');
+
+    // The button is not offered, because the server would refuse it.
+    await expect(page.getByTestId('scenario-deploy')).toBeDisabled();
+    await expect(page.getByTestId('deploy-progress')).toBeVisible();
+  });
+
+  // And a scenario the server is NOT deploying stays available.
+  test('a reload does not disable deploy for an idle scenario', async ({ page }) => {
+    await page.route('**/api/deployments', (route) => {
+      if (route.request().method() !== 'GET') return route.continue();
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          schema: 'infrafactory.api.deployments.v1',
+          deployments: [],
+          unreadable: [],
+          teardown_allowed: false,
+          deploy_allowed: true,
+          deploying: ['some-other-scenario']
+        })
+      });
+    });
+
+    await page.goto('/scenarios/training/web-app-paris');
+
+    await expect(page.getByTestId('scenario-deploy')).toBeEnabled();
+    await expect(page.getByTestId('deploy-progress')).toHaveCount(0);
+  });
+});
+
+// A success banner that reappears on every later visit is a claim about
+// something that may no longer exist -- the TTL may well have expired.
+test('a finished deploy does not haunt the scenario page', async ({ page }) => {
+  await page.route('**/api/deployments/preview**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        scenario: 'web-app-paris',
+        deployable: true,
+        expires_at: null,
+        internet_facing: false,
+        deploy_allowed: true,
+        cost: { components: [], eur_per_hour: 0, unpriced: [], complete: true, modelled: true }
+      })
+    })
+  );
+  await page.route('**/api/deployments', (route) =>
+    route.request().method() === 'POST'
+      ? route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ clean: true, steps: [], failures: [] })
+        })
+      : route.continue()
+  );
+
+  await page.goto('/scenarios/training/web-app-paris');
+  await page.getByTestId('scenario-deploy').click();
+  await page.getByTestId('deploy-confirm-go').click();
+  await expect(page.getByTestId('deploy-outcome')).toBeVisible();
+
+  await page.getByTestId('sidebar-scenario-training/lb-serving-paris').click();
+  await expect(page.locator('main h1')).toContainText('lb-serving-paris');
+
+  await page.getByTestId('sidebar-scenario-training/web-app-paris').click();
+  await expect(page.locator('main h1')).toContainText('web-app-paris');
+  await expect(page.getByTestId('deploy-outcome')).toHaveCount(0);
+});

--- a/ui/src/lib/deploy-store.js
+++ b/ui/src/lib/deploy-store.js
@@ -91,6 +91,31 @@ export function watch() {
   };
 }
 
+/**
+ * adoptInFlight seeds the store from what the SERVER says is deploying.
+ *
+ * A page reload wipes this module along with everything else, so without
+ * it a refresh mid-deploy showed an enabled Deploy button and no log --
+ * and the second click was only refused once it reached the server. The
+ * refusal is the guard; this is what stops the reader being invited to
+ * trip it.
+ *
+ * Existing entries are left alone: a deploy this tab started already has
+ * its progress, and replacing it would throw the log away.
+ */
+export function adoptInFlight(scenarios) {
+  if (!Array.isArray(scenarios) || scenarios.length === 0) return;
+  ensureSocket();
+  deploys.update((all) => {
+    const next = { ...all };
+    for (const scenario of scenarios) {
+      if (next[scenario]) continue;
+      next[scenario] = { running: true, progress: [], outcome: null, adopted: true };
+    }
+    return next;
+  });
+}
+
 export function beginDeploy(scenario) {
   ensureSocket();
   deploys.update((all) => ({

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -166,6 +166,10 @@ export interface DeploymentsResponse {
   // not offer a button it knows will 404; the SAFETY is that the
   // endpoint does not exist, and this field cannot make it exist.
   teardown_allowed: boolean;
+  // Scenarios currently applying, so a reloaded page can restore what it
+  // was showing. The guard against a second deploy is server-side; this
+  // only stops the UI offering a button that would be refused.
+  deploying: string[];
 }
 
 export interface ActionStep {

--- a/ui/src/routes/scenarios/[...path]/+page.svelte
+++ b/ui/src/routes/scenarios/[...path]/+page.svelte
@@ -10,8 +10,10 @@
     teardownOutcome
   } from "$lib/deployments-view.js";
   import {
+    adoptInFlight,
     beginDeploy,
     deploys,
+    forgetDeploy,
     finishDeploy,
     isConnected,
     isRunning,
@@ -92,7 +94,20 @@
   // The shared socket stays open while this page is mounted, and the
   // store keeps it open beyond that if a deploy is still running -- so
   // leaving and returning finds the log intact rather than frozen.
-  onMount(() => watchDeploys());
+  onMount(() => {
+    // A reload wipes the store, so ask the server what is running. The
+    // refusal is server-side either way; this stops the reader being
+    // shown a button that would be refused.
+    void api
+      .getDeployments()
+      .then((payload) => adoptInFlight(payload?.deploying))
+      .catch(() => {
+        // Unreachable estate. The Deploy button stays enabled and the
+        // server refuses if it must -- better than blocking deploys
+        // because a listing call failed.
+      });
+    return watchDeploys();
+  });
 
   onDestroy(() => {
     if (validationTimer) clearTimeout(validationTimer);
@@ -332,6 +347,13 @@
     // Every response in flight now belongs to a page that no longer
     // exists.
     navigation += 1;
+    // A FINISHED deploy's banner is dropped when the reader leaves the
+    // scenario it belongs to. Without this it reappeared on every later
+    // visit for the rest of the session, long after the TTL had expired
+    // -- a success message for something that may no longer exist.
+    if (detail?.name && deployEntry && !deployEntry.running) {
+      forgetDeploy(detail.name);
+    }
     scenarioPath = ($page.params.path || "").toString();
     // Belt and braces with confirmDeploy reading preview.scenario: a
     // confirmation describing the page you just left must not still be


### PR DESCRIPTION
Two deploys of one scenario produce **two run-owned projects and two sets of
billable resources for one thing**. Until now the only thing preventing that was
client-side state — and three review findings across two rounds were variants of
the same hole, each fix moving the client state around rather than noticing that
it *was* client state. A refresh wipes it, a second tab never had it, `curl` never
consulted it.

`LiveDeployer` holds a per-scenario lock. A second deploy of one already in flight
returns `ErrDeployInProgress`, answered **409** and naming the scenario — a bare
"conflict" leaves a reader wondering which of their tabs is responsible.

Per scenario rather than global: two different scenarios at once is ordinary.
Released on every exit including failure, because a scenario stuck
marked-as-deploying could never be deployed again without restarting the server.

`GET /api/deployments` reports `deploying: []` so a reloaded page can restore what
it was showing. **Advisory only** — the refusal is the guard, and a client that
ignores the field still cannot start two. Always a list, never `null`.

Also closed: a finished deploy's success banner reappeared on every later visit to
that scenario for the rest of the session — a claim about infrastructure whose TTL
may long since have expired.

## Review, and a finding of an unusual kind

Three fresh-context reviewers were launched and **all three died on API connection
errors**, one leaving a mutation applied in the tree. The mutation matrix was run
directly instead — losing independence of judgement, keeping the mechanical part.

Five of six mutations caught. The miss is worth the space:

I wrote *"claimed AFTER resolution, so a typo cannot lock a name nothing will ever
deploy."* **Moving the claim before resolution passes every test**, because the
deferred release fires on the resolution failure too. The lock is self-correcting
either way and the ordering buys nothing — the comment asserted a safety property
that does not exist.

That is mutation testing earning its keep by disproving a claim *about correct
code*. The code was fine; the explanation beside it was false, and a false
explanation is what the next person reasons from. The ADR, the comment and the
test's docstring now say what is true: the **release** is the guarantee, the
ordering is tidiness.

**And a test that hung instead of failing.** Under the no-lock mutation the fake
runtime factory blocked unconditionally, so the second `Deploy` waited on a release
the test had not sent — Go's default timeout is ten minutes. CI would report a
timeout rather than a name, and nobody reads a timeout as "the lock is gone". Only
the first call blocks now; the mutation fails in half a second.

Review pass 134 archived. 98 Playwright tests and the full Go suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD