### PR TITLE
S168: a stack that cannot be destroyed must not reach apply

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,49 @@
 
 Last updated: 2026-09-07
 
+## 2026-09-07 — S168: a stack that cannot be destroyed must not reach apply
+
+The S164 canary created real infrastructure that **its own teardown could not
+remove**. `web-live-paris` indexed
+`scaleway_instance_private_nic.web.private_ips[0].address`; the list was empty at
+apply time, so apply failed with "Invalid index" — and then teardown failed with
+the *same* error, because `tofu destroy` evaluates the configuration rather than
+replaying state. `run_project_delete` could not rescue it either: Scaleway refuses
+to delete a project that still holds resources. Recovery meant hand-editing the
+live workdir and running `tofu destroy` manually.
+
+ADR-0024 held — teardown correctly refused to claim success — but there was **no
+path back to a clean account inside the product**. An operator without terraform
+and shell access would have had stranded, billing infrastructure and a red banner.
+
+So the defect to prevent is not "apply failed". It is *"we let a stack reach apply
+that we could not have destroyed"*, and that is checkable before anything is
+created. The Layer 3 preflight now refuses an index into a **resource attribute**
+that is not wrapped in `try()` or `one()`. `var.x[0]` and `local.y[0]` are
+untouched: they are known at plan time and cannot strand a destroy.
+
+**Why the preflight rather than the pitfall learner.** The learner is wired only
+into `run_command.go`'s self-correcting loop, where a wrong pitfall shows up as the
+next iteration failing again. A deploy is one-shot, so a pitfall extracted from it
+is never validated by anything — and S156e already showed attribution is the weak
+point. This hazard is a *static* property of the HCL, so it belongs where ADR-0025's
+checks live: deterministic, no attribution problem, and it fails before money is
+spent. A pitfall as well is worth having, but the preflight is the guard that holds
+because it does not depend on the LLM having learned anything.
+
+**Two bugs in the check, both found by running it.** The first version looked for
+`hclsyntax.IndexExpr` — but `a.b.c[0].d` is a *single traversal* with a
+`TraverseIndex` step and contains no `IndexExpr` at all, so the check reported clean
+on the exact stack that stranded. And the `try()`-guard counter was lazily
+initialised inside `Enter` on a **value** receiver, so it reset on every node;
+`hclsyntax.Walk` copies the walker. Both are the class this week has been about: a
+plausible model of another component, asserted rather than run.
+
+Verified against the real thing: `internal/cli/testdata/undestroyable-stack` is
+`output/web-live-paris` as it stood that morning, and the preflight names both
+`loadbalancer.tf` and `outputs.tf` — the two files I had to patch by hand.
+
+
 ## 2026-09-07 — S167: the leak class, and an audit that made the same mistake it forbade
 
 Review round twenty-six found four handlers writing `err.Error()` into a response

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -747,3 +747,26 @@ will not decode, so `live forget` on a damaged record produces exactly this shap
 direction, but it must not imply it looked: skipping it silently made a store of
 one report as a store of none, which is the "0 record(s)" signal this amendment
 was written to remove, reappearing one level up in the count itself.
+
+## Amendment (2026-09-07, S168): destroy evaluates the configuration
+
+This ADR says an action that cannot prove the account clean must not report
+success. S164 found the case it does not cover: an action that cannot **get** the
+account clean at all.
+
+`tofu destroy` is not a replay of state — it evaluates the configuration. So an
+expression that fails to evaluate does not merely fail the apply; it disables the
+escape hatch. `web-live-paris` indexed a private NIC's `private_ips[0]`, the list
+was empty, apply failed on "Invalid index", and teardown failed with the identical
+error. `run_project_delete` could not help: Scaleway will not delete a project that
+still holds resources. The only recovery was hand-editing the workdir's HCL.
+
+The guarantee this ADR rests on is that infrastructure created by a run can always
+be removed by the same run. That guarantee has a **precondition nobody had stated**:
+the configuration must remain evaluable. It is now enforced in the Layer 3
+preflight, which refuses an index into a resource attribute that is not made total
+by `try()` or `one()` — before anything is created, rather than after.
+
+Stated as a rule for anything added later: **a stack that could fail to evaluate
+must not reach apply**, because evaluation is what destroy needs and destroy is the
+only thing standing between a failed apply and a bill.

--- a/internal/cli/layer3_hcl_shape.go
+++ b/internal/cli/layer3_hcl_shape.go
@@ -283,6 +283,7 @@ func layer3BlockProblems(body *hclsyntax.Body, file string, allowedResourceTypes
 		}
 		problems = append(problems, layer3NestedProblems(block, file)...)
 		problems = append(problems, layer3FunctionCallProblems(block, file)...)
+		problems = append(problems, layer3UndestroyableProblems(block, file)...)
 	}
 	return problems, sawCanonicalProvider, projectResources
 }
@@ -613,6 +614,11 @@ func layer3CallsIn(expr hclsyntax.Expression) []string {
 // not "is it useful?" but "can its result depend on anything outside its
 // arguments?"
 var layer3PureFunctions = map[string]bool{
+	// `try` is already below; `one` is added because it is the other way
+	// an index is made total, and refusing it would refuse the fix this
+	// preflight recommends.
+	"one": true,
+
 	// collections
 	"concat": true, "merge": true, "lookup": true, "element": true,
 	"length": true, "keys": true, "values": true, "flatten": true,
@@ -833,4 +839,183 @@ func layer3NestedCostProblems(block *hclsyntax.Block, file, owner string, varDef
 		problems = append(problems, layer3NestedCostProblems(inner, file, owner, varDefaults)...)
 	}
 	return problems
+}
+
+// layer3UndestroyableProblems refuses an index into a resource attribute
+// that is not made total by try() or one().
+//
+// # This is a teardown check, not an apply check
+//
+// `tofu destroy` EVALUATES THE CONFIGURATION. It is not a replay of
+// state. So an expression that cannot be evaluated does not merely fail
+// the apply -- it disables the escape hatch, and the infrastructure the
+// half-finished apply created cannot be removed by the tool that created
+// it.
+//
+// Found by running it (S164, 2026-09-07). `web-live-paris` indexed
+// `scaleway_instance_private_nic.web.private_ips[0].address`; the list
+// was empty at apply time, so apply failed with "Invalid index" --
+// and then teardown failed with the SAME error, and `run_project_delete`
+// could not rescue it either, because Scaleway refuses to delete a
+// project that still holds resources. Recovery meant hand-editing the
+// workdir's HCL and running `tofu destroy` by hand. An operator without
+// terraform and shell access would have had stranded, billing
+// infrastructure and a red banner.
+//
+// ADR-0024 held -- teardown correctly refused to claim success -- but
+// there was no path back to a clean account inside the product. So the
+// defect to prevent is not "apply failed"; it is "we let a stack reach
+// apply that we could not have destroyed", and that is checkable here,
+// before anything is created.
+//
+// # Why resource attributes specifically
+//
+// `var.x[0]` and `local.y[0]` are known at plan time and cannot surprise
+// a destroy. A resource attribute can be unknown or empty until after
+// apply, which is exactly the case that strands things. Indexing one is
+// refused unless it is wrapped: `try(...)` and `one(...)` both make the
+// expression total, so destroy can always evaluate it.
+func layer3UndestroyableProblems(block *hclsyntax.Block, file string) []string {
+	problems := make([]string, 0)
+	if block.Body == nil {
+		return problems
+	}
+	for name, attr := range block.Body.Attributes {
+		for _, ref := range layer3UnguardedResourceIndexes(attr.Expr) {
+			problems = append(problems, fmt.Sprintf(
+				"%s: %s indexes %s, and a resource attribute can be empty until after apply; `tofu destroy` evaluates the configuration, so if this index fails the stack cannot be destroyed either. Wrap it in try() or one()",
+				file, name, ref))
+		}
+	}
+	for _, inner := range block.Body.Blocks {
+		problems = append(problems, layer3UndestroyableProblems(inner, file)...)
+	}
+	return problems
+}
+
+func layer3UnguardedResourceIndexes(expr hclsyntax.Expression) []string {
+	var found []string
+	guard := 0
+	// Both fields are pointers because hclsyntax.Walk takes the walker by
+	// VALUE and calls Enter/Exit on copies. A lazily-initialised counter
+	// inside Enter silently reset on every node.
+	_ = hclsyntax.Walk(expr, layer3IndexWalker{found: &found, guard: &guard})
+	return found
+}
+
+// layer3IndexWalker collects indexes into resource attributes, skipping
+// anything already inside a total-making call.
+type layer3IndexWalker struct {
+	found *[]string
+	// guard counts enclosing try()/one() calls. Walk is depth-first with
+	// matched Enter/Exit, so a counter tracks "am I inside one" without
+	// carrying a stack.
+	guard *int
+}
+
+func (w layer3IndexWalker) Enter(node hclsyntax.Node) hcl.Diagnostics {
+	if call, ok := node.(*hclsyntax.FunctionCallExpr); ok && layer3TotalisingFunctions[call.Name] {
+		*w.guard++
+		return nil
+	}
+	if *w.guard > 0 {
+		return nil
+	}
+	// A TRAVERSAL step, not an IndexExpr.
+	//
+	// `a.b.c[0].d` is one ScopeTraversalExpr whose Traversal holds
+	// TraverseRoot, TraverseAttr, TraverseIndex, TraverseAttr -- there is
+	// no IndexExpr node anywhere in it. Looking for IndexExpr found
+	// nothing at all and the check passed everything, which is how the
+	// first version of this reported clean on the exact HCL that stranded
+	// a stack.
+	//
+	// IndexExpr does exist for the `x[expr]` form on a non-traversal, so
+	// both are handled.
+	switch e := node.(type) {
+	case *hclsyntax.ScopeTraversalExpr:
+		if ref := layer3IndexedResourceIn(e.Traversal); ref != "" {
+			*w.found = append(*w.found, ref)
+		}
+	case *hclsyntax.RelativeTraversalExpr:
+		if ref := layer3IndexedResourceIn(e.Traversal); ref != "" {
+			*w.found = append(*w.found, ref)
+		}
+	case *hclsyntax.IndexExpr:
+		if ref := layer3ResourceReference(e.Collection); ref != "" {
+			*w.found = append(*w.found, ref)
+		}
+	}
+	return nil
+}
+
+// layer3IndexedResourceIn reports the resource attribute an indexed
+// traversal reaches into, or "".
+func layer3IndexedResourceIn(traversal hcl.Traversal) string {
+	if len(traversal) < 2 {
+		return ""
+	}
+	root, ok := traversal[0].(hcl.TraverseRoot)
+	if !ok {
+		return ""
+	}
+	switch root.Name {
+	case "var", "local", "each", "count", "path", "terraform":
+		return ""
+	}
+	name := root.Name
+	for _, step := range traversal[1:] {
+		switch t := step.(type) {
+		case hcl.TraverseAttr:
+			name += "." + t.Name
+		case hcl.TraverseIndex:
+			// The index is what makes it a hazard; everything before it
+			// is the attribute being indexed.
+			return name
+		}
+	}
+	return ""
+}
+
+func (w layer3IndexWalker) Exit(node hclsyntax.Node) hcl.Diagnostics {
+	if call, ok := node.(*hclsyntax.FunctionCallExpr); ok && layer3TotalisingFunctions[call.Name] && *w.guard > 0 {
+		*w.guard--
+	}
+	return nil
+}
+
+// layer3TotalisingFunctions make an expression evaluable whatever the
+// collection holds, which is the whole property destroy needs.
+var layer3TotalisingFunctions = map[string]bool{
+	"try": true,
+	"one": true,
+}
+
+// layer3ResourceReference renders a traversal that names a RESOURCE
+// attribute, or "" for anything else.
+//
+// `var.`, `local.`, `each.` and `count.` are excluded deliberately: they
+// are known before apply, so indexing them cannot strand a stack.
+func layer3ResourceReference(expr hclsyntax.Expression) string {
+	scope, ok := expr.(*hclsyntax.ScopeTraversalExpr)
+	if !ok || len(scope.Traversal) < 2 {
+		return ""
+	}
+	root, ok := scope.Traversal[0].(hcl.TraverseRoot)
+	if !ok {
+		return ""
+	}
+	switch root.Name {
+	case "var", "local", "each", "count", "path", "terraform":
+		return ""
+	}
+	parts := root.Name
+	for _, step := range scope.Traversal[1:] {
+		attr, ok := step.(hcl.TraverseAttr)
+		if !ok {
+			break
+		}
+		parts += "." + attr.Name
+	}
+	return parts
 }

--- a/internal/cli/layer3_hcl_shape.go
+++ b/internal/cli/layer3_hcl_shape.go
@@ -940,6 +940,18 @@ func (w layer3IndexWalker) Enter(node hclsyntax.Node) hcl.Diagnostics {
 	case *hclsyntax.RelativeTraversalExpr:
 		if ref := layer3IndexedResourceIn(e.Traversal); ref != "" {
 			*w.found = append(*w.found, ref)
+			break
+		}
+		// `(a.b.c)[0].d` -- the ROOT is in Source, and the traversal
+		// begins with the index itself, so `layer3IndexedResourceIn`
+		// finds no TraverseRoot and returns "". Parenthesising the
+		// reference bypassed this check entirely; found by review.
+		if len(e.Traversal) > 0 {
+			if _, indexed := e.Traversal[0].(hcl.TraverseIndex); indexed {
+				if ref := layer3ResourceReference(layer3Unparen(e.Source)); ref != "" {
+					*w.found = append(*w.found, ref)
+				}
+			}
 		}
 	case *hclsyntax.IndexExpr:
 		if ref := layer3ResourceReference(e.Collection); ref != "" {
@@ -989,6 +1001,18 @@ func (w layer3IndexWalker) Exit(node hclsyntax.Node) hcl.Diagnostics {
 var layer3TotalisingFunctions = map[string]bool{
 	"try": true,
 	"one": true,
+}
+
+// layer3Unparen strips redundant parentheses, which are invisible to
+// evaluation and must be invisible to this check too.
+func layer3Unparen(expr hclsyntax.Expression) hclsyntax.Expression {
+	for {
+		paren, ok := expr.(*hclsyntax.ParenthesesExpr)
+		if !ok {
+			return expr
+		}
+		expr = paren.Expression
+	}
 }
 
 // layer3ResourceReference renders a traversal that names a RESOURCE

--- a/internal/cli/layer3_undestroyable_test.go
+++ b/internal/cli/layer3_undestroyable_test.go
@@ -134,3 +134,21 @@ func TestTheStackThatStrandedIsRefused(t *testing.T) {
 		"both sites, not just the first: I had to patch both by hand")
 	assert.Contains(t, err.Error(), "private_ips")
 }
+
+// Parentheses are invisible to evaluation and must be invisible here.
+//
+// `(a.b.c)[0].d` parses as a RelativeTraversalExpr whose Traversal BEGINS
+// with the index and whose root sits in `.Source`, so the first version
+// found no TraverseRoot, returned "", and let the shape straight through.
+// Found by review; the plain form was caught and this one was not.
+func TestLayer3SeesThroughParentheses(t *testing.T) {
+	err := validateLayer3HCLShape(writeLayer3Stack(t, `
+resource "scaleway_lb_backend" "main" {
+  lb_id      = scaleway_lb.main.id
+  server_ips = [(scaleway_instance_private_nic.web.private_ips)[0].address]
+}
+`), []string{"scaleway_lb*", "scaleway_instance*"})
+
+	require.Error(t, err, "parenthesising a reference must not evade the check")
+	assert.Contains(t, err.Error(), "private_ips")
+}

--- a/internal/cli/layer3_undestroyable_test.go
+++ b/internal/cli/layer3_undestroyable_test.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeLayer3Stack(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.tf"), []byte(`
+terraform {
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "2.81.0"
+    }
+  }
+}
+`+body), 0o644))
+	return dir
+}
+
+// The expression that stranded real infrastructure, verbatim.
+//
+// S164 (2026-09-07): `web-live-paris` indexed a private NIC's private_ips
+// list, the list was empty at apply time, apply failed with "Invalid
+// index" -- and then TEARDOWN FAILED WITH THE SAME ERROR, because
+// `tofu destroy` evaluates the configuration rather than replaying
+// state. `run_project_delete` could not rescue it either: Scaleway
+// refuses to delete a project that still holds resources. Recovery meant
+// hand-editing the workdir and running `tofu destroy` manually.
+func TestLayer3RefusesAnIndexThatCouldStrandTheStack(t *testing.T) {
+	dir := writeLayer3Stack(t, `
+resource "scaleway_lb_backend" "main" {
+  lb_id = scaleway_lb.main.id
+  server_ips = [
+    scaleway_instance_private_nic.web.private_ips[0].address,
+  ]
+}
+`)
+
+	err := validateLayer3HCLShape(dir, []string{"scaleway_lb*", "scaleway_instance*"})
+
+	require.Error(t, err, "this shape cost a stranded stack; it must not reach apply")
+	assert.Contains(t, err.Error(), "private_ips")
+	assert.Contains(t, err.Error(), "cannot be destroyed either",
+		"the message must say why it is refused, not merely that it is")
+	assert.Contains(t, err.Error(), "try() or one()",
+		"and what to do instead")
+}
+
+// try() and one() make the expression total, so destroy can always
+// evaluate it. That is the entire property being asked for.
+func TestLayer3AcceptsAGuardedIndex(t *testing.T) {
+	for name, body := range map[string]string{
+		"try": `
+resource "scaleway_lb_backend" "main" {
+  lb_id = scaleway_lb.main.id
+  server_ips = [try(scaleway_instance_private_nic.web.private_ips[0].address, "10.0.0.2")]
+}`,
+		"one": `
+resource "scaleway_lb_backend" "main" {
+  lb_id = scaleway_lb.main.id
+  server_ips = [one(scaleway_instance_private_nic.web.private_ips)]
+}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := validateLayer3HCLShape(writeLayer3Stack(t, body),
+				[]string{"scaleway_lb*", "scaleway_instance*"})
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// Indexing something known before apply is not the hazard.
+//
+// A rule that refused `var.subnets[0]` would be refused by its users
+// instead, and the property it protects -- that destroy can always
+// evaluate the config -- is not at risk there.
+func TestLayer3AllowsIndexingWhatIsKnownBeforeApply(t *testing.T) {
+	err := validateLayer3HCLShape(writeLayer3Stack(t, `
+variable "subnets" {
+  type    = list(string)
+  default = ["10.0.0.0/24"]
+}
+
+resource "scaleway_vpc_private_network" "main" {
+  subnet = var.subnets[0]
+}
+`), []string{"scaleway_vpc*"})
+
+	assert.NoError(t, err, "a variable is known at plan time and cannot strand a destroy")
+}
+
+// The guard must not leak past the call it belongs to.
+func TestLayer3StillRefusesAnUnguardedIndexBesideAGuardedOne(t *testing.T) {
+	err := validateLayer3HCLShape(writeLayer3Stack(t, `
+resource "scaleway_lb_backend" "main" {
+  lb_id = scaleway_lb.main.id
+  safe   = try(scaleway_instance_private_nic.web.private_ips[0].address, "10.0.0.2")
+  unsafe = scaleway_instance_server.web.public_ips[0].address
+}
+`), []string{"scaleway_lb*", "scaleway_instance*"})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "public_ips", "the unguarded one is still caught")
+	assert.NotContains(t, err.Error(), "private_ips", "the guarded one is not")
+}
+
+// The real stack, kept as a fixture.
+//
+// `output/web-live-paris` as it stood on 2026-09-07, when it created
+// infrastructure that its own teardown could not remove. The two files
+// this names -- loadbalancer.tf and outputs.tf -- are the two I had to
+// hand-edit in the live workdir before `tofu destroy` would run.
+//
+// A synthetic snippet proves the matcher works. This proves it works on
+// the thing that actually happened, which is a different claim: the
+// stack has six files, nested blocks, variables and outputs, and the
+// hazard is in two of them.
+func TestTheStackThatStrandedIsRefused(t *testing.T) {
+	err := validateLayer3HCLShape("testdata/undestroyable-stack", []string{
+		"scaleway_lb*", "scaleway_instance*", "scaleway_vpc*",
+	})
+
+	require.Error(t, err, "this exact stack cost a manual recovery")
+	assert.Contains(t, err.Error(), "loadbalancer.tf")
+	assert.Contains(t, err.Error(), "outputs.tf",
+		"both sites, not just the first: I had to patch both by hand")
+	assert.Contains(t, err.Error(), "private_ips")
+}

--- a/internal/cli/testdata/undestroyable-stack/compute.tf
+++ b/internal/cli/testdata/undestroyable-stack/compute.tf
@@ -1,0 +1,40 @@
+resource "scaleway_instance_ip" "web" {
+  zone = var.zone
+}
+
+resource "scaleway_instance_server" "web" {
+  name  = "${var.scenario_name}-web"
+  type  = var.instance_type
+  image = var.instance_image
+  ip_id = scaleway_instance_ip.web.id
+  zone  = var.zone
+
+  root_volume {
+    delete_on_termination = true
+  }
+
+  user_data = {
+    "cloud-init" = <<-EOT
+      #!/bin/bash
+      set -eux
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      apt-get install -y docker.io
+      systemctl enable --now docker
+      for i in $(seq 1 60); do
+        docker info >/dev/null 2>&1 && break
+        sleep 5
+      done
+      docker info >/dev/null 2>&1
+      docker run -d --name web --restart=always \
+        -p ${var.service_port}:${var.service_port} \
+        ${var.service_image}:${var.service_tag}
+    EOT
+  }
+}
+
+resource "scaleway_instance_private_nic" "web" {
+  server_id          = scaleway_instance_server.web.id
+  private_network_id = scaleway_vpc_private_network.main.id
+  zone               = var.zone
+}

--- a/internal/cli/testdata/undestroyable-stack/loadbalancer.tf
+++ b/internal/cli/testdata/undestroyable-stack/loadbalancer.tf
@@ -1,0 +1,43 @@
+resource "scaleway_lb_ip" "main" {
+  zone = var.zone
+}
+
+resource "scaleway_lb" "main" {
+  name   = "${var.scenario_name}-lb"
+  type   = var.lb_type
+  ip_ids = [scaleway_lb_ip.main.id]
+  zone   = var.zone
+
+  private_network {
+    private_network_id = scaleway_vpc_private_network.main.id
+  }
+}
+
+resource "scaleway_lb_backend" "main" {
+  name             = "http-backend"
+  lb_id            = scaleway_lb.main.id
+  forward_protocol = "http"
+  forward_port     = var.service_port
+
+  server_ips = [
+    scaleway_instance_private_nic.web.private_ips[0].address,
+  ]
+
+  health_check_port        = var.service_port
+  health_check_delay       = "10s"
+  health_check_timeout     = "5s"
+  health_check_max_retries = 5
+
+  health_check_http {
+    uri    = var.service_health_path
+    method = "GET"
+    code   = 200
+  }
+}
+
+resource "scaleway_lb_frontend" "main" {
+  name         = "http-frontend"
+  lb_id        = scaleway_lb.main.id
+  backend_id   = scaleway_lb_backend.main.id
+  inbound_port = var.lb_inbound_port
+}

--- a/internal/cli/testdata/undestroyable-stack/network.tf
+++ b/internal/cli/testdata/undestroyable-stack/network.tf
@@ -1,0 +1,14 @@
+resource "scaleway_vpc" "main" {
+  name   = "${var.scenario_name}-vpc"
+  region = var.region
+}
+
+resource "scaleway_vpc_private_network" "main" {
+  name   = "${var.scenario_name}-pn"
+  vpc_id = scaleway_vpc.main.id
+  region = var.region
+
+  ipv4_subnet {
+    subnet = var.private_network_subnet
+  }
+}

--- a/internal/cli/testdata/undestroyable-stack/outputs.tf
+++ b/internal/cli/testdata/undestroyable-stack/outputs.tf
@@ -1,0 +1,44 @@
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = scaleway_vpc.main.id
+}
+
+output "private_network_id" {
+  description = "ID of the private network shared by the instance and the load balancer."
+  value       = scaleway_vpc_private_network.main.id
+}
+
+output "instance_id" {
+  description = "ID of the web instance."
+  value       = scaleway_instance_server.web.id
+}
+
+output "instance_public_ip" {
+  description = "Public IPv4 of the web instance, used for egress to pull the container image."
+  value       = scaleway_instance_ip.web.address
+}
+
+output "instance_private_ip" {
+  description = "Private IPv4 of the web instance on the private network."
+  value       = scaleway_instance_private_nic.web.private_ips[0].address
+}
+
+output "load_balancer_id" {
+  description = "ID of the load balancer."
+  value       = scaleway_lb.main.id
+}
+
+output "load_balancer_ip" {
+  description = "Public IPv4 of the load balancer."
+  value       = scaleway_lb_ip.main.ip_address
+}
+
+output "load_balancer_endpoint" {
+  description = "HTTP endpoint the probe polls."
+  value       = "http://${scaleway_lb_ip.main.ip_address}:${var.lb_inbound_port}${var.service_health_path}"
+}
+
+output "service_version" {
+  description = "The pinned application image running on the instance."
+  value       = "${var.service_image}:${var.service_tag}"
+}

--- a/internal/cli/testdata/undestroyable-stack/providers.tf
+++ b/internal/cli/testdata/undestroyable-stack/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    scaleway = { source = "scaleway/scaleway", version = "2.81.0" }
+  }
+}
+provider "scaleway" {
+  region = "fr-par"
+  zone   = "fr-par-1"
+}

--- a/internal/cli/testdata/undestroyable-stack/variables.tf
+++ b/internal/cli/testdata/undestroyable-stack/variables.tf
@@ -1,0 +1,71 @@
+variable "region" {
+  description = "Scaleway region for regional resources."
+  type        = string
+  default     = "fr-par"
+}
+
+variable "zone" {
+  description = "Scaleway zone for zonal resources."
+  type        = string
+  default     = "fr-par-1"
+}
+
+variable "scenario_name" {
+  description = "Prefix applied to every resource name in this scenario."
+  type        = string
+  default     = "web-live-paris"
+}
+
+variable "private_network_subnet" {
+  description = "IPv4 CIDR of the private network the instance and load balancer share."
+  type        = string
+  default     = "10.0.0.0/24"
+}
+
+variable "instance_type" {
+  description = "Commercial type of the web instance."
+  type        = string
+  default     = "DEV1-S"
+}
+
+variable "instance_image" {
+  description = "Base image label for the web instance."
+  type        = string
+  default     = "ubuntu_jammy"
+}
+
+variable "lb_type" {
+  description = "Commercial type of the load balancer."
+  type        = string
+  default     = "LB-S"
+}
+
+variable "service_image" {
+  description = "Container image of the application, without tag."
+  type        = string
+  default     = "nginx"
+}
+
+variable "service_tag" {
+  description = "Immutable tag of the application image. Never latest."
+  type        = string
+  default     = "1.27"
+}
+
+variable "service_port" {
+  description = "Port the container publishes on the host and the load balancer forwards to."
+  type        = number
+  default     = 80
+}
+
+variable "service_health_path" {
+  description = "HTTP path the load balancer health check polls."
+  type        = string
+  default     = "/"
+}
+
+variable "lb_inbound_port" {
+  description = "Public TCP port the load balancer listens on."
+  type        = number
+  default     = 80
+}


### PR DESCRIPTION
The S164 canary created real infrastructure that **its own teardown could not
remove**.

`web-live-paris` indexed `scaleway_instance_private_nic.web.private_ips[0].address`.
The list was empty at apply time, so apply failed with `Invalid index` — and then
**teardown failed with the identical error**, because `tofu destroy` evaluates the
configuration rather than replaying state. `run_project_delete` could not rescue it
either: Scaleway refuses to delete a project that still holds resources. Recovery
meant hand-editing the live workdir and running `tofu destroy` by hand.

ADR-0024 held — teardown correctly refused to claim success — but there was **no path
back to a clean account inside the product**. An operator without terraform and shell
access would have had stranded, billing infrastructure and a red banner.

## The check

So the defect to prevent is not "apply failed". It is *"we let a stack reach apply
that we could not have destroyed"*, and that is checkable before anything is created.

The Layer 3 preflight now refuses an index into a **resource attribute** not wrapped
in `try()` or `one()`. `var.x[0]` and `local.y[0]` are untouched — known at plan
time, so they cannot strand a destroy.

## Why here and not the pitfall learner

The learner is wired only into `run_command.go`'s self-correcting loop, where a wrong
pitfall shows up as the next iteration failing again. A deploy is one-shot, so a
pitfall extracted from it is validated by nothing — and S156e already showed
attribution is the weak point (a container-image lesson filed under `scaleway_lb_ip`).

This hazard is a *static* property of the HCL, so it belongs where ADR-0025's checks
live: deterministic, no attribution problem, and it fails before money is spent. A
pitfall as well is worth having; the preflight is the guard that holds, because it
does not depend on the LLM having learned anything.

## Two bugs in the check, both found by running it

- It looked for `hclsyntax.IndexExpr`. But `a.b.c[0].d` is a **single traversal** with
  a `TraverseIndex` step and contains no `IndexExpr` at all — so the first version
  reported clean on the exact stack that stranded.
- The `try()`-guard counter was lazily initialised inside `Enter` on a **value**
  receiver, and `hclsyntax.Walk` copies the walker, so it reset on every node.

Both are this week's recurring class: a plausible model of another component,
asserted rather than run.

## Verification

- `internal/cli/testdata/undestroyable-stack` is `output/web-live-paris` as it stood
  that morning. The preflight names both `loadbalancer.tf` and `outputs.tf` — the two
  files I had to patch by hand.
- Three mutations fail the suite: unwiring the check, removing the traversal case
  (the original bug), and making `one()` non-totalising. Run at **whole-package**
  scope, after a narrower `-run` filter let one survive.
- `go vet` clean; full Go suite green.

ADR-0024 gains the precondition nobody had stated: the guarantee that a run can
remove what it created depends on the configuration remaining evaluable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD