### PR TITLE
S169b: wire the reverse citations

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -183,9 +183,9 @@ Verified by mutation: changing `deriveCurrentStage` to read any start event fail
 the assumption that says it does not.
 
 The limit, stated rather than hidden: facts about real Scaleway are expensive to
-test and stay prose — today's teardown finding is exactly that kind. And the
-reverse citations for S167/S168's comments land when those PRs do; they are on
-branches this one is not built from.
+test and stay prose — today's teardown finding is exactly that kind. The reverse citations are wired: the four comments
+that rest on these claims now name the test that proves them, so the link is
+navigable in both directions.
 
 
 ## 2026-09-06 — S164: the journey, and a decline that was wrong

--- a/docs/decisions/0028-factual-claims-are-tests-not-comments.md
+++ b/docs/decisions/0028-factual-claims-are-tests-not-comments.md
@@ -47,6 +47,12 @@ belongs in a comment or an ADR, which is what those are for.
 Assumption tests live in `assumptions_test.go` per package, named
 `TestAssumption_<claim>`, and each names the site that relies on it.
 
+**The citation runs both ways**, and both directions earn their keep. The test
+names its relying site, so deleting the site is visibly the moment the test stops
+mattering. The site names its test, so a reader who doubts the claim verifies it
+with one grep instead of reconstructing an argument — which is precisely what
+nobody did for the five claims that failed.
+
 ## Why not a convention
 
 Because S167 is the counter-example. "Do not put an error's text in a response body"

--- a/internal/api/handlers_pitfalls.go
+++ b/internal/api/handlers_pitfalls.go
@@ -163,7 +163,8 @@ func listPitfalls(state *serverState, w http.ResponseWriter, r *http.Request) {
 			// mistake built on a false premise.
 			//
 			// I wrote that "the YAML error names the file it was read
-			// from". It does not: `yaml.Unmarshal` receives bytes and
+			// from". It does not (TestAssumption_YAMLErrorsCannotNameTheFile):
+			// `yaml.Unmarshal` receives bytes and
 			// has no filename, so the text is `yaml: line 2: mapping
 			// values are not allowed in this context` -- a line number,
 			// nothing of ours. Hiding it stripped the one useful fact

--- a/internal/cli/layer3_hcl_shape.go
+++ b/internal/cli/layer3_hcl_shape.go
@@ -897,7 +897,8 @@ func layer3UnguardedResourceIndexes(expr hclsyntax.Expression) []string {
 	var found []string
 	guard := 0
 	// Both fields are pointers because hclsyntax.Walk takes the walker by
-	// VALUE and calls Enter/Exit on copies. A lazily-initialised counter
+	// VALUE and calls Enter/Exit on copies
+	// (TestAssumption_HCLWalkCopiesTheWalker). A lazily-initialised counter
 	// inside Enter silently reset on every node.
 	_ = hclsyntax.Walk(expr, layer3IndexWalker{found: &found, guard: &guard})
 	return found
@@ -925,7 +926,8 @@ func (w layer3IndexWalker) Enter(node hclsyntax.Node) hcl.Diagnostics {
 	//
 	// `a.b.c[0].d` is one ScopeTraversalExpr whose Traversal holds
 	// TraverseRoot, TraverseAttr, TraverseIndex, TraverseAttr -- there is
-	// no IndexExpr node anywhere in it. Looking for IndexExpr found
+	// no IndexExpr node anywhere in it
+	// (TestAssumption_HCLIndexesAreTraversalStepsNotIndexExprs). Looking for IndexExpr found
 	// nothing at all and the check passed everything, which is how the
 	// first version of this reported clean on the exact HCL that stranded
 	// a stack.

--- a/internal/cli/live_service.go
+++ b/internal/cli/live_service.go
@@ -310,7 +310,9 @@ func (d *LiveDeployer) Deploy(ctx context.Context, scenarioName, ttl string, pro
 		// stderr. An earlier version of this comment said stderr, and
 		// that was wrong: `runDeployCommand` is called directly rather
 		// than through `cmd.Execute()`, and cobra only prints a returned
-		// error on the latter. Nothing was written to the tee.
+		// error on the latter -- see
+		// TestAssumption_CobraOnlyPrintsErrorsFromExecute. Nothing was
+		// written to the tee.
 		runtime.Logger.Log(LogEntry{
 			Level: logLevelError, Command: "deploy", Event: "deploy_failed",
 			Status: "failed", Detail: deployErr.Error(),


### PR DESCRIPTION
S167 and S168 are on main now, so the four comments that rest on these claims can
name the test that proves them.

**The citation runs both ways, and both directions earn it.** The test names its
relying site, so deleting the site is visibly the moment the test stops mattering.
The site names its test, so a reader who doubts the claim verifies it with one grep
instead of reconstructing an argument — which is exactly what nobody did for the five
claims that failed this week.

| site | claim it rests on |
|---|---|
| `handlers_pitfalls.go` | `TestAssumption_YAMLErrorsCannotNameTheFile` |
| `live_service.go` | `TestAssumption_CobraOnlyPrintsErrorsFromExecute` |
| `layer3_hcl_shape.go` | `TestAssumption_HCLIndexesAreTraversalStepsNotIndexExprs` |
| `layer3_hcl_shape.go` | `TestAssumption_HCLWalkCopiesTheWalker` |

These were staged during S169 and never committed — the chain meant to commit them
failed and I read the absence of output as success, so #216 merged without them.
Landing them separately rather than pretending the first attempt worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD