### PR TITLE
S170: the gate catches it, and now generation learns it

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,35 @@
 
 Last updated: 2026-09-07
 
+## 2026-09-07 — S170: the gate catches it, and now generation learns it
+
+S168 added a preflight refusing an index into a resource attribute. Run against the
+whole corpus it refused **eight Scaleway scenarios** — `web-app-paris`,
+`web-app-paris-pinned`, `private-lb-db-paris`, `compute-lb-multi-paris`,
+`incremental-project-paris`, `web-live-paris` and two more — every one carrying the
+same `private_ips[0]` / `private_network[0]` shape that stranded real infrastructure.
+The stack that bit us was not special; it was the first one to be run.
+
+**The learning cycle had already seen it and could not act.** `pitfalls/scaleway.yaml`
+holds a `scaleway_lb_backend` entry discovered from `incremental-project-paris` whose
+rule is a raw stderr dump — `Error: Invalid index ... private_ips[0].address` — with
+`source: descriptive`. A symptom, not a remedy. Five of the seven Scaleway pitfalls
+are that shape. It told the generator what went wrong and nothing about what to write
+instead, which is why the shape kept being generated.
+
+So the loop closes with a prescriptive `source: avoid` rule: write
+`try(EXPR[0].address, "")` or `one(EXPR)`, and the reason — destroy evaluates the
+configuration, so an unevaluable expression breaks the escape hatch, not just the
+apply. Kept under the 1000-byte ratchet the corpus enforces (770).
+
+Both halves matter and neither substitutes for the other. The preflight is the guard
+that holds, because it does not depend on the LLM having learned anything. The
+pitfall is what stops the guard from simply blocking eight scenarios forever.
+
+**The demo is unaffected**, checked rather than assumed: `block-paris` and
+`lb-serving-paris` carry no indexed expressions, so nothing shipped this week changed
+what the gate does on stage.
+
 ## 2026-09-07 — S168: a stack that cannot be destroyed must not reach apply
 
 The S164 canary created real infrastructure that **its own teardown could not

--- a/pitfalls/scaleway.yaml
+++ b/pitfalls/scaleway.yaml
@@ -16,6 +16,23 @@ pitfalls:
       rule: "exit status 1 | stderr: ╷\n│ Error: Invalid index\n│ \n│   on loadbalancer.tf line 19, in resource \"scaleway_lb_backend\" \"web\":\n│   19:     scaleway_instance_server.web_1.private_ips[0].address,\n│     ├────────────────\n│     │ scaleway_instance_serve..."
       source: descriptive
       discovered_from: incremental-project-paris
+    - resource: scaleway_lb_backend
+      rule: |-
+        NEVER index a resource attribute directly. Write
+        `try(scaleway_instance_private_nic.web.private_ips[0].address, "")` or
+        `one(...)`, not `scaleway_instance_private_nic.web.private_ips[0].address`.
+
+        Not just about apply failing: `tofu destroy` EVALUATES THE CONFIGURATION
+        rather than replaying state, so an expression that cannot be evaluated
+        breaks destroy too -- what the half-finished apply created cannot be
+        removed, and deleting the run project does not help because Scaleway
+        refuses to delete a project holding resources. Recovery is manual.
+
+        `private_ips` and `private_network` are empty until after apply. `var.` and
+        `local.` are known at plan time and safe to index. The Layer 3 preflight
+        refuses the unguarded form, so generating it fails before anything exists.
+      source: avoid
+      discovered_from: web-live-paris
     - resource: scaleway_domain_record
       rule: "exit status 1 | stderr: ╷\n│ Error: scaleway-sdk-go: resource  with ID  is not found\n│ \n│   with scaleway_domain_record.app,\n│   on dns.tf line 1, in resource \"scaleway_domain_record\" \"app\":\n│    1: resource \"scaleway_domain_record\" \"app\" {\n│ \n╵"
       source: descriptive


### PR DESCRIPTION
S168 added a preflight refusing an index into a resource attribute. **Run against the
whole corpus it refuses eight Scaleway scenarios** — `web-app-paris`,
`web-app-paris-pinned`, `private-lb-db-paris`, `compute-lb-multi-paris`,
`incremental-project-paris`, `web-live-paris` and two more — every one carrying the
same `private_ips[0]` / `private_network[0]` shape that stranded real infrastructure
yesterday.

The stack that bit us was not special. It was the first one to be run.

## The learning cycle had already seen it and could not act

`pitfalls/scaleway.yaml` holds a `scaleway_lb_backend` entry, discovered from
`incremental-project-paris`, whose rule is a raw stderr dump:

```
exit status 1 | stderr: ╷ │ Error: Invalid index │ ...
│   scaleway_instance_server.web_1.private_ips[0].address,
```

`source: descriptive` — a **symptom, not a remedy**. Five of the seven Scaleway
pitfalls are that shape. It told the generator what went wrong and nothing about what
to write instead, which is exactly why the shape kept being generated into eight
scenarios.

## Closing the loop

A prescriptive `source: avoid` rule: write `try(EXPR[0].address, "")` or `one(EXPR)`,
with the reason — `tofu destroy` evaluates the configuration, so an unevaluable
expression breaks the escape hatch and not merely the apply. Under the corpus's
1000-byte ratchet at 770.

**Neither half substitutes for the other.** The preflight is the guard that holds,
because it does not depend on the LLM having learned anything. The pitfall is what
stops the guard from simply blocking eight scenarios forever.

## Demo safety

Checked rather than assumed: `block-paris` and `lb-serving-paris` carry no indexed
expressions, so nothing shipped this week changed what the gate does on stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD