### PR TITLE
demo: Layer 3 gate rehearsal (real cloud)

### DIFF
--- a/examples/layer3-gate/block-paris/variables.tf
+++ b/examples/layer3-gate/block-paris/variables.tf
@@ -31,5 +31,5 @@ variable "volume_iops" {
 variable "volume_tags" {
   description = "Tags applied to the application data block volume"
   type        = list(string)
-  default     = ["infrafactory", "block-paris", "app-data"]
+  default     = ["infrafactory", "block-paris", "app-data", "gate-rehearsal"]
 }


### PR DESCRIPTION
A one-tag change to the `block-paris` gate fixture, so the Layer 3 gate has a genuine
diff to apply, destroy and sweep.

**Purpose: prove the demo path still works.** Nothing has exercised it since S167
rewrote 65 error responses in `internal/api` and S168 added a preflight that refuses
HCL shapes which previously passed. The talk rests on this gate's PR comment, so it
should be proven against what is on `main` now rather than a week ago.

Expected: `preflight → init → plan → apply → destroy → orphan_sweep`, all pass, and a
summary comment on this PR. Under a penny, destroyed in the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD