### PR TITLE
S173: TypeScript 6, which SvelteKit actually supports

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -15,7 +15,7 @@
         "@tailwindcss/vite": "^4.3.3",
         "svelte": "^5.57.0",
         "tailwindcss": "^4.0.0",
-        "typescript": "^5.6.3",
+        "typescript": "^6.0.3",
         "vite": "^8.2.2"
       }
     },
@@ -1560,9 +1560,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,7 +18,7 @@
     "@tailwindcss/vite": "^4.3.3",
     "svelte": "^5.57.0",
     "tailwindcss": "^4.0.0",
-    "typescript": "^5.6.3",
+    "typescript": "^6.0.3",
     "vite": "^8.2.2"
   }
 }


### PR DESCRIPTION
**#213** proposed `typescript 7.0.2` and could not install at all:

```
npm error peerOptional typescript@"^5.3.3 || ^6.0.0" from @sveltejs/kit@2.70.3
npm error Conflicting peer dependency: typescript@6.0.3
```

TS 7 is outside SvelteKit's peer range, so `npm ci` fails at ERESOLVE before any test
runs. That is upstream — there is nothing to fix here until SvelteKit widens it.

**But `6.x` is inside the range, and we were on `^5.6.3`.** So rather than close #213
and stay put, this takes the bump that is actually supported.

## Verified

- `npm run build` clean on `6.0.3`
- 147 JS unit tests
- 133 Playwright tests, including the visual baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD