### PR TITLE
S174: the API saying "wait" is not the tool saying "broken"

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,32 @@
 
 Last updated: 2026-09-07
 
+## 2026-09-07 — S174: the API saying "wait" is not the tool saying "broken"
+
+The first live UI deploy of `web-live-paris` worked — 69 seconds, and a real HTTP 200 through a
+real load balancer. The teardown destroyed every resource and then could not delete the run's
+project: Scaleway answered **412**, `precondition is not respected`, with its own advice to retry
+later. The auto-created security group purge fired and did not unblock it.
+
+The project was verified empty by hand — no instances, load balancers, IPs or VPCs — and deleted
+cleanly on a later attempt with nothing else changed. **Roughly twenty minutes.** Scaleway's
+resource check lags its own deletions.
+
+So the failure was real and the message was misleading. It read as *something is wrong*, and sent
+the operator hunting for a leak that did not exist, when it meant *not yet*. A 412 is now marked
+with `ErrRunProjectNotYetDeletable` and reported as a timing answer: the account is clean, nothing
+is billing, run `infrafactory reap` shortly or delete it in the console.
+
+**Keyed on the HTTP status, not the message text** — matching Scaleway's prose would break the
+first time they reword it, and this package has spent enough rounds removing that coupling. The
+purge is skipped on this path too: nothing is blocking the delete except bookkeeping, so removing
+resources the API never complained about would be a guess dressed as a fix.
+
+Still a `fail`, deliberately. The project exists, so the pass cannot claim the account is clean and
+ADR-0024 does not bend for a hopeful guess. And it does **not** retry internally: twenty minutes
+would hold the teardown open for the whole window, so it reports and hands over.
+
+
 ## 2026-09-07 — S172: dependabot proposed a vulnerable stdlib, again
 
 `#211` bumped `go 1.25.13` → **`go 1.26.0`**, and CI's govulncheck failed with three

--- a/docs/decisions/0025-run-project-created-before-the-apply.md
+++ b/docs/decisions/0025-run-project-created-before-the-apply.md
@@ -454,3 +454,31 @@ One asymmetry, deliberate: the deletion guard treats a project the API reports
 a project that does not exist, or exists without the stamp, is one to refuse. So
 `live upgrade` uses its own check rather than reusing `AssertRunProjectDeletable`,
 whose message also describes the wrong operation.
+
+## Amendment (2026-09-07, S174): the delete has a timing answer
+
+This ADR moved the run's project outside Terraform: created through the Account API before the
+apply, deleted through it afterwards. That is the right call precisely *because* Terraform never
+knows the project exists — `tofu destroy` will never remove it, so if infrafactory does not, every
+run leaks one. Things outside Terraform's state are the things nothing else cleans up.
+
+What the original decision did not anticipate is that the delete has **three** outcomes, not two.
+
+Scaleway checks whether a project still holds resources before deleting it, and that check lags
+its own deletions. Immediately after a successful destroy it answers **412 `precondition is not
+respected`** with its own advice to retry later. Observed 2026-09-07: a project verified empty by
+hand — no instances, load balancers, IPs or VPCs — refused deletion for roughly twenty minutes,
+then deleted on the next attempt with nothing else changed.
+
+Reporting that as a plain failure was honest and misleading at once. It reads as *something is
+wrong*, and sends the operator looking for a leak that is not there.
+
+So a 412 is marked with `ErrRunProjectNotYetDeletable` and reported as a timing answer: resources
+destroyed, project empty, nothing billing, run `reap` shortly. Three properties are load-bearing:
+
+- **Keyed on the status, not the prose.** Scaleway's wording is theirs to change.
+- **Still a `fail`.** The project exists, so the pass cannot claim the account is clean, and
+  ADR-0024 does not bend for a hopeful guess. Only the operator's next action changes.
+- **No internal retry.** Twenty minutes would hold the teardown open for the whole window. It
+  reports and hands over, which is also why `live reconcile` gained a `Released` bucket in S167 —
+  the two together are how a project that outlives its run stays visible instead of forgotten.

--- a/internal/cli/run_project_lifecycle.go
+++ b/internal/cli/run_project_lifecycle.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -168,6 +169,13 @@ func releaseRunProject(
 		}}, nil
 	}
 
+	// A timing answer needs no purge: nothing is blocking the delete
+	// except the API's own bookkeeping, so removing resources it did not
+	// complain about would be a guess dressed as a fix.
+	if errors.Is(err, harness.ErrRunProjectNotYetDeletable) {
+		return runProjectDeleteNotYet(projectID, err.Error())
+	}
+
 	removed, purgeErr := purgeAutoCreated(cleanupCtx, runtime, projectID, secretKey)
 	if purgeErr != nil || len(removed) == 0 {
 		// Nothing was auto-created, so the delete failed for its own
@@ -176,6 +184,13 @@ func releaseRunProject(
 	}
 
 	if retryErr := runtime.Deps.RunProject.Delete(cleanupCtx, secretKey, projectID); retryErr != nil {
+		// The purge DID remove something and the delete still says wait.
+		// That is the timing answer again, not a leak the purge missed.
+		if errors.Is(retryErr, harness.ErrRunProjectNotYetDeletable) {
+			return runProjectDeleteNotYet(projectID, fmt.Sprintf(
+				"%v (after purging %d API-auto-created resource(s): %s)",
+				retryErr, len(removed), strings.Join(removed, "; ")))
+		}
 		return runProjectDeleteFailure(projectID, fmt.Sprintf(
 			"%v. Purging %d API-auto-created resource(s) (%s) did not unblock it",
 			retryErr, len(removed), strings.Join(removed, "; ")))
@@ -210,6 +225,33 @@ func runProjectDeleteFailure(projectID, detail string) ([]StageSummary, []Failur
 			Detail: fmt.Sprintf(
 				"the run's resources were destroyed but its project %s was not deleted: %s. "+
 					"An empty project is free but does not clean itself up", projectID, detail),
+		}}
+}
+
+// runProjectDeleteNotYet answers the case where the API said WAIT.
+//
+// Still a failure -- the project exists, so this pass cannot claim the
+// account is clean, and ADR-0024 does not bend for a hopeful guess. What
+// changes is what the operator is told to DO. The previous wording sent
+// them looking for a leak that is not there: the destroy succeeded, the
+// project is empty, and Scaleway's own resource check simply lags behind
+// its own deletions.
+//
+// Observed 2026-09-07: roughly twenty minutes, then it deleted on the
+// next attempt with nothing else changed. Long enough that retrying
+// inside the teardown would hold the command open for the whole window,
+// which is why this reports and hands over rather than blocking.
+func runProjectDeleteNotYet(projectID, detail string) ([]StageSummary, []FailureSummary) {
+	return []StageSummary{{Layer: "sandbox_deploy", Stage: "run_project_delete", Status: StageStatusFail}},
+		[]FailureSummary{{
+			Layer: "sandbox_deploy", Stage: "run_project_delete", Check: "delete_not_yet",
+			Command: "delete run project",
+			Detail: fmt.Sprintf(
+				"the run's resources were destroyed and project %s is empty, but the API will not "+
+					"delete it yet: its resource check lags behind the deletions. This usually "+
+					"clears within minutes and has taken up to twenty. Nothing is billing. Run "+
+					"`infrafactory reap` shortly to finish the job, or delete the project in the "+
+					"console. Detail: %s", projectID, detail),
 		}}
 }
 

--- a/internal/harness/run_project.go
+++ b/internal/harness/run_project.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -206,6 +207,16 @@ func (p *ScalewayRunProject) Describe(ctx context.Context, secretKey, projectID 
 // the same place destroySandbox already purges what the API auto-created.
 //
 // A 404 is success: the project is gone, which is the outcome asked for.
+// ErrRunProjectNotYetDeletable marks a delete the API refused because
+// its own resource check has not caught up -- a TIMING answer, not a
+// fault.
+//
+// It exists so a teardown can say "not yet" rather than "something is
+// wrong". The distinction matters: the account is genuinely clean, the
+// empty project costs nothing, and the operator's next action is to wait
+// and run `live reap` -- not to go hunting for a leak that isn't there.
+var ErrRunProjectNotYetDeletable = errors.New("the API's resource check has not caught up yet")
+
 func (p *ScalewayRunProject) Delete(ctx context.Context, secretKey, projectID string) error {
 	if strings.TrimSpace(secretKey) == "" {
 		return fmt.Errorf("delete run project: no secret key")
@@ -232,6 +243,25 @@ func (p *ScalewayRunProject) Delete(ctx context.Context, secretKey, projectID st
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
+		// 412 means NOT YET, not broken.
+		//
+		// Scaleway checks whether the project still holds resources
+		// before deleting it, and that check lags the deletions
+		// themselves. Immediately after a successful destroy it answers
+		// `precondition is not respected` with its own advice to retry
+		// later. Observed 2026-09-07: an empty project -- verified by
+		// hand as holding no instances, load balancers, IPs or VPCs --
+		// refused deletion for roughly twenty minutes, then deleted on
+		// the next attempt with no other change.
+		//
+		// Keyed on the STATUS, not on the message. Matching Scaleway's
+		// prose would break the moment they reword it, and this package
+		// has spent enough rounds removing that kind of coupling.
+		if resp.StatusCode == http.StatusPreconditionFailed {
+			return fmt.Errorf("delete project %s: http %d: %s: %w",
+				projectID, resp.StatusCode, strings.TrimSpace(string(body)),
+				ErrRunProjectNotYetDeletable)
+		}
 		return fmt.Errorf("delete project %s: http %d: %s",
 			projectID, resp.StatusCode, strings.TrimSpace(string(body)))
 	}

--- a/internal/harness/run_project_test.go
+++ b/internal/harness/run_project_test.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -240,4 +241,62 @@ func TestListRefusesWithoutCredentials(t *testing.T) {
 
 	_, err = client.List(context.Background(), "secret", "")
 	require.Error(t, err)
+}
+
+// A 412 is a TIMING answer and is marked as one.
+//
+// Scaleway checks whether a project still holds resources before
+// deleting it, and that check lags its own deletions: immediately after
+// a successful destroy it answers `precondition is not respected` and
+// tells you to retry. Observed 2026-09-07 on a project verified empty by
+// hand — it refused for about twenty minutes, then deleted with nothing
+// else changed.
+//
+// The sentinel is keyed on the STATUS, deliberately. Matching the
+// message text would break the first time Scaleway rewords it.
+func TestDeleteMarksAPreconditionFailureAsNotYet(t *testing.T) {
+	p := NewScalewayRunProjectWithDoer("https://api.example",
+		func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusPreconditionFailed,
+				Body: io.NopCloser(strings.NewReader(
+					`{"message":"precondition is not respected","precondition":"resource_not_usable"}`)),
+			}, nil
+		})
+
+	err := p.Delete(context.Background(), "sk", "proj-1")
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrRunProjectNotYetDeletable),
+		"a 412 means wait, not that something is broken")
+	assert.Contains(t, err.Error(), "proj-1", "and it still names the project")
+}
+
+// Every other failure stays an ordinary failure.
+//
+// Without this the sentinel could widen to swallow real errors, which is
+// the opposite of what it is for: a genuine block must not be reported
+// as "try again shortly".
+func TestDeleteDoesNotMarkOtherFailuresAsNotYet(t *testing.T) {
+	for name, status := range map[string]int{
+		"forbidden": http.StatusForbidden,
+		"conflict":  http.StatusConflict,
+		"server":    http.StatusInternalServerError,
+	} {
+		t.Run(name, func(t *testing.T) {
+			p := NewScalewayRunProjectWithDoer("https://api.example",
+				func(*http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: status,
+						Body:       io.NopCloser(strings.NewReader(`{"message":"nope"}`)),
+					}, nil
+				})
+
+			err := p.Delete(context.Background(), "sk", "proj-1")
+
+			require.Error(t, err)
+			assert.False(t, errors.Is(err, ErrRunProjectNotYetDeletable),
+				"only 412 is a timing answer")
+		})
+	}
 }


### PR DESCRIPTION
Found while rehearsing the live UI demo. The deploy of `web-live-paris` worked — **69 seconds, and
a real HTTP 200 through a real load balancer**. The teardown destroyed every resource, then could
not delete the run's project:

```
delete project 3b155bf1-…: http 412: {"message":"precondition is not respected",
"precondition":"resource_not_usable","help_message":"an unexpected error happened when
checking if project has resources, please retry later"}
```

The auto-created security-group purge fired and did not unblock it. The project was **verified
empty by hand** — no instances, load balancers, IPs or VPCs — and deleted cleanly about **twenty
minutes later** with nothing else changed. Scaleway's resource check lags its own deletions.

## The problem with the old message

The failure was real and the message was misleading at the same time. It read as *something is
wrong*, and sent the operator hunting for a leak that did not exist, when what it meant was *not
yet*.

## What changes

A 412 now carries `ErrRunProjectNotYetDeletable` and is reported as a timing answer: resources
destroyed, project empty, nothing billing, run `infrafactory reap` shortly or delete it in the
console.

Three properties are deliberate:

- **Keyed on the HTTP status, not the message text.** Scaleway's prose is theirs to reword, and
  this package has spent several rounds removing exactly that kind of coupling.
- **Still a `fail`.** The project exists, so the pass cannot claim the account is clean and
  ADR-0024 does not bend for a hopeful guess. Only the operator's *next action* changes.
- **No internal retry.** Twenty minutes would hold the teardown open for the whole window. It
  reports and hands over — which is what S167's `Released` bucket in `live reconcile` exists to
  keep visible.

The purge is also skipped on this path: nothing is blocking the delete except bookkeeping, so
removing resources the API never complained about would be a guess dressed as a fix.

## Verification

- 412 is marked; **403, 409 and 500 are not** — the sentinel cannot widen to swallow real errors.
- Mutation: removing the status check fails `TestDeleteMarksAPreconditionFailureAsNotYet`.
- Full Go suite green, `go vet` clean.

ADR-0025 amended: the delete has three outcomes, not two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD