### PR TITLE
S175: a warning about an apply that cannot happen

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,27 @@
 
 Last updated: 2026-09-07
 
+## 2026-09-07 — S175: a warning about an apply that cannot happen
+
+Spotted while rehearsing the demo, on the screen the talk projects. Opening the deploy
+confirmation for an infrastructure-only scenario rendered, in this order: the heading, what the
+scenario creates, two **bold warnings**, and only then the reason it could not be deployed at all.
+
+So `web-app-paris` was told *"This will be reachable from the public internet for its whole
+lifetime"* — asserted, in bold, about a deployment the same dialog was refusing to allow.
+
+Those warnings are true **of a deployment**. With no deployment possible they are not merely
+noise; they are false, which is the one thing this dialog exists not to be. It is the same class
+this arc has spent its rounds removing — a confident statement about something that is not
+happening — sitting on the most-looked-at screen in the product.
+
+The blocking reason now leads and suppresses the warnings. `confirmationLines` stays, because what
+the scenario *describes* is still worth reading and claims nothing about an apply.
+
+Found by looking at the thing rather than the code, which is becoming a pattern worth noticing:
+the ordering was plainly wrong on screen and entirely unremarkable in the template.
+
+
 ## 2026-09-07 — S174: the API saying "wait" is not the tool saying "broken"
 
 The first live UI deploy of `web-live-paris` worked — 69 seconds, and a real HTTP 200 through a

--- a/ui/e2e/deploy.spec.ts
+++ b/ui/e2e/deploy.spec.ts
@@ -2362,3 +2362,54 @@ test('a deploy already applying warns but leaves the refusal to the server', asy
   await expect(ending).toContainText('already running');
   await expect(ending).not.toContainText('may have created');
 });
+
+// A blocking reason LEADS, and silences warnings about an apply that
+// cannot happen.
+//
+// The dialog used to render the heading, what the scenario creates, the
+// bold warnings, and only then the reason it could not be deployed. So
+// an infrastructure-only scenario was told, in bold, "this will be
+// reachable from the public internet for its whole lifetime" — asserted
+// about a deployment the same dialog was refusing. True of a deployment;
+// false here, which is the one thing this dialog exists not to be.
+test('a scenario that cannot be deployed says so first, and warns about nothing', async ({
+  page
+}) => {
+  await page.route('**/api/deployments/preview**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        scenario: 'web-app-paris',
+        deployable: false,
+        reason:
+          'this scenario declares no service: block, so there is nothing to deploy. Use a run to validate infrastructure-only scenarios',
+        expires_at: null,
+        internet_facing: true,
+        deploy_allowed: true,
+        already_live: [],
+        already_live_unknown: false,
+        already_deploying: false,
+        cost: { components: [], eur_per_hour: 0, unpriced: ['managed database'], complete: false, modelled: true }
+      })
+    })
+  );
+
+  await page.goto('/scenarios/training/web-app-paris');
+  await page.getByTestId('scenario-deploy').click();
+
+  const reason = page.getByTestId('deploy-not-deployable');
+  await expect(reason).toContainText('nothing to deploy');
+
+  // Nothing asserts anything about an apply that cannot occur.
+  await expect(page.getByTestId('deploy-warning')).toHaveCount(0);
+  await expect(page.getByTestId('deploy-confirm')).not.toContainText(
+    'reachable from the public internet for its whole lifetime'
+  );
+
+  // ...and the reason comes BEFORE the list of what it would create.
+  const dialog = await page.getByTestId('deploy-confirm').innerText();
+  expect(dialog.indexOf('nothing to deploy')).toBeLessThan(dialog.indexOf('Creates'));
+
+  await expect(page.getByTestId('deploy-confirm-go')).toBeDisabled();
+});

--- a/ui/src/routes/scenarios/[...path]/+page.svelte
+++ b/ui/src/routes/scenarios/[...path]/+page.svelte
@@ -767,19 +767,40 @@
     >
       <p class="font-semibold text-slate-900">Deploy {preview.scenario}?</p>
 
+      <!-- A BLOCKING REASON LEADS, and suppresses the warnings.
+           
+           This used to render heading, then what it creates, then the
+           bold warnings, and only THEN the reason it cannot be deployed
+           at all. So an infrastructure-only scenario was told "this will
+           be reachable from the public internet for its whole lifetime"
+           -- asserted, in bold, about a deployment that cannot happen.
+           
+           The warnings are true OF A DEPLOYMENT. With no deployment
+           possible they are not merely noise, they are false, which is
+           the one thing this dialog exists not to be. The reason is what
+           the reader needs, so it goes first and the rest goes away.
+           
+           `confirmationLines` stays: what the scenario describes is
+           still worth reading, and it claims nothing about an apply. -->
+      {#if !preview.deployable}
+        <p class="mt-2 font-semibold text-rose-900" data-testid="deploy-not-deployable">
+          {preview.reason}
+        </p>
+      {/if}
+
       <ul class="mt-2 list-disc space-y-1 pl-5 text-slate-800">
         {#each confirmationLines as line}
           <li>{line}</li>
         {/each}
       </ul>
 
-      {#each previewWarnings as warning}
-        <p class="mt-2 font-semibold text-rose-900" data-testid="deploy-warning">{warning}</p>
-      {/each}
+      {#if preview.deployable}
+        {#each previewWarnings as warning}
+          <p class="mt-2 font-semibold text-rose-900" data-testid="deploy-warning">{warning}</p>
+        {/each}
+      {/if}
 
-      {#if !preview.deployable}
-        <p class="mt-2 text-rose-900" data-testid="deploy-not-deployable">{preview.reason}</p>
-      {:else if !preview.deploy_allowed}
+      {#if preview.deployable && !preview.deploy_allowed}
         <p class="mt-2 text-slate-700" data-testid="deploy-not-allowed">
           This server cannot deploy. Restart it with
           <code>infrafactory ui --allow-deploy</code>.


### PR DESCRIPTION
Spotted while rehearsing the demo, on the screen the talk projects.

Opening the deploy confirmation for an **infrastructure-only** scenario rendered, in this order:

1. heading
2. what the scenario creates
3. **two bold warnings**
4. …and only then the reason it could not be deployed at all

So the dialog told the reader, in bold:

> **This will be reachable from the public internet for its whole lifetime.**

about a deployment it was *simultaneously refusing to allow*.

## Why this is a defect and not untidiness

Those warnings are true **of a deployment**. With no deployment possible they are not merely noise
— they are false. That is the one thing this dialog exists not to be, and it is the same class this
arc has spent its rounds removing: a confident statement about something that is not happening,
sitting on the most-looked-at screen in the product.

## The fix

The blocking reason leads, and suppresses the warnings.

`confirmationLines` stays — what the scenario *describes* is still worth reading, and it claims
nothing about an apply. The `deploy_allowed` branch is likewise gated on `deployable`, so a server
without `--allow-deploy` doesn't explain how to enable a deploy that could never happen anyway.

## Verification

New e2e asserts three things: the reason appears, **no** `deploy-warning` renders, and the reason
comes *before* the creates list in the rendered text. 134 Playwright and 147 unit tests green.

## Worth noting

Found by looking at the screen, not the code. The ordering was plainly wrong rendered and entirely
unremarkable in the template — which is an argument for rehearsing the demo rather than reading it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD