### PR TITLE
S176: a bring-up that hangs forever tells you nothing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,7 @@ mockway-up: $(MOCKS_RUN_DIR)
 		echo "starting mockway on $(MOCKWAY_URL) ($(MOCKWAY_REPO))"; \
 		cd $(MOCKWAY_REPO) && $(GO) run ./cmd/mockway --port $(MOCKWAY_PORT) > $(MOCKS_RUN_DIR)/mockway.log 2>&1 & \
 		echo $$! > $(MOCKS_RUN_DIR)/mockway.pid; \
-		until curl -sSf $(MOCKWAY_URL)/mock/state >/dev/null 2>&1; do \
-			sleep 1; \
-		done; \
+		bash scripts/wait_for.sh $(MOCKWAY_URL)/mock/state mockway $(MOCKS_RUN_DIR)/mockway.log || exit 1; \
 		echo "mockway ready on $(MOCKWAY_URL) (pid=$$(cat $(MOCKS_RUN_DIR)/mockway.pid))"; \
 	fi
 
@@ -119,9 +117,7 @@ fakegcp-up: $(MOCKS_RUN_DIR)
 		echo "starting fakegcp on $(FAKEGCP_URL) ($(FAKEGCP_REPO))"; \
 		cd $(FAKEGCP_REPO) && $(GO) run ./cmd/fakegcp --port $(FAKEGCP_PORT) > $(MOCKS_RUN_DIR)/fakegcp.log 2>&1 & \
 		echo $$! > $(MOCKS_RUN_DIR)/fakegcp.pid; \
-		until curl -sSf $(FAKEGCP_URL)/mock/state >/dev/null 2>&1; do \
-			sleep 1; \
-		done; \
+		bash scripts/wait_for.sh $(FAKEGCP_URL)/mock/state fakegcp $(MOCKS_RUN_DIR)/fakegcp.log || exit 1; \
 		echo "fakegcp ready on $(FAKEGCP_URL) (pid=$$(cat $(MOCKS_RUN_DIR)/fakegcp.pid))"; \
 	fi
 
@@ -169,9 +165,7 @@ fakeaws-up: $(MOCKS_RUN_DIR)
 		echo "starting fakeaws on $(FAKEAWS_URL) ($(FAKEAWS_REPO))"; \
 		cd $(FAKEAWS_REPO) && $(GO) run ./cmd/fakeaws --port $(FAKEAWS_PORT) > $(MOCKS_RUN_DIR)/fakeaws.log 2>&1 & \
 		echo $$! > $(MOCKS_RUN_DIR)/fakeaws.pid; \
-		until curl -sSf $(FAKEAWS_URL)/mock/state >/dev/null 2>&1; do \
-			sleep 1; \
-		done; \
+		bash scripts/wait_for.sh $(FAKEAWS_URL)/mock/state fakeaws $(MOCKS_RUN_DIR)/fakeaws.log || exit 1; \
 		echo "fakeaws ready on $(FAKEAWS_URL) (pid=$$(cat $(MOCKS_RUN_DIR)/fakeaws.pid))"; \
 	fi
 
@@ -201,9 +195,7 @@ fakegenesys-up: $(MOCKS_RUN_DIR)
 		echo "starting fakegenesys on $(FAKEGENESYS_URL) ($(FAKEGENESYS_REPO))"; \
 		cd $(FAKEGENESYS_REPO) && $(GO) run ./cmd/fakegenesys --port $(FAKEGENESYS_PORT) > $(MOCKS_RUN_DIR)/fakegenesys.log 2>&1 & \
 		echo $$! > $(MOCKS_RUN_DIR)/fakegenesys.pid; \
-		until curl -sSf $(FAKEGENESYS_URL)/healthz >/dev/null 2>&1; do \
-			sleep 1; \
-		done; \
+		bash scripts/wait_for.sh $(FAKEGENESYS_URL)/healthz fakegenesys $(MOCKS_RUN_DIR)/fakegenesys.log || exit 1; \
 		echo "fakegenesys ready on $(FAKEGENESYS_URL) (pid=$$(cat $(MOCKS_RUN_DIR)/fakegenesys.pid))"; \
 	fi
 
@@ -272,7 +264,7 @@ seaweedfs-up:
 		docker run -d --name $(SEAWEEDFS_CONTAINER) --rm \
 			-p 127.0.0.1:$(SEAWEEDFS_PORT):8333 \
 			$(SEAWEEDFS_IMAGE) server -s3 -s3.port=8333 -s3.allowEmptyFolder=true >/dev/null; \
-		until curl -sSf http://127.0.0.1:$(SEAWEEDFS_PORT)/ >/dev/null 2>&1; do sleep 1; done; \
+		bash scripts/wait_for.sh http://127.0.0.1:$(SEAWEEDFS_PORT)/ seaweedfs "" 45 || exit 1; \
 		echo "seaweedfs ready on http://127.0.0.1:$(SEAWEEDFS_PORT)"; \
 	fi
 
@@ -300,7 +292,7 @@ s3router-up: $(MOCKS_RUN_DIR)
 			--seaweed-url http://127.0.0.1:$(SEAWEEDFS_PORT) \
 			--fakeaws-url $(FAKEAWS_URL) > $(MOCKS_RUN_DIR)/s3router.log 2>&1 & \
 		echo $$! > $(MOCKS_RUN_DIR)/s3router.pid; \
-		until curl -sSf $(S3ROUTER_URL)/healthz >/dev/null 2>&1 || nc -z 127.0.0.1 $(S3ROUTER_PORT) 2>/dev/null; do sleep 0.2; done; \
+		bash scripts/wait_for.sh tcp://127.0.0.1:$(S3ROUTER_PORT) s3router $(MOCKS_RUN_DIR)/s3router.log 30 || exit 1; \
 		echo "s3router ready on $(S3ROUTER_URL) (pid=$$(cat $(MOCKS_RUN_DIR)/s3router.pid))"; \
 	fi
 
@@ -509,10 +501,7 @@ smoke-validate:
 	INFRAFACTORY_ENABLE_REALTOOL_SMOKE=1 $(GO) test ./internal/cli -run TestValidateCommandRealToolSmoke
 
 smoke-mockway: mockway-up
-	@until curl -sSf $(MOCKWAY_URL)/mock/state >/dev/null; do \
-		echo "waiting for mockway at $(MOCKWAY_URL) ..."; \
-		sleep 1; \
-	done
+	@bash scripts/wait_for.sh $(MOCKWAY_URL)/mock/state mockway $(MOCKS_RUN_DIR)/mockway.log || exit 1
 	INFRAFACTORY_ENABLE_REALTOOL_MOCKWAY=1 INFRAFACTORY_MOCKWAY_URL=$(MOCKWAY_URL) $(GO) test ./internal/cli -run TestTestCommandRealToolMockwaySmoke
 
 smoke-mockway-manual:
@@ -527,10 +516,7 @@ smoke-mockway-local:
 	$(MOCKWAY_BIN) > /tmp/infrafactory-mockway.log 2>&1 & \
 	pid=$$!; \
 	trap 'kill $$pid >/dev/null 2>&1 || true; wait $$pid 2>/dev/null || true' EXIT; \
-	until curl -sSf http://127.0.0.1:8080/mock/state >/dev/null 2>&1; do \
-		echo "waiting for mockway binary at http://127.0.0.1:8080 ..."; \
-		sleep 1; \
-	done; \
+	bash scripts/wait_for.sh http://127.0.0.1:8080/mock/state "mockway binary" || exit 1; \
 	INFRAFACTORY_ENABLE_REALTOOL_MOCKWAY=1 INFRAFACTORY_MOCKWAY_URL=http://127.0.0.1:8080 $(GO) test ./internal/cli -run TestTestCommandRealToolMockwaySmoke
 
 smoke: smoke-validate smoke-mockway
@@ -614,7 +600,7 @@ up: mocks-up build $(MOCKS_RUN_DIR)
 		echo "==> starting infrafactory UI on http://127.0.0.1:4173"; \
 		nohup ./bin/infrafactory ui > $(MOCKS_RUN_DIR)/ui.log 2>&1 & \
 		echo $$! > $(MOCKS_RUN_DIR)/ui.pid; \
-		until curl -sSf http://127.0.0.1:4173/ >/dev/null 2>&1; do sleep 1; done; \
+		bash scripts/wait_for.sh http://127.0.0.1:4173/ ui $(MOCKS_RUN_DIR)/ui.log || exit 1; \
 	fi
 	@echo "==> all up: mockway :8080, fakegcp :8081, fakeaws :8082, seaweedfs :9090, ui :4173"
 	@echo "    make status   # check"

--- a/STATUS.md
+++ b/STATUS.md
@@ -21,6 +21,36 @@ the scenario *describes* is still worth reading and claims nothing about an appl
 
 Found by looking at the thing rather than the code, which is becoming a pattern worth noticing:
 the ordering was plainly wrong on screen and entirely unremarkable in the template.
+## 2026-09-07 — S176: a bring-up that hangs forever tells you nothing
+
+`make up` hung with no output and no timeout. Docker Desktop was not running, so `docker run`
+failed, SeaweedFS never listened, and `until curl ...; do sleep 1; done` spun until the terminal
+was killed. Nothing on screen said which of six services it was waiting for — and SeaweedFS is
+only needed for AWS S3 scenarios, so the whole stack was blocked on a service most runs never
+touch.
+
+**Nine unbounded waits, not one.** Every bring-up target ended the same way, so any service that
+fails to start hangs its target silently: a port already bound, a build error, a daemon that is
+not running. Docker was simply the one that happened first.
+
+`scripts/wait_for.sh` bounds the wait and fails **loudly** — naming the service, tailing its log,
+and calling out the Docker case by name, because that is the cause least visible from a log that
+does not exist. It is the CLI's own lesson from the Layer 3 arc applied to the Makefile: a guard
+that stops without saying why is half a guard.
+
+Two things caught by running it rather than reading it:
+
+- **The first version said why and still exited 0.** Each recipe is one `;`-joined `if/else`, so a
+  failing wait did not stop the chain, and `make` saw the trailing `echo` succeed. It printed the
+  error *and* "seaweedfs ready". Every call now ends `|| exit 1`.
+- **Closing the class dropped a special case.** s3router serves no `/healthz`; its original loop
+  fell back to `nc -z`, which looked like noise and was load-bearing. Replacing it with an
+  HTTP-only wait turned a working bring-up into a thirty-second failure. The helper now takes
+  `tcp://host:port` for services that have a listener and no health endpoint.
+
+Deliberately unchanged: `make up` still starts the UI with **no** deploy flags. That is the safe
+default, not an oversight — creating something that bills hourly should be a deliberate act, and
+the dialog already tells an operator to restart with `--allow-deploy`.
 
 
 ## 2026-09-07 — S174: the API saying "wait" is not the tool saying "broken"

--- a/scripts/wait_for.sh
+++ b/scripts/wait_for.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# wait_for.sh — poll a health URL until it answers, or FAIL SAYING WHY.
+#
+# Usage: wait_for.sh <url> <name> [logfile] [timeout-seconds]
+#
+# Every bring-up target used to end in:
+#
+#     until curl -sSf "$URL" >/dev/null 2>&1; do sleep 1; done
+#
+# which is fine when the service starts and a silent trap when it does
+# not. There is no bound, so a service that will never come up hangs the
+# target forever: no error, no output, nothing on screen to say which of
+# the six it was waiting for. `make up` just stops.
+#
+# Found on 2026-09-07 with Docker Desktop not running: `docker run` fails,
+# SeaweedFS never listens, and the terminal is simply dead. SeaweedFS is
+# only needed for AWS S3 scenarios, so the whole stack was blocked on a
+# service most runs never touch.
+#
+# The Layer 3 arc already learned this in the CLI: a guard that stops
+# without saying why is half a guard. Same rule here.
+set -euo pipefail
+
+url=${1:?usage: wait_for.sh <url> <name> [logfile] [timeout]}
+name=${2:?usage: wait_for.sh <url> <name> [logfile] [timeout]}
+logfile=${3:-}
+timeout=${4:-60}
+
+deadline=$(( $(date +%s) + timeout ))
+
+# `tcp://host:port` waits for the LISTENER, not a health endpoint.
+#
+# Not every service has one. s3router logs "listening" and serves no
+# /healthz at all, so the original loop for it fell back to `nc -z`.
+# Replacing that with an HTTP-only wait turned a working bring-up into a
+# 30-second failure -- the fallback was load-bearing and looked like
+# noise.
+probe() {
+  case "$url" in
+    tcp://*)
+      hostport=${url#tcp://}
+      nc -z "${hostport%%:*}" "${hostport##*:}" 2>/dev/null
+      ;;
+    *)
+      curl -sSf "$url" >/dev/null 2>&1
+      ;;
+  esac
+}
+
+while true; do
+  if probe; then
+    exit 0
+  fi
+
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    echo "ERROR: $name did not answer $url within ${timeout}s." >&2
+
+    # The log is the whole point of failing loudly: it is the only place
+    # the real cause lives -- a port already bound, a build error, a
+    # daemon that is not running.
+    if [ -n "$logfile" ] && [ -s "$logfile" ]; then
+      echo "--- last 15 lines of $logfile ---" >&2
+      tail -15 "$logfile" >&2
+      echo "--- end ---" >&2
+    elif [ -n "$logfile" ]; then
+      echo "  ($logfile is empty or missing — the process may not have started at all)" >&2
+    fi
+
+    # Named separately because it is the most common cause and the least
+    # obvious from a log that does not exist.
+    case "$name" in
+      seaweedfs)
+        echo "  seaweedfs runs in Docker. Is Docker Desktop running?" >&2
+        echo "  It is only needed for AWS S3 scenarios — 'make mockway-up' skips it." >&2
+        ;;
+    esac
+    exit 1
+  fi
+
+  sleep 1
+done


### PR DESCRIPTION
`make up` hung with no output and no timeout. Docker Desktop was not running, so `docker run`
failed, SeaweedFS never listened, and this spun until I killed the terminal:

```make
until curl -sSf http://127.0.0.1:$(SEAWEEDFS_PORT)/ >/dev/null 2>&1; do sleep 1; done
```

Nothing on screen said which of six services it was waiting for. And SeaweedFS is only needed for
AWS S3 scenarios — the whole stack was blocked on a service most runs never touch.

## It was nine waits, not one

Every bring-up target ended the same way. So **any** service that fails to start hangs its target
silently — a port already bound, a build error, a daemon that isn't running. Docker was just the
one that happened first.

`scripts/wait_for.sh` bounds the wait and fails **loudly**: names the service, tails its log, and
calls out the Docker case by name because that's the cause least visible from a log that doesn't
exist. The CLI learned this in the Layer 3 arc — *a guard that stops without saying why is half a
guard* — and the Makefile hadn't.

## Two things found by running it, not reading it

**The first version said why and still exited 0.** Each recipe is one `;`-joined `if/else`, so a
failing wait didn't stop the chain and `make` saw the trailing `echo` succeed. It printed the error
*and* `seaweedfs ready`. Every call now ends `|| exit 1`, and `make` reports `Error 1`.

**Closing the class dropped a special case.** s3router serves no `/healthz`; its original loop fell
back to `nc -z`, which looked like noise and was load-bearing. My HTTP-only replacement turned a
working bring-up into a 30-second failure. The helper now takes `tcp://host:port` for services with
a listener and no health endpoint.

## Deliberately unchanged

`make up` still starts the UI with **no deploy flags**. That's the safe default, not an oversight —
creating something that bills hourly should be a deliberate act, and the dialog already tells the
operator to restart with `--allow-deploy`.

## Verification

- Happy path: `make mocks-up` → `exit=0`, all six services ready.
- Failure path: pointed at a dead port → error naming the service, its log, the Docker hint, and
  `make: *** [seaweedfs-up] Error 1`.
- Both probe modes exercised directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD