### PR TITLE
S177: S174 skipped the fix and then reassured the operator about it

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -51,6 +51,39 @@ Two things caught by running it rather than reading it:
 Deliberately unchanged: `make up` still starts the UI with **no** deploy flags. That is the safe
 default, not an oversight — creating something that bills hourly should be a deliberate act, and
 the dialog already tells an operator to restart with `--allow-deploy`.
+## 2026-09-07 — S177: S174 skipped the fix and then reassured the operator about it
+
+Caught the same evening, on a real teardown, by the operator it misled.
+
+S174 marked a 412 from the project delete as a timing answer and short-circuited **before**
+`purgeAutoCreated`, reasoning that "a timing answer needs no purge: nothing is blocking the delete
+except the API's own bookkeeping". That was a confident explanation of an API I had observed once.
+
+Scaleway returns at least two preconditions behind a 412:
+
+| precondition | help_message | means |
+|---|---|---|
+| `resource_not_usable` | "please retry later" | the check is lagging |
+| `resource_still_in_use` | "all resources are not deleted" | **there really is something there** |
+
+The second one means exactly what it says. The teardown reported *"the project is empty… Nothing is
+billing"* while the API-created `Default security group` sat there holding the project open — the D6
+case `purgeAutoCreated` exists for, skipped by the short-circuit that ran instead of it. Deleting
+that one group unblocked the project immediately.
+
+So S174 turned a **self-healing** case (purge → retry → deleted) into a permanent failure carrying a
+comforting message. Strictly worse than the wording it replaced.
+
+The purge now always runs first, and only a 412 that *survives* it is reported as wait-and-retry.
+The message no longer claims the project is empty or that nothing is billing — it says what was
+actually done (resources destroyed, nothing left to purge, API still refusing) and points at the
+console if a retry does not clear it.
+
+**The lesson is the week's, again, and I had already written it down.** Facts about the real cloud
+are the class ADR-0028 explicitly cannot reach: too expensive to pin in a test, so they live in
+prose and stay risky. I observed one 412 in the afternoon, generalised it to all 412s, and wrote the
+generalisation into a comment as though it were established. Two tests now hold the shape that
+matters, and neither could have been written without seeing the second variant.
 
 
 ## 2026-09-07 — S174: the API saying "wait" is not the tool saying "broken"

--- a/docs/decisions/0025-run-project-created-before-the-apply.md
+++ b/docs/decisions/0025-run-project-created-before-the-apply.md
@@ -482,3 +482,22 @@ destroyed, project empty, nothing billing, run `reap` shortly. Three properties 
 - **No internal retry.** Twenty minutes would hold the teardown open for the whole window. It
   reports and hands over, which is also why `live reconcile` gained a `Released` bucket in S167 —
   the two together are how a project that outlives its run stays visible instead of forgotten.
+
+## Correction (2026-09-07, S177): purge before judging the 412
+
+The amendment above was right that a 412 can mean "not yet" and wrong that it always does.
+
+Scaleway returns at least two preconditions behind that status: `resource_not_usable` with "please
+retry later", which is the lagging check, and `resource_still_in_use` with "all resources are not
+deleted", which means precisely what it says. S174 short-circuited on the sentinel before
+`purgeAutoCreated` ran — so a project held open by the API-created default security group, the D6
+case that purge exists for, was reported to the operator as empty and not billing.
+
+That is worse than the failure it replaced: it skipped the fix and then reassured them.
+
+**The purge always runs first.** Only a 412 that survives it is a timing answer, and even then the
+message says what was done rather than what is presumed true — resources destroyed, nothing left to
+purge, API still refusing, retry and then look in the console.
+
+The general rule this arc keeps relearning: a status code is a category, not a diagnosis. Keying on
+it is right; concluding from one observation of it is not.

--- a/internal/cli/run_project_lifecycle.go
+++ b/internal/cli/run_project_lifecycle.go
@@ -169,17 +169,36 @@ func releaseRunProject(
 		}}, nil
 	}
 
-	// A timing answer needs no purge: nothing is blocking the delete
-	// except the API's own bookkeeping, so removing resources it did not
-	// complain about would be a guess dressed as a fix.
-	if errors.Is(err, harness.ErrRunProjectNotYetDeletable) {
-		return runProjectDeleteNotYet(projectID, err.Error())
-	}
-
+	// PURGE FIRST, always. The 412 short-circuit that used to sit here
+	// was wrong twice over.
+	//
+	// It read "a timing answer needs no purge: nothing is blocking the
+	// delete except the API's own bookkeeping" -- which assumed every 412
+	// was the lagging-check kind. It is not. Scaleway returns at least
+	// two:
+	//
+	//   resource_not_usable   "please retry later"           -- lagging
+	//   resource_still_in_use "all resources are not deleted" -- REAL
+	//
+	// The second one means exactly what it says. Observed 2026-09-07: a
+	// teardown reported "the project is empty, nothing is billing" while
+	// the API-created `Default security group` was still there holding
+	// the project open -- the D6 case this purge exists for. Deleting
+	// that one group unblocked the project immediately.
+	//
+	// So the short-circuit skipped the fix and then reassured the
+	// operator about it, turning a self-healing case into a permanent
+	// failure with a comforting message. Purge, retry, and only then
+	// decide what kind of failure this is.
 	removed, purgeErr := purgeAutoCreated(cleanupCtx, runtime, projectID, secretKey)
 	if purgeErr != nil || len(removed) == 0 {
 		// Nothing was auto-created, so the delete failed for its own
-		// reasons. Report that error, not a retry's.
+		// reasons. Report that error, not a retry's -- and only NOW is a
+		// 412 safely a timing answer: there was nothing to remove, so
+		// there is nothing left holding the project.
+		if errors.Is(err, harness.ErrRunProjectNotYetDeletable) {
+			return runProjectDeleteNotYet(projectID, err.Error())
+		}
 		return runProjectDeleteFailure(projectID, err.Error())
 	}
 
@@ -228,30 +247,40 @@ func runProjectDeleteFailure(projectID, detail string) ([]StageSummary, []Failur
 		}}
 }
 
-// runProjectDeleteNotYet answers the case where the API said WAIT.
+// runProjectDeleteNotYet answers a 412 that SURVIVED the purge.
 //
 // Still a failure -- the project exists, so this pass cannot claim the
 // account is clean, and ADR-0024 does not bend for a hopeful guess. What
-// changes is what the operator is told to DO. The previous wording sent
-// them looking for a leak that is not there: the destroy succeeded, the
-// project is empty, and Scaleway's own resource check simply lags behind
-// its own deletions.
+// changes is what the operator is told to do next.
 //
-// Observed 2026-09-07: roughly twenty minutes, then it deleted on the
-// next attempt with nothing else changed. Long enough that retrying
-// inside the teardown would hold the command open for the whole window,
-// which is why this reports and hands over rather than blocking.
+// It no longer claims the project is EMPTY or that nothing is billing.
+// The first version did, and was caught being wrong the same evening: a
+// 412 carrying `resource_still_in_use` meant exactly what it said -- an
+// API-created security group was holding the project open -- while this
+// message reassured the operator that there was nothing there. A
+// comforting sentence about someone else's account is worse than no
+// sentence.
+//
+// What can honestly be said is what we did: the run's resources were
+// destroyed, the purge found nothing more to remove, and the API still
+// refuses. That is a wait-and-retry, and if retrying does not clear it
+// the operator is pointed at the console rather than told to relax.
+//
+// Observed 2026-09-07: the lagging-check variant cleared in about twenty
+// minutes with nothing else changed. Long enough that retrying inside
+// the teardown would hold the command open for the whole window, which
+// is why this reports and hands over rather than blocking.
 func runProjectDeleteNotYet(projectID, detail string) ([]StageSummary, []FailureSummary) {
 	return []StageSummary{{Layer: "sandbox_deploy", Stage: "run_project_delete", Status: StageStatusFail}},
 		[]FailureSummary{{
 			Layer: "sandbox_deploy", Stage: "run_project_delete", Check: "delete_not_yet",
 			Command: "delete run project",
 			Detail: fmt.Sprintf(
-				"the run's resources were destroyed and project %s is empty, but the API will not "+
-					"delete it yet: its resource check lags behind the deletions. This usually "+
-					"clears within minutes and has taken up to twenty. Nothing is billing. Run "+
-					"`infrafactory reap` shortly to finish the job, or delete the project in the "+
-					"console. Detail: %s", projectID, detail),
+				"the run's resources were destroyed and nothing auto-created was left to purge, "+
+					"but the API will not delete project %s yet. Its resource check can lag its "+
+					"own deletions; that usually clears within minutes and has taken up to twenty. "+
+					"Run `infrafactory reap` shortly, and if it still refuses, open the project in "+
+					"the console and look for what it is holding. Detail: %s", projectID, detail),
 		}}
 }
 

--- a/internal/cli/run_project_lifecycle_test.go
+++ b/internal/cli/run_project_lifecycle_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -448,4 +449,68 @@ func (f *fakeRunProject) List(_ context.Context, _, organizationID string) ([]ha
 	f.lists++
 	f.lastOrg = organizationID
 	return f.listed, f.listErr
+}
+
+// A 412 does NOT mean "wait" until the purge has had its turn.
+//
+// Scaleway returns at least two preconditions behind a 412:
+//
+//	resource_not_usable    "please retry later"            -- lagging check
+//	resource_still_in_use  "all resources are not deleted"  -- really still there
+//
+// The second one means exactly what it says, and the thing saying it is
+// usually the `Default security group` the API creates on the first
+// Instance and Terraform never owns -- the D6 case `purgeAutoCreated`
+// exists for.
+//
+// S174 short-circuited on the sentinel BEFORE the purge, on the reasoning
+// that "a timing answer needs no purge". That skipped the fix and then
+// told the operator the project was empty and nothing was billing.
+// Observed the same evening on a real teardown: the group was sitting
+// there holding the project open, and deleting it unblocked the project
+// immediately.
+func TestA412StillPurgesBeforeGivingUp(t *testing.T) {
+	notYet := fmt.Errorf("delete project: http 412: resource_still_in_use: %w",
+		harness.ErrRunProjectNotYetDeletable)
+
+	rp := &fakeRunProject{deleteErrs: []error{notYet, nil}}
+	purge := &fakePurge{removed: []string{"security_group 19e815eb (Default security group) in fr-par-1"}}
+	rt := &CommandRuntime{Deps: RuntimeDependencies{RunProject: rp, AutoCreated: purge}}
+
+	stages, failures := releaseRunProject(
+		context.Background(), rt, purgeWorkDir(t), purgeProjectID, destroyEnv)
+
+	assert.Equal(t, 1, purge.calls, "the purge must run even for a 412")
+	assert.Equal(t, 2, rp.deletes, "and the delete must be retried after it")
+	assert.Empty(t, failures, "the retry succeeded, so this is not a failure")
+
+	var stageNames []string
+	for _, s := range stages {
+		stageNames = append(stageNames, s.Stage)
+	}
+	assert.Contains(t, stageNames, "auto_created_purge",
+		"and the operator is told what was removed")
+}
+
+// Only once the purge finds nothing is a 412 safely a timing answer.
+func TestA412WithNothingToPurgeReportsWaitNotFailure(t *testing.T) {
+	notYet := fmt.Errorf("delete project: http 412: %w", harness.ErrRunProjectNotYetDeletable)
+
+	rp := &fakeRunProject{deleteErr: notYet}
+	rt := &CommandRuntime{Deps: RuntimeDependencies{
+		RunProject: rp, AutoCreated: &fakePurge{removed: nil},
+	}}
+
+	_, failures := releaseRunProject(
+		context.Background(), rt, purgeWorkDir(t), purgeProjectID, destroyEnv)
+
+	require.Len(t, failures, 1)
+	assert.Equal(t, "delete_not_yet", failures[0].Check)
+
+	// It must NOT claim the project is empty or that nothing is billing.
+	// The first version did, on an account where a security group was
+	// still holding the project open.
+	assert.NotContains(t, failures[0].Detail, "is empty")
+	assert.NotContains(t, failures[0].Detail, "Nothing is billing")
+	assert.Contains(t, failures[0].Detail, "reap")
 }


### PR DESCRIPTION
Caught the same evening, on a real teardown, by the operator it misled.

**#223 (S174)** marked a 412 from the project delete as a timing answer and short-circuited
**before** `purgeAutoCreated`, reasoning that *"a timing answer needs no purge: nothing is blocking
the delete except the API's own bookkeeping."*

That was a confident explanation of an API I had observed exactly once.

## Scaleway returns at least two 412s

| precondition | help_message | means |
|---|---|---|
| `resource_not_usable` | "please retry later" | the check is lagging |
| `resource_still_in_use` | "all resources are not deleted" | **there really is something there** |

The second means what it says. The teardown reported:

> the run's resources were destroyed and project 90a9c030-… **is empty** … **Nothing is billing.**

while the API-created `Default security group` sat there holding the project open — the D6 case
`purgeAutoCreated` exists for, skipped by the short-circuit that ran instead of it. Deleting that
one group unblocked the project immediately.

**So S174 turned a self-healing case — purge, retry, deleted — into a permanent failure carrying a
comforting message.** Strictly worse than the wording it replaced.

## The fix

The purge always runs first. Only a 412 that *survives* it is reported as wait-and-retry.

The message no longer claims the project is empty or that nothing is billing. It says what was
actually done — resources destroyed, nothing left to purge, API still refusing — and points at the
console if retrying doesn't clear it.

## Verification

Two tests, and restoring the short-circuit fails both:
- a 412 with an auto-created resource behind it **still purges**, retries, and succeeds
- a 412 with nothing to purge reports `delete_not_yet`, and **must not** contain "is empty" or
  "Nothing is billing"

## The lesson, which I had already written down

This is exactly the class ADR-0028 says it cannot reach: facts about the real cloud are too
expensive to pin in a test, so they live in prose and stay risky. I saw one 412, generalised to all
412s, and wrote the generalisation into a comment as established fact.

A status code is a category, not a diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD