### PR TITLE
S178: the loop learned three things and could act on one

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -84,6 +84,39 @@ are the class ADR-0028 explicitly cannot reach: too expensive to pin in a test, 
 prose and stay risky. I observed one 412 in the afternoon, generalised it to all 412s, and wrote the
 generalisation into a comment as though it were established. Two tests now hold the shape that
 matters, and neither could have been written without seeing the second variant.
+## 2026-09-08 — S178: the loop learned three things and could act on one
+
+A real Layer 3 run of `web-live-paris` failed at `repair_budget_exhausted` (5/5) and appended
+three pitfalls to the corpus. All three `source: descriptive` — raw stderr dumps. The corpus went
+from five-of-seven symptom-only to eight-of-ten, which is S170's finding happening live rather
+than in retrospect.
+
+Only **one** could be responsibly converted.
+
+**`scaleway_instance_security_group` → `avoid`.** The generator declared one, the allowlist refused
+the whole configuration, and an iteration was lost. The remedy is concrete and verifiable: do not
+declare one, because Scaleway creates a "Default security group" per project on the first instance
+and it already permits what these scenarios need. Worth stating twice over, since that same
+API-created group is what the teardown purge exists to remove — it blocks the project delete.
+
+**The image error stays descriptive, deliberately.** The obvious remedy — *"the model invented an
+image, use ubuntu_jammy"* — is **wrong**. `docker` is a real Scaleway marketplace label, it is what
+this scenario's own `variables.tf` defaults to with a comment explaining why, and a deploy using it
+on DEV1-S in fr-par-1 **succeeded the previous evening**. Why the same combination failed the next
+day is not understood. I had written that remedy in my head before checking, which is the third
+time in two days.
+
+**The private-network error stays descriptive too** — `resource with ID is not found` with an empty
+ID is undiagnosed.
+
+The truncation was repaired: the extractor had cut the third rule mid-word (`\"w...`), so even as a
+record of what happened it was damaged.
+
+**What the run says about the tool, separately.** Two of the five iterations were spent on
+`http_probe … 503`. The probe retries 6 times at 5s = about 30 seconds of patience; a hand
+measurement of the same stack the previous morning showed the load balancer needs 40–60 seconds
+before it serves. Those two iterations were a false negative, not a failure, and with a probe that
+waits long enough the run plausibly passes.
 
 
 ## 2026-09-07 — S174: the API saying "wait" is not the tool saying "broken"

--- a/pitfalls/scaleway.yaml
+++ b/pitfalls/scaleway.yaml
@@ -47,3 +47,39 @@ pitfalls:
         }
       source: fix
       discovered_from: full-stack-paris
+    - resource: scaleway_vpc_private_network
+      rule: "exit status 1 | stderr: ╷\n│ Error: scaleway-sdk-go: resource  with ID  is not found\n│ \n│   with scaleway_vpc_private_network.main,\n│   on network.tf line 1, in resource \"scaleway_vpc_private_network\" \"main\":\n│    1: resource \"scaleway_vpc_private_network\" \"main\" {\n│ \n╵"
+      source: descriptive
+      discovered_from: web-live-paris
+    - resource: scaleway_instance_security_group
+      rule: |-
+        NEVER declare a `scaleway_instance_security_group`. It is not in
+        `allow_resource_types`, so Layer 3 refuses the whole configuration before
+        anything is applied and the run loses an iteration to it.
+
+        You do not need one. Scaleway CREATES a "Default security group" in every
+        project on the first instance, and it permits what these scenarios need.
+        Declaring your own adds a resource the allowlist rejects to solve a problem
+        that does not exist.
+
+        The API-created one is also why teardown has a purge step: Terraform never
+        owns it, so `destroy` never removes it, and an undeleted security group
+        blocks the run project from being deleted afterwards. One more reason not
+        to add a second.
+      source: avoid
+      discovered_from: web-live-paris
+    # Left DESCRIPTIVE on purpose, and it is worth saying why.
+    #
+    # The obvious remedy -- "the model invented an image, use ubuntu_jammy" -- is
+    # WRONG. `docker` is a real Scaleway marketplace label, it is what this
+    # scenario's own variables.tf defaults to, and a deploy using it on DEV1-S in
+    # fr-par-1 succeeded the previous evening. Why the same combination failed the
+    # next day is not understood.
+    #
+    # Writing a confident remedy for a cause nobody has diagnosed is how a symptom
+    # becomes a wrong instruction the generator then follows. Until somebody knows,
+    # this stays a record of what happened.
+    - resource: scaleway_instance_server
+      rule: "exit status 1 | stderr: ╷\n│ Error: could not get image 'fr-par-1/docker': scaleway-sdk-go: couldn't find a local image for the given zone (fr-par-1) and commercial type (DEV1-S)\n│ \n│   with scaleway_instance_server.web,\n│   on compute.tf line 7, in resource \"scaleway_instance_server\" \"web\""
+      source: descriptive
+      discovered_from: web-live-paris


### PR DESCRIPTION
A real Layer 3 run of `web-live-paris` failed at `repair_budget_exhausted` (5/5) and appended three
pitfalls to the corpus. All three `source: descriptive` — raw stderr dumps.

The corpus went from **five-of-seven** symptom-only to **eight-of-ten**. That's S170's finding
happening live rather than in retrospect: the loop watched itself fail three times and recorded
*what happened* rather than *what to do instead*.

Only **one** could be responsibly converted.

## Converted → `avoid`

`scaleway_instance_security_group`. The generator declared one, the allowlist refused the whole
configuration, and an iteration was lost before anything was applied.

The remedy is concrete and verifiable: don't declare one. Scaleway creates a `Default security
group` per project on the first instance and it already permits what these scenarios need. Worth
saying twice over, since that same API-created group is what the teardown purge exists to remove —
it's what blocks the project delete.

## Left descriptive, deliberately

**The image error.** The obvious remedy — *"the model invented an image, use `ubuntu_jammy`"* — is
**wrong**, and I had written it in my head before checking:

- `docker` is a real Scaleway marketplace label (verified against the API)
- it's what this scenario's own `variables.tf` defaults to, with a comment explaining why
- a deploy using it on **DEV1-S in fr-par-1 succeeded the previous evening**

Why the same combination failed the next day is not understood. Writing a confident remedy for an
undiagnosed cause is how a symptom becomes a *wrong instruction the generator then follows* — the
same mistake as the 412, which I made twice in two days.

**The private-network error** stays descriptive too: `resource with ID is not found` with an empty
ID is undiagnosed.

The truncation is repaired — the extractor had cut the third rule mid-word (`\"w...`), so even as a
record it was damaged.

## Separately, about the tool

Two of the five iterations went to `http_probe … 503`. The probe retries 6 times at 5s — **~30
seconds of patience** — while a hand measurement of the same stack showed the load balancer needs
**40–60 seconds** before it serves. Those two iterations were false negatives, not failures. Worth
its own change, with the measurement as the justification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD