### PR TITLE
ui: the live run is the newest run, not the oldest one still claiming to run

### DIFF
--- a/docs/review-passes/pass165.md
+++ b/docs/review-passes/pass165.md
@@ -1,0 +1,63 @@
+# Review pass 165 — live run selects the newest run
+
+`codex exec review --base main` on `fix/live-run-selects-newest`.
+
+## Verdict
+
+Clean on the first pass.
+
+> No discrete correctness issues were found in the diff. The changes consistently
+> make latest-run selection timestamp-based and avoid auto-pinning the live page
+> URL while preserving explicit run_id pins.
+
+Nothing declined — nothing was raised.
+
+## What the pass was reviewing
+
+`selectLatestRun` sorted newest-first and then discarded that order, scanning the
+whole history for any run whose status was `running` and preferring it. That can
+only disagree with `filtered[0]` when an **older** run claims to be running, which
+is always a lie: a run id is a UTC timestamp, so a live run is already first.
+
+There was a steady supply of liars. Nothing marks a run terminal when its process
+dies, so **21 records going back to 29 May** still said `status: "running"` on
+disk. The live page showed a run interrupted on 30 August — frozen elapsed timer,
+stage list ten days stale — instead of the run started minutes earlier.
+
+Two further sites in the same chain:
+
+- `scenarios/[...path]/+page.svelte` carried a verbatim copy of the rule. It now
+  calls `selectLatestRun`, so there is one implementation to be wrong.
+- `live/+page.svelte` wrote the **auto-selected** run id back into the URL via
+  `replaceState`. `onMount` reads `run_id` first and then never looks for a newer
+  run, so an incidental landing became a permanent pin that survived every reload.
+  It now writes the scenario only; an explicit `?run_id=` from the runs list is
+  still honoured, because that pin is one somebody asked for.
+
+## The part worth keeping
+
+The old behaviour had a test, and it was green:
+
+```js
+test("selectLatestRun prefers running run within a scenario", () => {
+  { run_id: "20260228T100000Z", status: "failed"  },
+  { run_id: "20260228T110000Z", status: "running" },   // ALSO the newest
+```
+
+The running fixture was also the newest, so the assertion held whether the
+implementation preferred running runs or simply took the newest. The test named a
+behaviour its own sample could not distinguish from the alternative — so it
+certified the bug for as long as it existed.
+
+The new test inverts the ordering, which is the entire fix to the test:
+
+```js
+{ run_id: "20260830T201451Z", status: "running" },   // older, and lying
+{ run_id: "20260909T093610Z", status: "failed"  },   // newer, and true
+```
+
+Mutation-checked rather than assumed: restoring the old one-liner fails exactly
+one test (`pass 148 / fail 1`); with the fix, `pass 149 / fail 0`.
+
+Same shape as [[feedback-narrow-sample-wrong-conclusion]] — a check whose sample
+cannot separate the two answers reads as confirmation of whichever one is there.

--- a/ui/src/lib/run-view.js
+++ b/ui/src/lib/run-view.js
@@ -17,7 +17,19 @@ export function selectLatestRun(runs, scenario = "") {
     return null;
   }
   filtered.sort((a, b) => compareRunIDs(a.run_id, b.run_id));
-  return filtered.find((run) => run.status === "running") || filtered[0];
+
+  // Newest wins, full stop. This used to scan the WHOLE sorted list for
+  // anything marked "running" and prefer it, which can only ever disagree
+  // with filtered[0] when an OLDER run claims to be running -- exactly the
+  // case that is always a lie. A run id is a UTC timestamp, so a genuinely
+  // live run is already first.
+  //
+  // Found 2026-09-09: a run interrupted on 30 August still said
+  // status:"running" on disk, so the live page showed a ten-day-old corpse
+  // with a frozen elapsed timer instead of the run just started. 21 records
+  // going back to May were in that state -- nothing marks a run terminal when
+  // its process dies, so this scan had a growing supply of stale winners.
+  return filtered[0];
 }
 
 export function filterRuns(runs, search, statusFilter) {

--- a/ui/src/routes/live/+page.svelte
+++ b/ui/src/routes/live/+page.svelte
@@ -102,7 +102,13 @@
     scenario = active.scenario || "";
     runID = active.run_id || "";
     if (scenario && runID) {
-      const url = `/live?scenario=${encodeURIComponent(scenario)}&run_id=${encodeURIComponent(runID)}`;
+      // Scenario only. Writing the auto-selected run_id back into the URL
+      // turned a "show me the latest" visit into a permanent pin on one run:
+      // onMount reads run_id first and then never looks for a newer one, so
+      // the tab stayed on whatever it happened to land on across every
+      // reload. An explicit /live?...&run_id=... from the runs list is still
+      // honoured -- that pin is the one somebody actually asked for.
+      const url = `/live?scenario=${encodeURIComponent(scenario)}`;
       window.history.replaceState({}, "", url);
       statusMessage = "";
     }

--- a/ui/src/routes/scenarios/[...path]/+page.svelte
+++ b/ui/src/routes/scenarios/[...path]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { selectLatestRun } from "$lib/run-view.js";
   import { afterNavigate } from "$app/navigation";
   import { onDestroy, onMount } from "svelte";
   import { page } from "$app/stores";
@@ -151,13 +152,10 @@
 
   async function redirectToLatestRun(scenario: string) {
     const resp = await api.getRunsForScenario(scenario);
-    const runs = ((resp.runs as any[]) || []).slice();
-    if (runs.length === 0) {
+    const active = selectLatestRun((resp.runs as any[]) || [], scenario);
+    if (!active) {
       throw new Error("run already in progress, but no run metadata was found");
     }
-
-    runs.sort((a, b) => (a.run_id < b.run_id ? 1 : -1));
-    const active = runs.find((run) => run.status === "running") || runs[0];
     window.location.href = encodeLiveURL(scenario, active.run_id);
   }
 

--- a/ui/tests/run-view.test.js
+++ b/ui/tests/run-view.test.js
@@ -26,7 +26,7 @@ test("buildRunBaselineURL encodes scenario and run id", () => {
   assert.equal(buildRunBaselineURL("web app", "run/1"), "/api/runs/web%20app/run%2F1/baseline");
 });
 
-test("selectLatestRun prefers running run within a scenario", () => {
+test("selectLatestRun takes the newest run in the scenario, ignoring other scenarios", () => {
   const runs = [
     { scenario: "web-app-paris", run_id: "20260228T100000Z", status: "failed" },
     { scenario: "web-app-paris", run_id: "20260228T110000Z", status: "running" },
@@ -35,6 +35,34 @@ test("selectLatestRun prefers running run within a scenario", () => {
 
   const selected = selectLatestRun(runs, "web-app-paris");
   assert.equal(selected?.run_id, "20260228T110000Z");
+});
+
+// The case the suite could not see. Its predecessor was named "prefers
+// running run", but its running fixture was ALSO the newest, so it passed
+// whether the implementation preferred running runs or simply took the
+// newest -- and the implementation preferred running runs, scanning the
+// entire history to do it. A run interrupted on 30 August still said
+// "running" on disk and beat the run started ten days later.
+//
+// Ordering the fixture the other way is the whole test.
+test("selectLatestRun ignores an older run still claiming to be running", () => {
+  const runs = [
+    { scenario: "web-live-paris", run_id: "20260830T201451Z", status: "running" },
+    { scenario: "web-live-paris", run_id: "20260909T093610Z", status: "failed" }
+  ];
+
+  const selected = selectLatestRun(runs, "web-live-paris");
+  assert.equal(selected?.run_id, "20260909T093610Z");
+});
+
+test("selectLatestRun still returns a genuinely live newest run", () => {
+  const runs = [
+    { scenario: "web-live-paris", run_id: "20260909T093610Z", status: "failed" },
+    { scenario: "web-live-paris", run_id: "20260909T101500Z", status: "running" }
+  ];
+
+  const selected = selectLatestRun(runs, "web-live-paris");
+  assert.equal(selected?.run_id, "20260909T101500Z");
 });
 
 test("selectLatestRun falls back to newest run when none are running", () => {


### PR DESCRIPTION
The Live Run page showed a run **interrupted on 30 August** — status `running`,
frozen elapsed timer, ten-day-old stage list — instead of the run started minutes
earlier.

## Cause

`ui/src/lib/run-view.js`:

```js
filtered.sort((a, b) => compareRunIDs(a.run_id, b.run_id));   // newest first
return filtered.find((run) => run.status === "running") || filtered[0];
```

It sorts newest-first and then throws that away to scan the entire history for
anything marked `running`. That can only disagree with `filtered[0]` when an
**older** run claims to be running — which is always a lie, since a run id is a
UTC timestamp and a genuinely live run is already first.

And there was a steady supply of liars: **nothing marks a run terminal when its
process dies**, so 21 records going back to 29 May still said `status: "running"`
on disk.

## The change

- `selectLatestRun` returns the newest run in the scenario. Full stop.
- `scenarios/[...path]/+page.svelte` had a verbatim copy of the rule; it now calls
  `selectLatestRun`, so there is one implementation to be wrong.
- `live/+page.svelte` no longer writes the **auto-selected** run id into the URL.
  `onMount` reads `run_id` first and then never looks for a newer run, so an
  incidental landing became a permanent pin that survived every reload. It writes
  the scenario only now; an explicit `?run_id=` from the runs list is still
  honoured — that pin is one somebody asked for.

## The test that certified the bug

```js
test("selectLatestRun prefers running run within a scenario", () => {
  { run_id: "20260228T100000Z", status: "failed"  },
  { run_id: "20260228T110000Z", status: "running" },   // ALSO the newest
```

Green throughout. The running fixture was also the newest, so the assertion held
whether the implementation preferred running runs or simply took the newest. The
test **named a behaviour its own sample could not distinguish** from the
alternative.

The new test inverts the ordering, which is the entire fix to the test — and it
was mutation-checked rather than assumed: restoring the old one-liner fails
exactly one test (`pass 148 / fail 1`); with the fix, `pass 149 / fail 0`.

## Verification

- `npm --prefix ui test` — 149 pass
- `make test` — Go suite + 134 Playwright e2e green
- `go vet ./...` clean, doc hygiene clean
- codex review pass 165: clean on the first pass, nothing raised

Not in scope, and still true: a run whose process dies leaves `status: "running"`
on disk forever. This stops those records hijacking the live view; it does not
reconcile them. The 21 stale ones were marked `interrupted` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD