### PR TITLE
admit Play2, and retract three claims a real run falsified

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,45 @@
 # STATUS
 
-Last updated: 2026-09-09
+Last updated: 2026-09-10
+
+## 2026-09-10 — S180: three retractions, and the fix moves out of the HCL
+
+Yesterday's fixes were run against real Scaleway. One worked, two were wrong, and the wrong ones
+were mine.
+
+**The inline `private_network` block does not destroy either.** Run `20260910T104418Z` iteration 4
+generated exactly the prescribed shape and failed teardown with the identical
+`Can't delete a private network interface attached to a server`. ADR-0029's mechanism claim — the
+provider powers the server off first, so its NICs go with it — is refuted and marked as such. What
+survives is that a standalone NIC genuinely cannot be destroyed and a policy should not mandate it;
+what does not survive is that the inline block fixes anything.
+
+**So no HCL shape works, and the fix leaves the configuration.** Both hand recoveries succeeded the
+same way: power the server off, then delete. The teardown path has to do that before
+`tofu destroy`. ADR-0029 dismissed exactly this as "teaching the tool to work around HCL nobody
+should be generating" — a dismissal that assumed a working alternative existed.
+
+Worth naming: the Layer 2 verification of the inline shape **passed** (`7 added`, `7 destroyed`),
+because mockway does not enforce the power-off precondition. A mock more permissive than reality
+cannot refute a claim about reality, and the claim shipped on mock evidence alone.
+
+**The `docker` image pitfall is retracted one day after being written.** It steered the generator to
+an image whose apply fails (`couldn't find a local image for zone fr-par-1 and commercial type
+DEV1-M`) — while the marketplace API continues to insist that combination is compatible. So
+`compatible_commercial_types` is not what the provider resolves against and cannot settle the
+question. The pitfall it overrode had explicitly warned against writing a remedy for this symptom.
+The warning is restored, and no remedy is offered.
+
+**Play2 admitted, and not for the reason first given.** `PLAY2-PICO` and `PLAY2-NANO` are now
+allowed instance types. The claim that motivated it — that they are cheaper than DEV1-S — was
+wrong: they are 59% and 207% dearer (Scaleway public catalog). The real argument is iteration cost.
+DEV1 is the superseded range, Play2 is what a model reaches for, and one run spent three of five
+iterations proposing Play2 and being refused before exhausting its budget. `PLAY2-MICRO` (+513%)
+stays out.
+
+**And the stuck detector missed an oscillation.** `IsStuck` compares only the immediately previous
+iteration, so an alternating gate-refusal / apply-failure / gate-refusal sequence never repeats
+consecutively and runs to the full budget — paying for two real applies on the way. Open.
 
 ## 2026-09-09 — S179: the scenario the docs said could not run, and the two defects it was hiding
 

--- a/docs/decisions/0029-a-policy-may-not-mandate-an-undestroyable-shape.md
+++ b/docs/decisions/0029-a-policy-may-not-mandate-an-undestroyable-shape.md
@@ -1,7 +1,8 @@
 # ADR-0029: A policy may not mandate a shape that cannot be destroyed
 
 ## Status
-Accepted
+Accepted — **with its central mechanism claim REFUTED on 2026-09-10. Read the
+"Refutation" section before relying on anything here.**
 
 ## Context
 
@@ -126,3 +127,56 @@ next run is told, silently, with no record in the run's own metadata — which i
 how a run on 2026-09-10 came to be judged against a pitfall file it had never
 read. Recording the commit a run was generated under would close that, and is
 not done here.
+
+
+## Refutation, 2026-09-10
+
+**The inline block does not destroy either.** Run `20260910T104418Z`, iteration
+4, generated exactly the shape this ADR prescribes —
+
+```hcl
+resource "scaleway_instance_server" "web" {
+  private_network { pn_id = scaleway_vpc_private_network.main.id }
+}
+```
+
+— applied it to real Scaleway, and failed teardown with the identical error:
+
+```
+Can't delete a private network interface attached to a server
+```
+
+So the reasoning in "Decision" is wrong where it matters. *"Deleting the server
+takes its NICs with it, because the provider powers the server off first"* is
+not what the provider does. It detaches the NIC as its own API call whether the
+attachment was declared inline or as a standalone resource, and that call fails
+while the server is running.
+
+What survives, and what does not:
+
+- **Survives.** The standalone `scaleway_instance_private_nic` genuinely cannot
+  be destroyed, and a policy genuinely should not mandate a shape that cannot be
+  torn down. The gate and the amended `vpc_required` stay.
+- **Does not survive.** The claim that the inline block *solves* it. It does not.
+  It is a smaller, tidier stack with the same teardown failure.
+- **Unchanged.** The precondition is power state. Both hand recoveries worked the
+  same way: `scw instance server stop`, then delete.
+
+**The consequence is that no HCL shape can express a destroyable private-network
+attachment on a running Scaleway instance.** When no configuration works, the
+configuration is not where the fix goes. The teardown path has to power the run's
+instances off before `tofu destroy` — which is precisely the move this ADR
+dismissed as "teaching the tool to work around HCL nobody should be generating".
+That dismissal assumed a working alternative existed. It does not.
+
+Superseding decision to be recorded separately; this section exists so nobody
+reads the Decision above and believes the problem is solved.
+
+### Why this was believed
+
+The mechanism was inferred from one true observation — a NIC deletes cleanly once
+its server is stopped — and never tested against the inline shape, because
+testing it costs a real apply. The Layer 2 verification that *was* run passed
+(`7 added`, `7 destroyed`) because mockway does not enforce the precondition. A
+mock that is more permissive than reality cannot refute a claim about reality,
+and this ADR shipped a claim it had only mock evidence for.

--- a/docs/review-passes/pass172.md
+++ b/docs/review-passes/pass172.md
@@ -1,0 +1,57 @@
+# Review pass 172 — Play2 admitted, three claims retracted
+
+`codex exec review --base main` on `fix/play2-types-and-retractions`. Clean on
+the first pass, nothing raised.
+
+> I did not identify any discrete correctness regression introduced by these
+> changes. The code change is narrowly scoped to widening the Layer 3 enum
+> allowlist, and the accompanying documentation/pitfall edits do not introduce
+> an actionable risk.
+
+The review had little to find because the substance of this change is **removing
+three wrong claims**, all added by me in the previous 24 hours and all falsified
+by one real-cloud run.
+
+| claim | falsified by |
+|---|---|
+| the inline `private_network` block destroys cleanly | run `20260910T104418Z` iteration 4 — that exact shape, same teardown error |
+| `docker` is a safe image because the marketplace API says DEV1-M is compatible | iteration 2 — `couldn't find a local image for zone fr-par-1 and commercial type DEV1-M` |
+| Play2 is cheaper than DEV1-S, so admitting it cuts spend | Scaleway public catalog — `PLAY2-PICO` +59%, `PLAY2-NANO` +207% |
+
+The change is still worth making, on a corrected reason: **iteration cost, not
+instance cost.** DEV1 is the superseded range, Play2 is what a model reaches for
+when asked for a small instance, and one run spent three of five iterations
+proposing `PLAY2-NANO` and `PLAY2-PICO` and being refused before exhausting its
+budget. At demo durations the price difference is fractions of a penny; a wasted
+iteration is a real apply. `PLAY2-MICRO` (+513%) stays out, so the ceiling
+remains near 3× DEV1-S and the gate remains deny-by-default.
+
+## The pattern under all three
+
+Each claim was checked against something cheaper than the thing it was about.
+
+- The inline block was verified against **mockway**, which does not enforce the
+  power-off precondition. It reported `7 added`, `7 destroyed`. A mock more
+  permissive than reality cannot refute a claim about reality.
+- The image was verified against the **marketplace API**, which is not what the
+  provider resolves against — it still insists DEV1-M is compatible.
+- The price was not verified at all until after it had been acted on.
+
+This is ADR-0028's limit restated with evidence: facts about the real cloud are
+too expensive to pin in tests, so they live in prose — and prose written from a
+cheap proxy reads exactly like prose written from the real thing.
+
+The `docker` pitfall is the sharpest case. The note it overrode said, in as many
+words, that writing a confident remedy for an undiagnosed symptom is how a
+symptom becomes a wrong instruction the generator then follows. It was overridden
+on marketplace evidence, the generator followed it, and the apply failed. The
+warning is restored and no remedy is offered.
+
+## Left open, deliberately
+
+- **No HCL shape destroys.** The fix moves to the teardown path: power the run's
+  instances off before `tofu destroy`. ADR-0029 records the refutation so nobody
+  reads its Decision and believes the problem is solved.
+- **`IsStuck` misses oscillation.** It compares only the immediately previous
+  iteration, so alternating failure signatures run to the full budget. Two of
+  those five iterations were real applies.

--- a/internal/cli/layer3_hcl_shape.go
+++ b/internal/cli/layer3_hcl_shape.go
@@ -871,8 +871,26 @@ var layer3NumericBounds = map[string]map[string]float64{
 	},
 }
 
+// Play2 admitted 2026-09-10, and NOT because it is cheaper -- it is dearer.
+// Retail EUR/hour in fr-par-1, from Scaleway's public product catalog:
+//
+//	DEV1-S       0.00898
+//	PLAY2-PICO   0.01428   (+59%)
+//	DEV1-M       0.02020   (+125%)
+//	PLAY2-NANO   0.02754   (+207%)
+//	PLAY2-MICRO  0.05508   (+513%)   <- deliberately NOT admitted
+//
+// The reason is iteration cost, not instance cost. DEV1 is the superseded
+// range and Play2 is what a model reaches for when asked for a small
+// instance; one run spent THREE of its five iterations proposing PLAY2-NANO
+// and PLAY2-PICO and being refused, then exhausted its budget. At demo
+// durations the difference is fractions of a penny -- a five-minute
+// PLAY2-PICO is about EUR 0.001 -- and a wasted iteration costs a real apply.
+//
+// MICRO is left out to keep the ceiling near 3x DEV1-S. The gate is still
+// deny-by-default; this widens it by two named values, not by a family.
 var layer3EnumBounds = map[string]map[string][]string{
-	"scaleway_instance_server": {"type": {"DEV1-S", "DEV1-M"}},
+	"scaleway_instance_server": {"type": {"DEV1-S", "DEV1-M", "PLAY2-PICO", "PLAY2-NANO"}},
 	"scaleway_lb":              {"type": {"LB-S"}},
 }
 

--- a/pitfalls/scaleway.yaml
+++ b/pitfalls/scaleway.yaml
@@ -13,16 +13,14 @@ pitfalls:
             private_network { pn_id = scaleway_vpc_private_network.main.id }
           }
 
-        `vpc_required` accepts either shape and IS evaluated for Scaleway. Use the
-        inline one because it can be DESTROYED. A standalone NIC applies and then
-        fails teardown on real Scaleway -- "Can't delete a private network interface
-        attached to a server" -- because destroy runs in reverse dependency order and
-        deletes the NIC while its server is still running -- a NIC is deletable only
-        when its server is POWERED OFF. Deleting the server takes its NICs with it,
-        because the provider powers it off first. The Layer 3 gate REFUSES a
-        standalone NIC, so this is not a preference. (web-live-paris 2026-09-09.)
+        `vpc_required` accepts either shape, and the Layer 3 gate REFUSES the
+        standalone NIC, so this is not a preference. Up to 8 blocks; with `count`
+        the block comes too. No `project_id`.
 
-        Up to 8 blocks; with `count` the block comes too. No `project_id`.
+        Neither shape destroys cleanly: a private NIC is deletable only while its
+        server is POWERED OFF, and that precondition is the API's, not the HCL's
+        (measured 2026-09-09 and 2026-09-10). Use the inline block because it is
+        the smaller stack the gate accepts -- not because it solves teardown.
       source: fix
       discovered_from: web-live-paris
     - resource: scaleway_k8s_cluster
@@ -85,23 +83,29 @@ pitfalls:
         to add a second.
       source: avoid
       discovered_from: web-live-paris
-    - resource: scaleway_instance_server
-      rule: |-
-        When the scenario declares a `service:` (a container), boot Scaleway's
-        `docker` image and only RUN the container -- do not install a runtime in
-        `user_data`:
-
-          variable "instance_image" { default = "docker" }
-          # cloud-init: wait for the daemon, then `docker run -d --restart always`
-
-        `apt-get install docker.io` on a cold instance takes 2-4 MINUTES, and an
-        `http_probe` has a bounded retry window, so such a stack fails the probe
-        every time -- as a 503 from a healthy load balancer with no healthy backend,
-        which reads like a broken app rather than one still installing.
-        (web-live-paris 2026-09-09: two iterations, both 503, nothing serving yet.)
-        `docker` is a real marketplace label, compatible with DEV1-S in fr-par-1.
-      source: fix
-      discovered_from: web-live-paris
+    # RETRACTED 2026-09-10, one day after it was written. It said: when a
+    # scenario declares a `service:`, boot Scaleway's `docker` image instead of
+    # apt-installing a runtime, and it cited the marketplace API as proof the
+    # image was compatible with DEV1-S in fr-par-1.
+    #
+    # The generator took the advice and the apply FAILED:
+    #
+    #   could not get image 'fr-par-1/docker': couldn't find a local image for
+    #   the given zone (fr-par-1) and commercial type (DEV1-M)
+    #
+    # The marketplace API still says the opposite -- all four fr-par-1 `docker`
+    # local images list DEV1-M in compatible_commercial_types. So
+    # `compatible_commercial_types` is NOT what the provider resolves against,
+    # and it cannot be used to settle this question.
+    #
+    # That is the second time this exact failure has been recorded, and the
+    # pitfall below already warned against writing a remedy for it. Overriding
+    # that warning turned an honest "not understood" into a prescription that
+    # cost a real apply. The warning stands; no remedy is offered.
+    #
+    # What IS supported by evidence: `ubuntu_jammy` plus an apt install serves
+    # inside a 120s probe window (web-live-paris, 2026-09-10 09:35, probe
+    # passed). Slower, and it works.
     # Left DESCRIPTIVE on purpose, and it is worth saying why.
     #
     # The obvious remedy -- "the model invented an image, use ubuntu_jammy" -- is


### PR DESCRIPTION
Yesterday's fixes met real Scaleway. One worked, two were wrong, and the wrong
ones were mine.

## Retracted: the inline block destroys cleanly

Run `20260910T104418Z` iteration 4 generated exactly the prescribed shape —

```hcl
resource "scaleway_instance_server" "web" {
  private_network { pn_id = scaleway_vpc_private_network.main.id }
}
```

— and failed teardown with the identical `Can't delete a private network
interface attached to a server`. ADR-0029's mechanism claim is **refuted** and
marked at the top of the file.

Survives: a standalone NIC genuinely cannot be destroyed, and a policy should not
mandate it. The gate and the amended `vpc_required` stay.
Does not: that the inline block fixes it. It is a tidier stack with the same
failure.

**No HCL shape can express a destroyable private-network attachment on a running
instance.** The fix therefore leaves the configuration: teardown must power the
run's instances off before `tofu destroy`, which is what both hand recoveries
did. ADR-0029 dismissed that as "teaching the tool to work around HCL nobody
should be generating" — a dismissal that assumed a working alternative existed.

## Retracted: the `docker` image pitfall, one day old

It steered the generator to an image whose apply fails:

```
could not get image 'fr-par-1/docker': couldn't find a local image for the
given zone (fr-par-1) and commercial type (DEV1-M)
```

The marketplace API still says all four fr-par-1 `docker` images list `DEV1-M`
as compatible. So `compatible_commercial_types` is not what the provider
resolves against and cannot settle this.

The note this overrode said, in as many words, that writing a confident remedy
for an undiagnosed symptom is how a symptom becomes a wrong instruction the
generator follows. It was overridden, the generator followed it, the apply
failed. Warning restored; no remedy offered.

## Corrected: Play2 is not cheaper

| type | €/h | vs DEV1-S |
|---|---|---|
| `DEV1-S` | 0.00898 | — |
| `PLAY2-PICO` | 0.01428 | +59% |
| `DEV1-M` | 0.02020 | +125% |
| `PLAY2-NANO` | 0.02754 | +207% |
| `PLAY2-MICRO` | 0.05508 | +513% ← not admitted |

`PLAY2-PICO` and `PLAY2-NANO` are admitted on the real reason: **iteration cost,
not instance cost.** DEV1 is the superseded range, Play2 is what a model reaches
for, and one run spent three of five iterations proposing it and being refused
before exhausting its budget. At demo durations the difference is fractions of a
penny; a wasted iteration is a real apply.

## The pattern

Each claim was checked against something cheaper than the thing it was about —
the mock, the marketplace API, and nothing at all. **A mock more permissive than
reality cannot refute a claim about reality**, and the inline-block verification
(`7 added`, `7 destroyed`) was exactly that.

## Left open

- The teardown power-off. Recorded in the ADR rather than implemented here.
- `IsStuck` compares only the immediately previous iteration, so alternating
  failure signatures run to the full budget. Two of those five iterations were
  real applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD