### PR TITLE
teardown says why it powered nothing off, and stops teaching a refused shape

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,38 @@
 
 Last updated: 2026-09-10
 
+## 2026-09-10 — S182: the guard that would not say why, and a rule frozen against its own enforcement
+
+Run `20260910T141427Z` was the first on the new binary. Two things worked and two were broken, both
+of the broken ones mine, both from the same day.
+
+**Worked:** the rewritten `vpc_required` denial named the fix and the generator *applied it* —
+iteration 1 failed validate, iteration 2 emitted the inline `private_network` block and passed. The
+denial text as repair-loop input did exactly what it was changed to do.
+
+**The poweroff never ran, and the log could not say why.** No `instance_poweroff` stage anywhere.
+The first version had three silent `return nil` paths, so a real apply bought no information at
+all — the exact failure the Layer 3 arc closed with ("a guard that stops without saying why is half
+a guard"), written into code whose own ADR quotes that lesson. Every skip now carries its reason
+into the stage summary.
+
+The likely cause is also fixed rather than only reported: callers pass
+`sweepTargetProjectID(...)`, which is empty whenever `CaptureSweepTarget` failed — and that
+silently disabled **both** remediations, which is why the run shows no purge stage either. The
+poweroff now falls back to the run-project marker, the same provenance the deletable check reads
+anyway.
+
+**The learning loop was teaching the shape three layers refuse.** `ExtractDescriptivePitfall`'s VPC
+fallback is a prescriptive rule frozen into Go, and it still said *"Always declare … a
+`scaleway_instance_private_nic`"* — a resource the Layer 3 gate now rejects, that `vpc_required`
+now argues against, and that a real teardown cannot delete. The same run recorded it as a fresh
+pitfall while its own Layer 1 was saying the opposite.
+
+The general point, and the reason it is a liability rather than a typo: **a prescriptive rule
+frozen in source cannot be reviewed next to the thing that enforces it**, so it drifts silently and
+then teaches the drift. Refusals extracted by `ExtractGatePitfall` cannot fail this way — they are
+emitted by the enforcing code itself. An audit test now fails if the fallback and the gate diverge.
+
 ## 2026-09-10 — S181: the fix leaves the HCL, and the loop starts learning from its own gates
 
 Five changes, four here and one in mockway, all from the same run.

--- a/docs/decisions/0030-teardown-powers-instances-off.md
+++ b/docs/decisions/0030-teardown-powers-instances-off.md
@@ -79,3 +79,29 @@ Best-effort otherwise. The authoritative "did we leak?" answer stays with
   not be expressed, and three attempts to write it as a rule produced two
   retracted pitfalls and one refuted ADR before the constraint was located
   correctly.
+
+## Amendment, 2026-09-10 — it has to say why it did nothing
+
+The first implementation had three silent `return nil` paths. Run
+`20260910T141427Z` then failed its destroy with **no `instance_poweroff` stage at
+all**, and the log could not distinguish "no project id" from "guard refused"
+from "found nothing to stop". A real apply bought no information.
+
+That is the finding the Layer 3 arc closed with — *a guard that stops without
+saying why is half a guard* — reproduced inside the change whose own ADR quotes
+it. Every skip now carries its reason into the stage summary, rendered as a
+**skip**, never as a pass.
+
+**And the likely cause is fixed, not merely reported.** Callers pass
+`sweepTargetProjectID(...)`, which is empty whenever `CaptureSweepTarget` failed.
+Both remediations are scoped by that id, so one failed capture disabled the purge
+and the poweroff *together* — which is why that run shows neither stage. The
+project id is now resolved once, in `destroySandbox`, falling back to the
+run-project marker: the same provenance `AssertProjectDeletable` reads, one step
+earlier, and that check still runs.
+
+The boundary this moves was previously asserted as a safety property ("without a
+project id, do not purge"). It was not one. An empty id is not a caller declining
+to act; it is a capture that failed, and treating it as a refusal turned a
+recoverable teardown into a leak. The guard that makes purging safe is
+`AssertProjectDeletable`, and it is untouched.

--- a/docs/review-passes/pass180.md
+++ b/docs/review-passes/pass180.md
@@ -1,0 +1,67 @@
+# Review passes 180–182 — the guard that would not say why
+
+`codex exec review --base main` on `fix/poweroff-says-why-it-skipped`. Three
+passes, four findings, all accepted; the third pass clean.
+
+> I did not identify any discrete correctness, safety, or maintainability issues
+> introduced by this diff.
+
+## What prompted the branch
+
+Run `20260910T141427Z` — the first on the S181 binary — failed its destroy with
+**no `instance_poweroff` stage anywhere in the log**. The implementation had
+three silent `return nil` paths, so a real apply against real Scaleway bought no
+information: "no project id", "guard refused" and "found nothing to stop" were
+indistinguishable.
+
+That is the Layer 3 arc's closing finding — *a guard that stops without saying
+why is half a guard* — reproduced inside the change whose own ADR quotes it.
+
+## Findings
+
+**[P2] the purge did not get the recovery.** The marker fallback was added
+inside `powerOffRunInstances`, so `destroySandbox` still passed the original
+empty id to the purge. Since both remediations are scoped by that one id, fixing
+only the poweroff would have fixed half the outage — and the missing purge stage
+in that run is the evidence both were disabled together. Resolution hoisted into
+`destroySandbox`.
+
+**[P2] a committed pitfall still prescribed the standalone NIC.** Not the Go
+fallback this branch fixed — an entry the loop had *learned and written to
+`pitfalls/scaleway.yaml`* during that same run, from the old fallback. Deleted,
+with a comment kept in its place because the mechanism is worth remembering: the
+loop recorded a durable rule contradicting its own enforcement while its Layer 1
+was telling the generator the opposite.
+
+**Doc hygiene** required an ADR touch; ADR-0030 amended rather than a new record
+written, since this refines the same decision.
+
+## A boundary that moved, deliberately
+
+`TestDestroyWithoutProjectIDDoesNotPurge` asserted "without a project id, do not
+purge" as a safety property. It was not one. Every caller derives that id from
+`CaptureSweepTarget`, so an empty value means *the capture failed*, not *the
+caller declined to act* — and treating it as a refusal turned a recoverable
+teardown into a leak. The check that makes purging safe is
+`AssertProjectDeletable`, and it is untouched. The test is now
+`TestDestroyWithoutProjectIDOrMarkerDoesNotPurge`, with a companion asserting the
+recovery.
+
+## Mutation checks
+
+| mutation | result |
+|---|---|
+| marker fallback removed | `TestPowerOffFallsBackToTheRunProjectMarker` fails |
+| VPC fallback restored to the standalone-NIC wording | `TestVPCFallbackPrescribesTheShapeTheGateAccepts` fails |
+
+## The thing worth keeping
+
+Two of today's defects were the same shape: **a prescriptive rule frozen in
+source, drifting from the code that enforces it.** The Go VPC fallback said
+"declare a `scaleway_instance_private_nic`" while the gate refused that resource,
+the policy argued against it, and a real teardown could not delete one.
+
+Refusals extracted by `ExtractGatePitfall` cannot fail this way — they are
+emitted by the enforcing code itself, so they cannot disagree with it. That is
+the argument for deriving pitfalls from gates rather than writing them, and it
+now has an audit test behind it.

--- a/internal/cli/destroy_retry.go
+++ b/internal/cli/destroy_retry.go
@@ -23,6 +23,12 @@ const runProjectTimeout = 20 * time.Second
 // tens of seconds while each individual request should not.
 const instancePowerOffTimeout = 15 * time.Second
 
+// powerOffSkipReasonPrefix marks a result entry that is a REASON NOTHING
+// HAPPENED rather than a server that was stopped. Carried in the same
+// slice so no call site changes; marked so the stage cannot render it as
+// an accomplishment.
+const powerOffSkipReasonPrefix = "skipped: "
+
 // destroySandbox runs the sandbox destroy, and on failure clears
 // API-auto-created resources out of the run's project and tries once
 // more.
@@ -65,7 +71,22 @@ func destroySandbox(
 	// has done anything. Unlike the purge below, this is known in advance
 	// for every stack that declares compute, so it runs first rather than
 	// after a failure nobody could have predicted.
-	stopped := powerOffRunInstances(ctx, runtime, workDir, projectID, sandboxEnv)
+	// Resolved ONCE, and used by both remediations. Callers pass
+	// sweepTargetProjectID(...), which is empty whenever
+	// CaptureSweepTarget failed -- and on 2026-09-10 that silently
+	// disabled the purge AND the poweroff together, leaving a run with
+	// neither stage to say so. Recovering it inside only one of them
+	// would have fixed half the outage.
+	projectID = resolveRunProjectID(workDir, projectID)
+
+	stopped, powerOffSkipped := powerOffRunInstances(ctx, runtime, workDir, projectID, sandboxEnv)
+
+	if powerOffSkipped != "" && len(stopped) == 0 {
+		// Carried in the same slice so no call site has to change, and
+		// marked so instancePowerOffStage renders it as a SKIP rather
+		// than claiming instances were stopped.
+		stopped = []string{powerOffSkipReasonPrefix + powerOffSkipped}
+	}
 
 	result, err := runtime.Deps.SandboxDestroy.Run(ctx, workDir, sandboxEnv)
 	if err == nil || projectID == "" {
@@ -111,24 +132,44 @@ func destroySandbox(
 // other run's. Guarding against the wrong state file would have skipped
 // the poweroff on exactly the paths that tear down long-lived
 // infrastructure -- the ones where a failed destroy costs the most.
-func powerOffRunInstances(ctx context.Context, runtime *CommandRuntime, workDir, projectID string, sandboxEnv map[string]string) []string {
-	if projectID == "" || runtime.Deps.InstanceStop == nil {
-		return nil
+func powerOffRunInstances(ctx context.Context, runtime *CommandRuntime, workDir, projectID string, sandboxEnv map[string]string) (stopped []string, skipped string) {
+	if projectID == "" {
+		return nil, fmt.Sprintf("no project id from the caller and no usable run-project marker in %s, so there is nothing safe to scope a poweroff to", workDir)
+	}
+	if runtime.Deps.InstanceStop == nil {
+		return nil, "no poweroff dependency is wired into this runtime"
 	}
 	secretKey := sandboxEnv["SCW_SECRET_KEY"]
 	if secretKey == "" {
-		return nil
+		return nil, "no SCW_SECRET_KEY in the sandbox environment"
 	}
 	if err := assertRunProjectDeletable(ctx, runtime, workDir, projectID, sandboxEnv); err != nil {
-		return nil
+		return nil, fmt.Sprintf("project %s did not pass the deletable check (%v), so its servers are not this run's to stop", projectID, err)
 	}
 	stopped, err := runtime.Deps.InstanceStop.Run(ctx, projectID, secretKey)
 	if err != nil {
 		// Best-effort by design. The destroy runs regardless and reports
 		// for itself; the sweep is what fails closed.
-		return stopped
+		return stopped, fmt.Sprintf("poweroff reported %v", err)
 	}
-	return stopped
+	return stopped, ""
+}
+
+// instancePowerOffSkippedStage says WHY nothing was powered off.
+//
+// A guard that stops without saying why is half a guard -- the durable
+// finding of the Layer 3 arc, and one this function was written in
+// violation of. The first version had three silent `return nil` paths,
+// so when a real run failed its destroy with no poweroff stage at all,
+// the log could not distinguish "no project id" from "guard refused"
+// from "found nothing to stop". That cost a real apply to learn nothing.
+func instancePowerOffSkippedStage(reason string) StageSummary {
+	return StageSummary{
+		Layer:  "sandbox_deploy",
+		Stage:  "instance_poweroff",
+		Status: StageStatusSkip,
+		Detail: fmt.Sprintf("no instance was powered off before the destroy: %s", reason),
+	}
 }
 
 // instancePowerOffStage records what was stopped. Only emitted when
@@ -150,6 +191,9 @@ func powerOffRunInstances(ctx context.Context, runtime *CommandRuntime, workDir,
 // path exists to remove false statements in both directions, not to
 // trade one for the other.
 func instancePowerOffStage(stopped []string) StageSummary {
+	if len(stopped) == 1 && strings.HasPrefix(stopped[0], powerOffSkipReasonPrefix) {
+		return instancePowerOffSkippedStage(strings.TrimPrefix(stopped[0], powerOffSkipReasonPrefix))
+	}
 	status := StageStatusPass
 	verb := "powered off"
 	for _, s := range stopped {
@@ -187,4 +231,24 @@ func sweepTargetProjectID(target *harness.SweepTarget) string {
 		return ""
 	}
 	return target.ProjectID
+}
+
+// resolveRunProjectID falls back to the run-project marker when the
+// caller has no project id.
+//
+// The marker is the same provenance assertRunProjectDeletable reads, so
+// this is not a weaker source -- it is the source, one step earlier.
+// Callers derive their id from CaptureSweepTarget, which yields nothing
+// when the live state is unreadable, and both remediations are scoped by
+// that id, so one failed capture disables the purge and the poweroff at
+// once.
+func resolveRunProjectID(workDir, projectID string) string {
+	if projectID != "" {
+		return projectID
+	}
+	marker, err := harness.ReadRunProjectMarker(workDir)
+	if err != nil {
+		return ""
+	}
+	return marker.ProjectID
 }

--- a/internal/cli/destroy_retry_test.go
+++ b/internal/cli/destroy_retry_test.go
@@ -111,17 +111,42 @@ func TestDestroySkipsPurgeWhenItSucceeds(t *testing.T) {
 	assert.Zero(t, purge.calls, "a successful destroy must not touch the API")
 }
 
-// Without a project id there is no blast radius to scope a purge to, so
-// deleting anything would be guessing.
-func TestDestroyWithoutProjectIDDoesNotPurge(t *testing.T) {
+// Without a project id AND without a marker there is no blast radius to
+// scope a purge to, so deleting anything would be guessing.
+//
+// The empty-id case alone no longer stops it, and that boundary moved
+// deliberately on 2026-09-10. An empty id is not a caller saying "do
+// nothing" -- every caller derives it from CaptureSweepTarget, so it
+// means that capture failed, and treating it as a refusal silently
+// disabled the purge and the poweroff together on a run that needed
+// both. The marker is the same provenance assertRunProjectDeletable
+// reads, and that check still runs, so recovery is scoped by the guard
+// rather than by an accident of capture.
+func TestDestroyWithoutProjectIDOrMarkerDoesNotPurge(t *testing.T) {
 	wantErr := errors.New("destroy failed")
 	destroy := &sequencedDestroy{errs: []error{wantErr, nil}}
 	purge := &fakePurge{}
 
-	_, _, _, err := destroySandbox(context.Background(), retryRuntime(t, destroy, purge), purgeWorkDir(t), destroyEnv, "")
+	// t.TempDir(), not purgeWorkDir: no marker, so nothing to recover.
+	_, _, _, err := destroySandbox(context.Background(), retryRuntime(t, destroy, purge), t.TempDir(), destroyEnv, "")
 
 	require.ErrorIs(t, err, wantErr)
 	assert.Zero(t, purge.calls)
+}
+
+// ...and with a marker, an empty caller id recovers rather than
+// disabling remediation. This is the outage: no purge stage and no
+// poweroff stage on a run whose destroy failed for a reason both would
+// have cleared.
+func TestDestroyRecoversTheProjectFromTheMarkerWhenTheCallerHasNone(t *testing.T) {
+	destroy := &sequencedDestroy{errs: []error{errors.New("precondition failed: resource is still in use")}}
+	purge := &fakePurge{removed: []string{"security_group 142eef7b (Default security group) in fr-par-1"}}
+
+	_, purged, _, err := destroySandbox(context.Background(), retryRuntime(t, destroy, purge), purgeWorkDir(t), destroyEnv, "")
+
+	require.NoError(t, err, "the retry should succeed once the blocker is purged")
+	assert.Equal(t, 1, purge.calls, "an empty caller id must not disable the purge when the marker names a project")
+	assert.NotEmpty(t, purged)
 }
 
 // A destroy that fails twice is a real failure, and the second error is
@@ -241,4 +266,51 @@ func TestPowerOffStageFailsWhenAServerNeverStopped(t *testing.T) {
 		"one server still running is enough to make the destroy fail")
 	assert.NotContains(t, bad.Detail, "powered off 2 instance(s)",
 		"and the summary must not claim it powered off what it did not")
+}
+
+// A guard that stops without saying why is half a guard -- the Layer 3
+// arc's durable finding, and one the first version of this code broke.
+// It had three silent `return nil` paths, so when a real run failed its
+// destroy with no poweroff stage at all, the log could not tell "no
+// project id" from "guard refused" from "found nothing". That cost a
+// real apply to learn nothing.
+func TestPowerOffSaysWhyItSkipped(t *testing.T) {
+	rt := retryRuntime(t, &sequencedDestroy{}, &fakePurge{})
+	rt.Deps.InstanceStop = nil
+
+	_, reason := powerOffRunInstances(context.Background(), rt, purgeWorkDir(t), purgeProjectID, destroyEnv)
+
+	require.NotEmpty(t, reason, "a skip must carry its reason")
+	assert.Contains(t, reason, "poweroff dependency")
+
+	stage := instancePowerOffStage([]string{powerOffSkipReasonPrefix + reason})
+	assert.Equal(t, StageStatusSkip, stage.Status,
+		"a skip is not a pass -- nothing was powered off")
+	assert.Contains(t, stage.Detail, "poweroff dependency",
+		"and the reason has to reach the stage summary, which is where an operator looks")
+}
+
+// The caller's project id comes from CaptureSweepTarget, which is empty
+// whenever that capture failed -- and on 2026-09-10 that silently
+// disabled BOTH remediations, leaving neither a purge stage nor a
+// poweroff stage to say so. The marker is the same provenance the
+// deletable check reads anyway.
+func TestPowerOffFallsBackToTheRunProjectMarker(t *testing.T) {
+	stop := &recordingPowerOff{}
+	rt := retryRuntime(t, &sequencedDestroy{}, &fakePurge{})
+	rt.Deps.InstanceStop = stop
+
+	dir := purgeWorkDir(t)
+	// Recovery lives in destroySandbox now, so BOTH remediations get it;
+	// see TestDestroyRecoversTheProjectFromTheMarkerWhenTheCallerHasNone.
+	require.Equal(t, purgeProjectID, resolveRunProjectID(dir, ""),
+		"the marker is the fallback source, and it is the same provenance the deletable check reads")
+	assert.Empty(t, resolveRunProjectID(t.TempDir(), ""),
+		"and with no marker there is nothing to recover")
+
+	stopped, reason := powerOffRunInstances(context.Background(), rt, dir, resolveRunProjectID(dir, ""), destroyEnv)
+
+	assert.Empty(t, reason, "the marker names a project, so there is nothing to skip: %s", reason)
+	require.True(t, stop.called, "an empty caller-supplied id must not disable the poweroff")
+	require.NotEmpty(t, stopped)
 }

--- a/internal/generator/gate_pitfalls_test.go
+++ b/internal/generator/gate_pitfalls_test.go
@@ -115,3 +115,25 @@ func TestExtractGatePitfallSkipsAPluralAllowlistRefusal(t *testing.T) {
 	detail := "layer 3 refuses to apply resource type(s) scaleway_k8s_cluster, scaleway_rdb_instance: not in validation.layers.sandbox_deploy.allow_resource_types (scaleway_lb*)"
 	assert.Nil(t, ExtractGatePitfall(detail, "full-stack-paris"))
 }
+
+// The hardcoded VPC fallback must agree with what the repository
+// actually enforces. It prescribed a standalone
+// `scaleway_instance_private_nic` until 2026-09-10, by which time the
+// Layer 3 gate refused that resource, `vpc_required`'s denial argued
+// against it, and a real teardown could not delete one -- and the
+// learning loop recorded it as a fresh pitfall anyway, in the same run
+// whose Layer 1 was saying the opposite.
+//
+// This is an audit rather than a spelling check: a prescriptive rule
+// frozen in Go cannot be reviewed next to the code that enforces it, so
+// the only defence is a test that fails when they diverge.
+func TestVPCFallbackPrescribesTheShapeTheGateAccepts(t *testing.T) {
+	got := ExtractDescriptivePitfall(
+		"scaleway_instance_server.web is not attached to a private network via scaleway_instance_private_nic", "s")
+	require.NotNil(t, got, "the VPC fallback must still fire for the policy's own wording")
+
+	assert.Contains(t, got.Rule, "private_network { pn_id =",
+		"the fallback must prescribe the inline attachment")
+	assert.NotContains(t, got.Rule, "The private NIC has the shape",
+		"it must not hand the generator a standalone NIC the Layer 3 gate refuses")
+}

--- a/internal/generator/pitfalls_learn.go
+++ b/internal/generator/pitfalls_learn.go
@@ -670,7 +670,22 @@ func matchScalewayMissingPrivateNic(detail, scenario string) *LearnedPitfall {
 		// caller's detail mentions only `scaleway_instance_private_nic`.
 		resource = "scaleway_instance_server"
 	}
-	rule := "Always declare a `scaleway_vpc_private_network` AND a `scaleway_instance_private_nic` for EACH `scaleway_instance_server`. The private NIC has the shape: `resource \"scaleway_instance_private_nic\" \"NAME\" { server_id = scaleway_instance_server.SERVER.id; private_network_id = scaleway_vpc_private_network.PN.id }`. The `vpc_required` policy fails any instance without this attachment. Add one NIC per instance (use `count` to mirror the `count` on the instance) — do NOT rely on the instance's `routed_ip_enabled` flag, which the provider doesn't accept."
+	// Prescribes the INLINE attachment. It used to prescribe a standalone
+	// `scaleway_instance_private_nic`, and by 2026-09-10 that had become
+	// a rule this repository refuses three separate ways: the Layer 3
+	// gate rejects the resource, `vpc_required`'s denial argues against
+	// it, and a real teardown cannot delete one. The learning loop was
+	// still teaching it -- run 20260910T141427Z recorded it as a fresh
+	// pitfall while the same run's Layer 1 was telling the generator the
+	// opposite.
+	//
+	// The general lesson, and the reason this string is a liability: a
+	// prescriptive rule frozen into Go cannot be reviewed alongside the
+	// thing that enforces it, so it drifts silently and then teaches the
+	// drift. Refusals extracted by ExtractGatePitfall do not have this
+	// failure mode -- they are emitted by the enforcing code itself.
+	// Prefer adding enforcement over adding another one of these.
+	rule := "Attach every `scaleway_instance_server` to a private network with the provider's INLINE block: `private_network { pn_id = scaleway_vpc_private_network.NAME.id }`. Declare the `scaleway_vpc_private_network` too. Do NOT use a standalone `scaleway_instance_private_nic`: the Layer 3 gate refuses it. With `count` on the server the block comes with it. Do not set `project_id`, and do not use `routed_ip_enabled`, which the provider does not accept."
 	return &LearnedPitfall{Resource: resource, Rule: rule, DiscoveredFrom: scenario}
 }
 

--- a/pitfalls/scaleway.yaml
+++ b/pitfalls/scaleway.yaml
@@ -83,51 +83,14 @@ pitfalls:
         to add a second.
       source: avoid
       discovered_from: web-live-paris
-    # RETRACTED 2026-09-10, one day after it was written. It said: when a
-    # scenario declares a `service:`, boot Scaleway's `docker` image instead of
-    # apt-installing a runtime, and it cited the marketplace API as proof the
-    # image was compatible with DEV1-S in fr-par-1.
+    # A pitfall this run LEARNED on 2026-09-10 and that had to be deleted the
+    # same day: "Always declare ... a scaleway_instance_private_nic". It came
+    # from ExtractDescriptivePitfall's hardcoded VPC fallback, which still
+    # prescribed a resource the Layer 3 gate refuses, `vpc_required` argues
+    # against, and a real teardown cannot delete.
     #
-    # The generator took the advice and the apply FAILED:
-    #
-    #   could not get image 'fr-par-1/docker': couldn't find a local image for
-    #   the given zone (fr-par-1) and commercial type (DEV1-M)
-    #
-    # The marketplace API still says the opposite -- all four fr-par-1 `docker`
-    # local images list DEV1-M in compatible_commercial_types. So
-    # `compatible_commercial_types` is NOT what the provider resolves against,
-    # and it cannot be used to settle this question.
-    #
-    # That is the second time this exact failure has been recorded, and the
-    # pitfall below already warned against writing a remedy for it. Overriding
-    # that warning turned an honest "not understood" into a prescription that
-    # cost a real apply. The warning stands; no remedy is offered.
-    #
-    # What IS supported by evidence: `ubuntu_jammy` plus an apt install serves
-    # inside a 120s probe window (web-live-paris, 2026-09-10 09:35, probe
-    # passed). Slower, and it works.
-    # Left DESCRIPTIVE on purpose, and it is worth saying why.
-    #
-    # The obvious remedy -- "the model invented an image, use ubuntu_jammy" -- is
-    # WRONG. `docker` is a real Scaleway marketplace label and it is what this
-    # scenario's own variables.tf defaults to.
-    #
-    # 2026-09-09, asked the public marketplace API directly:
-    #
-    #   GET /marketplace/v2/local-images?image_label=docker&zone=fr-par-1
-    #   -> 4 local images, x86_64, every one listing DEV1-S in
-    #      compatible_commercial_types
-    #
-    # So the label, the zone and the commercial type ARE compatible, which means
-    # the failure below was TRANSIENT -- a moment when fr-par-1 had no local image
-    # to hand -- not a wrong image name. That is why there is still no prescriptive
-    # remedy: "avoid `docker`" would teach the generator to route around a stock
-    # blip, and `docker` is exactly the image a container workload should use (see
-    # the pitfall above it).
-    #
-    # Writing a confident remedy for a symptom is how a symptom becomes a wrong
-    # instruction the generator then follows.
-    - resource: scaleway_instance_server
-      rule: "exit status 1 | stderr: ╷\n│ Error: could not get image 'fr-par-1/docker': scaleway-sdk-go: couldn't find a local image for the given zone (fr-par-1) and commercial type (DEV1-S)\n│ \n│   with scaleway_instance_server.web,\n│   on compute.tf line 7, in resource \"scaleway_instance_server\" \"web\""
-      source: descriptive
-      discovered_from: web-live-paris
+    # Kept as a comment because the mechanism is worth remembering: the loop
+    # wrote a durable rule contradicting its own enforcement, in the same run
+    # whose Layer 1 was telling the generator the opposite. The fallback is
+    # fixed and audited (TestVPCFallbackPrescribesTheShapeTheGateAccepts), and
+    # the attachment rule the corpus should carry is the one above.


### PR DESCRIPTION
Run `20260910T141427Z` — the first on the S181 binary — failed its destroy with
**no `instance_poweroff` stage anywhere**. Three silent `return nil` paths meant
a real apply against real Scaleway bought no information: "no project id",
"guard refused" and "found nothing to stop" were indistinguishable.

That's the Layer 3 arc's closing finding — *a guard that stops without saying why
is half a guard* — reproduced inside the change whose own ADR quotes it.

## Fixed

**Every skip carries its reason** into the stage summary, rendered as a `skip`,
never as a pass.

**And the likely cause, not just the reporting.** Callers pass
`sweepTargetProjectID(...)`, empty whenever `CaptureSweepTarget` failed — and
*both* remediations are scoped by that id, which is why that run shows no purge
stage either. Resolved once in `destroySandbox`, falling back to the run-project
marker: the same provenance `AssertProjectDeletable` reads, one step earlier, and
that check still runs.

**The loop was teaching a shape three layers refuse.**
`ExtractDescriptivePitfall`'s VPC fallback still said *"Always declare a
`scaleway_instance_private_nic`"* — refused by the Layer 3 gate, argued against
by `vpc_required`, undeletable in a real teardown. That same run wrote it into
`pitfalls/scaleway.yaml` as a fresh entry **while its own Layer 1 was telling the
generator the opposite.** Fallback fixed, learned entry deleted, audit test added.

## What also worked in that run, worth recording

Iteration 1 failed `vpc_required` with the rewritten denial, and **iteration 2's
generator applied the fix** — inline `private_network` block, validate passed.
The denial-as-repair-loop-input change did exactly what it was for.

## A boundary that moved deliberately

`TestDestroyWithoutProjectIDDoesNotPurge` asserted "without a project id, do not
purge" as a safety property. It wasn't one: every caller derives that id from
`CaptureSweepTarget`, so empty means *the capture failed*, not *the caller
declined to act* — and treating it as a refusal turned a recoverable teardown
into a leak. `AssertProjectDeletable` is what makes purging safe, and it is
untouched.

## Review

Three passes, four findings, all accepted, third pass clean. Two mutations
checked, each failing the test that claims to cover it.

## The thing worth keeping

Two of today's defects were the same shape: **a prescriptive rule frozen in
source, drifting from the code that enforces it.** Refusals extracted by
`ExtractGatePitfall` cannot fail that way — they are emitted by the enforcing
code itself. That's the argument for deriving pitfalls from gates rather than
writing them, and it now has an audit test behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD