### PR TITLE
every Layer 3 run reconciles the projects it did not clean up

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,6 +2,24 @@
 
 Last updated: 2026-09-10
 
+## 2026-09-10 — S184: every Layer 3 run now reconciles the projects it did not clean up
+
+Eight stray `if-run-*` projects accumulated over two days, **four still running an instance**, and
+they surfaced only because a human ran `scw account project list` on a hunch.
+
+The leak is structural, not incidental. A failed run KEEPS its project deliberately — the id is the
+handle to whatever survived. The orphan sweep only inspects the current run's project. `reap` needs
+a state file the next iteration has already overwritten. Each decision is right; the aggregate
+leaks one project per applied iteration and shows up only on the bill.
+
+`live reconcile` has done exactly the right comparison since S157a and is invoked by hand, which is
+to say never. Every Layer 3 run now runs it at the end and **fails on an unexplained stamped
+project**, including ones inherited from earlier runs — ADR-0024's promise finally has a mechanism.
+
+Reports, never destroys: a project the records cannot explain is by definition not understood, and
+deleting what you do not understand is how a reconciler becomes the incident. A run that leaves no
+stray is unaffected.
+
 ## 2026-09-10 — S183: two curl calls, and the first green end-to-end run
 
 `web-live-paris` reached **`target_reached` in one iteration from the UI**, every stage green in

--- a/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
+++ b/docs/decisions/0024-live-deployments-bounded-by-mandatory-ttl.md
@@ -770,3 +770,26 @@ by `try()` or `one()` — before anything is created, rather than after.
 Stated as a rule for anything added later: **a stack that could fail to evaluate
 must not reach apply**, because evaluation is what destroy needs and destroy is the
 only thing standing between a failed apply and a bill.
+
+## Amendment, 2026-09-10 — the reconciliation now runs
+
+"A run that cannot prove the account is clean must not report success" held for
+the run's OWN project and nothing else. A failed run keeps its project on
+purpose — the id is the handle to whatever survived — the orphan sweep only ever
+inspects the current run's project, and `reap` needs a state file the next
+iteration has already overwritten. Every individual decision is right and the
+aggregate leaks.
+
+**Eight stray run projects accumulated over two days, four still running an
+instance.** They surfaced only because a human ran `scw account project list` on
+a hunch. `live reconcile` had done exactly the right comparison since S157a and
+was invoked by hand, which is to say never.
+
+Every Layer 3 run now performs that reconciliation at the end and **fails when a
+stamped project is unexplained** — including strays it inherited from earlier
+runs. It reports and never destroys, for the reason `live reconcile` does not:
+a project the records cannot explain is by definition not understood, and the
+blast radius is somebody's running infrastructure.
+
+A run that leaves no stray is unaffected. A run that inherits one finds out at
+the only moment anyone is watching.

--- a/docs/review-passes/pass184.md
+++ b/docs/review-passes/pass184.md
@@ -1,0 +1,59 @@
+# Review passes 184+ — every run reconciles what it did not clean up
+
+`codex exec review --base main` on `fix/reconcile-stray-run-projects`.
+**Five findings, all accepted.** Three were the same defect at three different
+levels, which is the interesting part.
+
+## The change
+
+Eight stray `if-run-*` projects accumulated over two days, four still running an
+instance, found only because a human listed projects on a hunch. Every Layer 3
+run now performs `live reconcile`'s comparison at the end and fails on a stamped
+project nothing explains — including strays inherited from earlier runs.
+ADR-0024 promised this and S157a built the comparison; nothing called it.
+
+## The same false green, three times
+
+**[P2] the failures were appended after `status` was decided.** A
+`target_reached` run would have written `success` with a stray outstanding —
+precisely the thing the check exists to prevent, reintroduced by where the call
+sat. Moved above the decision.
+
+**[P2] the JSON said `failed` and the process exited 0.** The final error path
+still tested only `terminalReason` and `holdoutBlocked`. Every caller that is a
+script — the PR gate included — would have read success. The status decision is
+now one function, `runCommandStatus`, used by both, so the two cannot drift.
+
+**[P2] unreadable live records were discarded.** `store.List()` returns them and
+this threw them away, so a record it could not read produced a clean pass. "Could
+not check" and "nothing leaked" must never look alike.
+
+## Also accepted
+
+**[P3] the pass line counted every project in the organization**, not the
+stamped ones — "12 projects carry infrafactory's stamp" when eleven belong to
+somebody else. That line is the evidence an operator reads for "nothing leaked",
+so overstating what was checked is the whole problem in miniature.
+
+## Why `runCommandStatus` exists now
+
+It was an inline boolean expression. An expression cannot be tested without
+driving the entire command, which is why the first version shipped with the new
+clause in the status but not in the exit code. Each clause is a promise this
+project has broken before; making them a named function made the mutation test
+possible, and the mutation is caught.
+
+## Mutation checks
+
+| mutation | result |
+|---|---|
+| never report strays | `…FailsOnAnUnexplainedProject` fails |
+| treat a list error as clean | `…FailsWhenItCannotList` fails |
+| strays no longer block the status | `TestRunReportsFailureWhenAStrayProjectSurvives` fails |
+
+## What it still will not do
+
+It reports and never destroys, for the reason `live reconcile` does not: a
+project the records cannot explain is by definition not understood, and deleting
+what you do not understand is how a reconciler becomes the incident. The blast
+radius is somebody's running infrastructure.

--- a/internal/cli/run_command.go
+++ b/internal/cli/run_command.go
@@ -852,10 +852,31 @@ func runRunCommand(cmd *cobra.Command, args []string, runtime *CommandRuntime) e
 		allStages = append(allStages, StageSummary{Layer: "holdout", Stage: "skipped", Status: StageStatusSkip, Detail: "skipped by --no-destroy"})
 	}
 
-	status := CommandStatusSuccess
-	if terminalReason != "target_reached" || holdoutBlocked {
-		status = CommandStatusFailed
+	// Every Layer 3 run checks the organization for run projects nothing
+	// explains -- its own and, more importantly, earlier runs'.
+	//
+	// A run that SUCCEEDS deletes its project. A run that fails keeps it,
+	// deliberately, because the id is the handle to what survived.
+	// Nothing ever looks again: the orphan sweep only inspects the
+	// current run's project, and `reap` needs a state file the next
+	// iteration has already overwritten. The leak compounds one project
+	// per applied iteration and shows up only on the bill -- eight over
+	// two days by 2026-09-10, four still running an instance, found
+	// because a human listed projects on a hunch.
+	//
+	// BEFORE `status` is computed, deliberately. Appending these
+	// failures afterwards would let a target_reached run report success
+	// with a stray outstanding, which is the false green this check
+	// exists to remove.
+	strayBlocked := false
+	if sandboxRunEnabled(runtime) {
+		strayStages, strayFailures := reportStrayRunProjects(cmd.Context(), runtime)
+		allStages = append(allStages, strayStages...)
+		allFailures = append(allFailures, strayFailures...)
+		strayBlocked = len(strayFailures) > 0
 	}
+
+	status := runCommandStatus(terminalReason, holdoutBlocked, strayBlocked)
 
 	if err := store.WriteRunMetadata(runstore.RunMetadata{
 		Schema:              runstore.RunMetadataSchemaVersion,
@@ -899,10 +920,18 @@ func runRunCommand(cmd *cobra.Command, args []string, runtime *CommandRuntime) e
 		return err
 	}
 
-	if terminalReason != "target_reached" || holdoutBlocked {
+	// The same three clauses as runCommandStatus, because the JSON saying
+	// `failed` while the process exits 0 is a false green for every
+	// caller that is a script -- the PR gate included. `strayBlocked`
+	// was missing here when it was added above, so a target_reached run
+	// with an unexplained project wrote "failed" and returned success.
+	if runCommandStatus(terminalReason, holdoutBlocked, strayBlocked) == CommandStatusFailed {
 		errDetail := fmt.Errorf("run stopped with terminal reason %q after %d iteration(s)", terminalReason, completed)
 		if holdoutBlocked {
 			errDetail = fmt.Errorf("holdout checks failed after training convergence")
+		}
+		if strayBlocked {
+			errDetail = fmt.Errorf("run projects remain that nothing explains; they have no TTL and nothing will reap them")
 		}
 		return &CLIError{
 			Op:   "run",
@@ -1521,4 +1550,25 @@ func logLayer3RecoveryHint(runtime *CommandRuntime, runID, scenarioPath, reason 
 		Detail: fmt.Sprintf("%s: real Scaleway resources may still exist; run `%s` to tear them down and verify",
 			reason, reapCommand(runtime.ConfigPath, scenarioPath)),
 	})
+}
+
+// runCommandStatus decides whether a run reports success.
+//
+// A function rather than an inline expression because each clause is a
+// promise this project has broken before, and an expression cannot be
+// tested without driving the whole command:
+//
+//   - terminalReason: the loop reached its target.
+//   - holdoutBlocked: the holdout check proved the change survives.
+//   - strayBlocked: no run project is left that nothing explains
+//     (ADR-0024). Added 2026-09-10 after eight accumulated unseen; the
+//     first version of that check appended its failures AFTER this
+//     decision, so a target_reached run would still have reported
+//     success with a stray outstanding -- the exact false green the
+//     check exists to remove.
+func runCommandStatus(terminalReason string, holdoutBlocked, strayBlocked bool) CommandStatus {
+	if terminalReason != "target_reached" || holdoutBlocked || strayBlocked {
+		return CommandStatusFailed
+	}
+	return CommandStatusSuccess
 }

--- a/internal/cli/stray_run_projects.go
+++ b/internal/cli/stray_run_projects.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/redscaresu/infrafactory/internal/livestore"
+)
+
+// sandboxRunEnabled reports whether this run could have created a run
+// project at all. A Layer 2 run creates none, so checking would be
+// noise.
+func sandboxRunEnabled(runtime *CommandRuntime) bool {
+	return runtime != nil && runtime.Config.Validation.Layers.SandboxDeploy.Enabled
+}
+
+// reportStrayRunProjects names run projects the organization holds that
+// nothing explains.
+//
+// # Why a run is the place to do it
+//
+// Because it is the only moment anybody looks. `live reconcile` has done
+// this comparison since S157a and is invoked by hand, which is to say
+// never -- eight stray projects accumulated over two days, four still
+// running an instance, and they surfaced only because a human happened
+// to list projects.
+//
+// The leak is structural, not incidental: a failed run KEEPS its project
+// on purpose (the id is the handle to whatever survived), the orphan
+// sweep only ever inspects the current run's project, and `reap` needs a
+// state file the next iteration has already overwritten. Every
+// individual decision is right and the aggregate leaks.
+//
+// # Why it reports and never deletes
+//
+// Same reason `live reconcile` does not: a project this system's records
+// cannot explain is by definition something it does not understand, and
+// deleting what you do not understand is how a reconciler becomes the
+// incident. The blast radius is somebody's running infrastructure.
+//
+// # Why a stray fails the run
+//
+// ADR-0024: a run that cannot prove the account is clean must not report
+// success. A stray run project is billing infrastructure with no TTL and
+// nothing that will reap it, so a green summary alongside one would be
+// false in the way this project keeps removing. A run that leaves no
+// stray is unaffected, and a run that inherits somebody else's stray
+// finds out at the only moment anyone is watching.
+func reportStrayRunProjects(ctx context.Context, runtime *CommandRuntime) ([]StageSummary, []FailureSummary) {
+	if runtime.Deps.RunProject == nil {
+		return nil, nil
+	}
+	secretKey := strings.TrimSpace(os.Getenv("SCW_SECRET_KEY"))
+	orgID := strings.TrimSpace(os.Getenv("SCW_DEFAULT_ORGANIZATION_ID"))
+	if secretKey == "" || orgID == "" {
+		// Silent here, unlike `live reconcile` which fails. A Layer 3
+		// run cannot reach this point without credentials -- the
+		// sandbox preflight refuses first -- so an absence means the
+		// environment is shaped in a way this check cannot read, not
+		// that the estate is clean. Reporting a failure the operator
+		// cannot act on would train them to ignore this stage.
+		return nil, nil
+	}
+
+	listed, err := runtime.Deps.RunProject.List(ctx, secretKey, orgID)
+	if err != nil {
+		// "Could not check" and "nothing leaked" must never look alike.
+		return nil, []FailureSummary{{
+			Layer: "live", Stage: "stray_run_projects", Check: "reconcile",
+			Command: "run",
+			Detail: fmt.Sprintf(
+				"could not list the organization's projects, so stray run projects cannot be ruled out: %v", err),
+		}}
+	}
+
+	store := livestore.NewFilesystemStore(runtime.LiveStoreRoot())
+	deployments, unreadable, err := store.List()
+	if err != nil {
+		return nil, []FailureSummary{{
+			Layer: "live", Stage: "stray_run_projects", Check: "reconcile",
+			Command: "run",
+			Detail: fmt.Sprintf(
+				"could not read the live store, so a project it explains would be misreported as stray: %v", err),
+		}}
+	}
+
+	// An unreadable record is not a clean estate. The record might be the
+	// one explaining a project that is about to be called stray, or the
+	// one whose absence hides a real leak -- either way this check
+	// cannot do its job and must say so rather than return a pass.
+	var failures []FailureSummary
+	for _, u := range unreadable {
+		failures = append(failures, FailureSummary{
+			Layer: "live", Stage: "stray_run_projects", Check: "record",
+			Command: "run",
+			Detail: fmt.Sprintf(
+				"a live record could not be read, so a project it explains cannot be told from a stray: %v", u),
+		})
+	}
+
+	stamped := stampedProjects(listed)
+	result := livestore.Reconcile(stamped, deployments)
+	// `len(failures) == 0` matters as much as the unrecorded count: an
+	// unreadable record already produced a failure above, and returning
+	// the pass here would throw it away and report a clean estate that
+	// was never fully read.
+	if len(result.Unrecorded) == 0 && len(failures) == 0 {
+		// The STAMPED count, not every project in the organization.
+		// Saying "12 projects carry infrafactory's stamp" when eleven of
+		// them are somebody else's overstates what was checked, and this
+		// line is the evidence an operator reads for "nothing leaked".
+		ours := 0
+		for _, p := range stamped {
+			if p.Ours {
+				ours++
+			}
+		}
+		return []StageSummary{{
+			Layer: "live", Stage: "stray_run_projects", Status: StageStatusPass,
+			Detail: fmt.Sprintf("%d project(s) carry infrafactory's stamp and all are accounted for (%d in the organization)",
+				ours, len(listed)),
+		}}, nil
+	}
+
+	for _, p := range result.Unrecorded {
+		failures = append(failures, FailureSummary{
+			Layer: "live", Stage: "stray_run_projects", Check: "unrecorded",
+			Command: "run",
+			Detail: fmt.Sprintf(
+				"project %s (%s) carries infrafactory's stamp but nothing explains it — it has no TTL and "+
+					"nothing will reap it. Nothing was destroyed. Inspect it and tear it down: "+
+					"`scw account project delete project-id=%s`, or `live reconcile` for the full picture",
+				p.ProjectID, p.Name, p.ProjectID),
+		})
+	}
+	return []StageSummary{{
+		Layer: "live", Stage: "stray_run_projects", Status: StageStatusFail,
+		Detail: fmt.Sprintf("%d run project(s) nothing explains, %d live record(s) unreadable",
+			len(result.Unrecorded), len(unreadable)),
+	}}, failures
+}

--- a/internal/cli/stray_run_projects_test.go
+++ b/internal/cli/stray_run_projects_test.go
@@ -1,0 +1,141 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/redscaresu/infrafactory/internal/harness"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type listingRunProject struct {
+	fakeRunProject
+	projects []harness.ListedProject
+	err      error
+}
+
+func (l *listingRunProject) List(ctx context.Context, secretKey, orgID string) ([]harness.ListedProject, error) {
+	return l.projects, l.err
+}
+
+func strayRuntime(t *testing.T, rp RunProjectManager) *CommandRuntime {
+	t.Helper()
+	t.Setenv("SCW_SECRET_KEY", "secret")
+	t.Setenv("SCW_DEFAULT_ORGANIZATION_ID", "org")
+	rt := &CommandRuntime{Deps: RuntimeDependencies{RunProject: rp}}
+	rt.livestoreRoot = t.TempDir()
+	return rt
+}
+
+// The leak this exists for: a run project nothing explains. Eight of
+// these accumulated over two days, four still running an instance, and
+// they surfaced only because a human listed projects on a hunch.
+func TestStrayRunProjectsFailsOnAnUnexplainedProject(t *testing.T) {
+	rt := strayRuntime(t, &listingRunProject{projects: []harness.ListedProject{
+		{ID: "p-1", Name: harness.RunProjectNamePrefix + "web-live-paris-20260909t110101z", Description: harness.RunProjectDescription},
+	}})
+
+	stages, failures := reportStrayRunProjects(context.Background(), rt)
+
+	require.Len(t, failures, 1)
+	assert.Contains(t, failures[0].Detail, "p-1")
+	assert.Contains(t, failures[0].Detail, "Nothing was destroyed",
+		"a reconciler that deletes what it cannot explain becomes the incident")
+	require.Len(t, stages, 1)
+	assert.Equal(t, StageStatusFail, stages[0].Status)
+}
+
+// A clean estate passes, and says how many it checked -- "found nothing"
+// and "looked at nothing" must not read alike.
+func TestStrayRunProjectsPassesWhenNothingIsUnexplained(t *testing.T) {
+	rt := strayRuntime(t, &listingRunProject{projects: nil})
+
+	stages, failures := reportStrayRunProjects(context.Background(), rt)
+
+	assert.Empty(t, failures)
+	require.Len(t, stages, 1)
+	assert.Equal(t, StageStatusPass, stages[0].Status)
+	assert.Contains(t, stages[0].Detail, "accounted for")
+}
+
+// "Could not check" and "nothing leaked" must never look alike -- the
+// S139 lesson, and the reason this reports a failure rather than a pass
+// when the API cannot be read.
+func TestStrayRunProjectsFailsWhenItCannotList(t *testing.T) {
+	rt := strayRuntime(t, &listingRunProject{err: errors.New("401 unauthorized")})
+
+	stages, failures := reportStrayRunProjects(context.Background(), rt)
+
+	assert.Empty(t, stages)
+	require.Len(t, failures, 1)
+	assert.Contains(t, failures[0].Detail, "cannot be ruled out")
+}
+
+// A project without infrafactory's stamp is somebody else's. The
+// ownership test is shared with the teardown guard so "infrafactory
+// created this" has one definition.
+func TestStrayRunProjectsIgnoresUnstampedProjects(t *testing.T) {
+	rt := strayRuntime(t, &listingRunProject{projects: []harness.ListedProject{
+		{ID: "p-prod", Name: "openclaw-prod", Description: "not ours"},
+	}})
+
+	_, failures := reportStrayRunProjects(context.Background(), rt)
+
+	assert.Empty(t, failures, "an unstamped project must never be reported as infrafactory's litter")
+}
+
+// A Layer 2 run creates no project, so checking would be noise.
+func TestStrayCheckSkippedWhenLayer3IsOff(t *testing.T) {
+	assert.False(t, sandboxRunEnabled(&CommandRuntime{}))
+}
+
+// The pass line is the evidence an operator reads for "nothing leaked",
+// so it must count what was CHECKED, not every project in the
+// organization.
+func TestStrayRunProjectsCountsOnlyStampedProjects(t *testing.T) {
+	rt := strayRuntime(t, &listingRunProject{projects: []harness.ListedProject{
+		{ID: "p-prod", Name: "openclaw-prod", Description: "not ours"},
+		{ID: "p-default", Name: "default", Description: ""},
+	}})
+
+	stages, failures := reportStrayRunProjects(context.Background(), rt)
+
+	require.Empty(t, failures)
+	require.Len(t, stages, 1)
+	assert.Contains(t, stages[0].Detail, "0 project(s) carry infrafactory's stamp",
+		"none of these are ours, and the summary must not imply they were checked as ours")
+}
+
+// A stray must fail a run that otherwise reached its target. The first
+// version of the stray check appended its failures after the status had
+// been decided, so a green run could carry an unexplained project --
+// billing infrastructure with no TTL, reported as success.
+func TestRunReportsFailureWhenAStrayProjectSurvives(t *testing.T) {
+	assert.Equal(t, CommandStatusSuccess, runCommandStatus("target_reached", false, false))
+	assert.Equal(t, CommandStatusFailed, runCommandStatus("target_reached", false, true),
+		"a stray run project is billing infrastructure nothing will reap")
+	assert.Equal(t, CommandStatusFailed, runCommandStatus("target_reached", true, false))
+	assert.Equal(t, CommandStatusFailed, runCommandStatus("stuck", false, false))
+}
+
+// An unreadable live record cannot be told from a clean estate unless it
+// is reported. With no unrecorded project the pass path would otherwise
+// return, discarding the failure and calling an estate clean that was
+// never fully read.
+func TestStrayRunProjectsFailsOnAnUnreadableLiveRecord(t *testing.T) {
+	rt := strayRuntime(t, &listingRunProject{projects: nil})
+	// A record the store cannot parse.
+	require.NoError(t, os.MkdirAll(rt.livestoreRoot, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(rt.livestoreRoot, "broken.json"), []byte("{not json"), 0o600))
+
+	stages, failures := reportStrayRunProjects(context.Background(), rt)
+
+	require.NotEmpty(t, failures, "an unreadable record is not a clean estate")
+	assert.Contains(t, failures[0].Detail, "cannot be told from a stray")
+	require.Len(t, stages, 1)
+	assert.Equal(t, StageStatusFail, stages[0].Status)
+}


### PR DESCRIPTION
Eight stray `if-run-*` projects accumulated over two days — **four still running
an instance** — and they surfaced only because a human ran
`scw account project list` on a hunch.

## The leak is structural, not incidental

- A **failed run keeps its project deliberately** — the id is the handle to
  whatever survived.
- The **orphan sweep** only inspects the current run's project.
- **`reap`** needs a state file the next iteration has already overwritten.

Every individual decision is right. The aggregate leaks one project per applied
iteration, and the only symptom is the bill.

`live reconcile` has done exactly the right comparison since S157a — and is
invoked by hand, which is to say never.

## The change

Every Layer 3 run performs that reconciliation at the end and **fails on a
stamped project nothing explains**, including strays inherited from earlier
runs. ADR-0024 promised this; now it has a mechanism.

It **reports and never destroys**, for the same reason `live reconcile` doesn't:
a project the records cannot explain is by definition not understood, and
deleting what you don't understand is how a reconciler becomes the incident.

A run that leaves no stray is unaffected. A run that inherits one finds out at
the only moment anyone is watching.

## Review found the same false green at three levels

| level | defect |
|---|---|
| stage list | failures appended **after** `status` was decided — a `target_reached` run would report success with a stray outstanding |
| exit code | JSON said `failed`, process exited **0** — every script caller, the PR gate included, read success |
| input | unreadable live records **discarded**, turning "could not check" into "nothing leaked" |

The status decision is now one function, `runCommandStatus`, used by both the
JSON and the exit code. It was an inline expression, and an expression can't be
tested without driving the whole command — which is precisely how the new clause
ended up in one and not the other.

## Verification

Four mutations, each failing the test that claims to cover it: never report
strays; treat a list error as clean; strays don't block the status; discard
unreadable-record failures.

Five findings, all accepted. Full suite green, `go vet` and doc hygiene clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsog2H4UsfraUyWAFJUWcD